### PR TITLE
Add test for long summaries

### DIFF
--- a/tests/search/dynteaser/dynteaser.1.xml
+++ b/tests/search/dynteaser/dynteaser.1.xml
@@ -1,0 +1,10 @@
+  <document documenttype="cjk" documentid="id:test:cjk::en-0">
+                        <url><![CDATA[en-0]]></url>
+                        <lang><![CDATA[en]]></lang>
+                        <content><![CDATA[Kaw-Liga;Johnny Red;Ringo;The Hanging Tree;Despaerados Waiting For A Train;Lizzie And The Rainman;Mama Sang A Song;Honey;Marie Laveau;Ode To Billie\
+ Joe;Ten Thousand Drums;Hot Rod Lincoln;One Piece At A Time;Pancho And Lefty;Coat Of Many Colors]]></content>
+                        <content2><![CDATA[Kaw-Liga;Johnny Red;Ringo;The Hanging Tree;Despaerados Waiting For A Train;Lizzie And The Rainman;Mama Sang A Song;Honey;Marie Laveau;Ode To Billi\
+e Joe;Ten Thousand Drums;Hot Rod Lincoln;One Piece At A Time;Pancho And Lefty;Coat Of Many Colors]]></content2>
+                        <content3><![CDATA[Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Kaw-Liga;Johnny Red;Ringo;The Hanging Tree;Despaerados Waiting For A Train;Lizzie And The Rainman;Mama Sang A Song;Honey;Marie Laveau;Ode To Billi\
+e Joe;Ten Thousand Drums;Hot Rod Lincoln;One Piece At A Time;Pancho And Lefty;Coat Of Many Colors. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text. Additional text.]]></content3>
+                </document>

--- a/tests/search/dynteaser/dynteaser.rb
+++ b/tests/search/dynteaser/dynteaser.rb
@@ -52,6 +52,20 @@ class DynTeaser < IndexedSearchTest
 
   end
 
+  def test_long_dyn_teaser
+    deploy_app(SearchApp.new.sd(selfdir+"cjk.sd").
+                             config(ConfigOverride.new("vespa.config.search.summary.juniperrc").
+                                                   add("length", 360).
+                                                   add("surround_max", 360).
+                                                   add("min_length", 300)))
+    start
+
+    feed_and_wait_for_docs("cjk", 1, :file => selfdir+"dynteaser.1.xml")
+
+    puts "Query: english"
+    compare("query=content:time", selfdir+"time.long.result", "content3")
+  end
+
   def test_fallback_none
     deploy_app(SearchApp.new.sd(selfdir+"fallback.sd").
                              config(ConfigOverride.new("vespa.config.search.summary.juniperrc").

--- a/tests/search/dynteaser/time.long.result
+++ b/tests/search/dynteaser/time.long.result
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result total-hit-count="1">
+  <hit relevancy="1000" source="sc0.num0">
+    <field name="relevancy">1000</field>
+    <field name="sddocname">cjk</field>
+    <field name="uri">en-0</field>
+    <field name="url">en-0</field>
+    <field name="content">Kaw-Liga;Johnny Red;Ringo;The Hanging Tree;Despaerados Waiting For A Train;Lizzie And The Rainman;Mama Sang A Song;Honey;Marie Laveau;Ode To Billie Joe;Ten Thousand Drums;Hot Rod Lincoln;One Piece At A Time;Pancho And Lefty;Coat Of Many Colors</field>
+    <field name="dyncontent"><sep /> Rod Lincoln;One Piece At A <hi>Time</hi>;Pancho And Lefty;Coat Of Many <sep /></field>
+    <field name="content2"><sep /> Rod Lincoln;One Piece At A <hi>Time</hi>;Pancho And Lefty;Coat Of Many <sep /></field>
+    <field name="content3"><sep /> Drums;Hot Rod Lincoln;One Piece At A <hi>Time</hi>;Pancho And Lefty;Coat Of Many Colors. Additional<sep /></field>
+  </hit>
+</result>


### PR DESCRIPTION
@geirst I added a test for configuring longer dynamic summaries. It's in its currently working form here (so it can be merged), but the behavior does not seem very good: I configure summaries of min and preferred length of 300 and 360 respectively, and the matched field ("content3") has enough characters to supply that, but the dynamic summary is still capped at about 120 characters.