### PR TITLE
Revert "Use port and method names for new metricsproxy" MERGEOK

### DIFF
--- a/lib/nodetypes/metricproxy_node.rb
+++ b/lib/nodetypes/metricproxy_node.rb
@@ -15,7 +15,7 @@ class MetricsProxyNode < VespaNode
     while not done and retries < 60
       retries += 1
       begin
-        @wrapper = RpcWrapper.new(host, 19095, tls_env())
+        @wrapper = RpcWrapper.new(host, 19091, tls_env())
       rescue Errno::ECONNREFUSED
         sleep 1
         next

--- a/lib/nodetypes/yamas.rb
+++ b/lib/nodetypes/yamas.rb
@@ -88,7 +88,7 @@ module Yamas
 
   # get metrics directly from metricsproxy in JSON format using RPC
   def get_yamas_metrics_rpc(service,wrapper)
-    jsondata = wrapper.getMetricsForYamas(service)[0]
+    jsondata = wrapper.getYAMASMetrics(service)[0]
     puts "Output from metrics proxy: #{jsondata}"
     result = JSON.parse(jsondata)
     return result

--- a/tests/search/metricsproxy/metricsproxy.rb
+++ b/tests/search/metricsproxy/metricsproxy.rb
@@ -122,7 +122,7 @@ class MetricsProxy < IndexedSearchTest
 
   def get_metrics(yamas_service_name)
     wrapper = vespa.metricsproxies.values.first.get_wrapper
-    JSON.parse(wrapper.getMetricsForYamas(yamas_service_name)[0])
+    JSON.parse(wrapper.getYAMASMetrics(yamas_service_name)[0])
   end 
 
   def teardown


### PR DESCRIPTION
Reverts vespa-engine/system-test#112