### PR TITLE
Expect just 2 put errors

### DIFF
--- a/tests/search/httpgateway/documentv1.rb
+++ b/tests/search/httpgateway/documentv1.rb
@@ -145,7 +145,6 @@ class DocumentV1Test < SearchTest
       response.body)
     http.delete("/document/v1/fruit/banana/docid/vg.no/latest/news/!", httpheaders)
 
-
     # send document with wrong field
     response = http.post("/document/v1/fruit/banana/docid/doc1", feedDataBroken, httpheaders)
     assert_equal("400", response.code)
@@ -188,7 +187,7 @@ class DocumentV1Test < SearchTest
     # visit all documents and check the total number of documents
     found = 0
     contToken = ""
-    # Avoid infinite loop in case of cycles, numDocuments is absoulute max
+    # Avoid infinite loop in case of cycles, numDocuments is absolute max
     for q in 0..numDocuments
        # Visit zero result test
        response = http.get("/document/v1/fruit/banana/docid/" + contToken)
@@ -205,7 +204,8 @@ class DocumentV1Test < SearchTest
     end
     assert_equal(numDocuments, found)
 
-    assert(verify_with_retries(http, {"PUT" => 3503, "UPDATE" => 3, "REMOVE" => 3502}, {"PUT" => 3, "REMOVE" => 1}))
+    # Expect 2, not 3 put errors as route="" is not counted correctly
+    assert(verify_with_retries(http, {"PUT" => 3503, "UPDATE" => 3, "REMOVE" => 3502}, {"PUT" => 2, "REMOVE" => 1}))
   end
 
   def deploy_application


### PR DESCRIPTION
@freva please review

I added explicit early validation of the route parameter. This led to us missing counting that as a PUT request error as that happens deeper down. However, I don't think it's worth re-complicating the code to handle this case as we also already don't count incorrect create parameter as PUT errors. 

Ideally, RestApi should be restructured such that metrics are counted once in RestApi.handleInternal