### PR TITLE
Wait longer for sentinel to change state

### DIFF
--- a/tests/cloudconfig/configserver/configserver.rb
+++ b/tests/cloudconfig/configserver/configserver.rb
@@ -197,7 +197,7 @@ ENDER
   def wait_for_logserver_state(&block)
     i = 0
     loop do
-      break if yield or i > 70
+      break if yield or i > 120
       i = i + 1
       sleep 1
     end


### PR DESCRIPTION
Looks like config request timeouts and retries might lead to new
config taking longer time to propagate