### PR TITLE
Revert "Wait longer for sentinel to change state"

### DIFF
--- a/tests/cloudconfig/configserver/configserver.rb
+++ b/tests/cloudconfig/configserver/configserver.rb
@@ -197,7 +197,7 @@ ENDER
   def wait_for_logserver_state(&block)
     i = 0
     loop do
-      break if yield or i > 120
+      break if yield or i > 70
       i = i + 1
       sleep 1
     end


### PR DESCRIPTION
Reverts vespa-engine/system-test#101

That just made it worse. Test works every time when running it manually, need to take a different approach to find out what's going on.