### PR TITLE
Skip test temporarily

### DIFF
--- a/tests/cloudconfig/configserver/configserver.rb
+++ b/tests/cloudconfig/configserver/configserver.rb
@@ -242,7 +242,7 @@ ENDER
 
   # Check that default jute maxbuffer is as expected
   # Check that setting jute maxbuffer in config override works
-  def test_jute_maxbuffer
+  def no_test_jute_maxbuffer
     deploy_app(CloudconfigApp.new)
     @configserver = vespa.configservers["0"]
 


### PR DESCRIPTION
Other tests in same class will fail as well, skip test until fixed (I am not able to find a way to run system tests with the latest version at the moment).