### PR TITLE
Verify that multiple uses of the same queryvector behaves as expected

### DIFF
--- a/tests/search/dotproductfeature/dotproduct.sd
+++ b/tests/search/dotproductfeature/dotproduct.sd
@@ -4,23 +4,49 @@ search dotproduct {
   document dotproduct {
     field a type weightedset<string> {
       indexing: attribute | summary
+      attribute: fast-search
+    }
+    field a2 type weightedset<string> {
+      indexing: attribute | summary
+      attribute: fast-search
     }
     field b type weightedset<string> {
       indexing: attribute | summary
+      attribute: fast-search
+    }
+    field b2 type weightedset<string> {
+      indexing: attribute | summary
+      attribute: fast-search
     }
     field i type array<int> {
+      indexing: attribute | summary
+    }
+    field i2 type array<int> {
       indexing: attribute | summary
     }
     field l type array<long> {
       indexing: attribute | summary
     }
+    field l2 type array<long> {
+      indexing: attribute | summary
+    }
     field f type array<float> {
+      indexing: attribute | summary
+    }
+    field f2 type array<float> {
       indexing: attribute | summary
     }
     field d type array<double> {
       indexing: attribute | summary
     }
+    field d2 type array<double> {
+      indexing: attribute | summary
+    }
     field fi type array<int> {
+      indexing: attribute | summary
+      attribute:fast-search
+    }
+    field fi2 type array<int> {
       indexing: attribute | summary
       attribute:fast-search
     }
@@ -28,7 +54,15 @@ search dotproduct {
       indexing: attribute | summary
       attribute:fast-search
     }
+    field fl2 type array<long> {
+      indexing: attribute | summary
+      attribute:fast-search
+    }
     field ff type array<float> {
+      indexing: attribute | summary
+      attribute:fast-search
+    }
+    field ff2 type array<float> {
       indexing: attribute | summary
       attribute:fast-search
     }
@@ -36,22 +70,48 @@ search dotproduct {
       indexing: attribute | summary
       attribute:fast-search
     }
+    field fd2 type array<double> {
+      indexing: attribute | summary
+      attribute:fast-search
+    }
   }
 
-  rank-profile default {
+  rank-profile sum_dotproduct {
+
+    macro sum_dp () {
+      expression: dotProduct(a,x) + dotProduct(a,y) + dotProduct(a2,x) + dotProduct(a2,y) + dotProduct(b,x) + dotProduct(b,y) + dotProduct(b2,x) + dotProduct(b2,y) + dotProduct(i,vi) + dotProduct(i2,vi) + dotProduct(f,vf) + dotProduct(f2,vf) + dotProduct(l,vl) + dotProduct(l2,vl) + dotProduct(d,vd) + dotProduct(d2,vd) + dotProduct(fi,vfi) + dotProduct(fi2,vfi) + dotProduct(ff,vff) + dotProduct(ff2,vff) + dotProduct(fl,vfl) + dotProduct(fl2,vfl) + dotProduct(fd,vfd) + dotProduct(fd2,vfd)
+    }
+
+    first-phase {
+      expression: sum_dp
+    }
+
     summary-features { 
+      rankingExpression(sum_dp)
       dotProduct(a,x)
       dotProduct(a,y)
+      dotProduct(a2,x)
+      dotProduct(a2,y)
       dotProduct(b,x)
       dotProduct(b,y)
+      dotProduct(b2,x)
+      dotProduct(b2,y)
       dotProduct(i,vi)
+      dotProduct(i2,vi)
       dotProduct(f,vf)
+      dotProduct(f2,vf)
       dotProduct(l,vl)
+      dotProduct(l2,vl)
       dotProduct(d,vd)
+      dotProduct(d2,vd)
       dotProduct(fi,vfi)
+      dotProduct(fi2,vfi)
       dotProduct(ff,vff)
+      dotProduct(ff2,vff)
       dotProduct(fl,vfl)
+      dotProduct(fl2,vfl)
       dotProduct(fd,vfd)
+      dotProduct(fd2,vfd)
     }
   }
 }

--- a/tests/search/dotproductfeature/dotproduct.xml
+++ b/tests/search/dotproductfeature/dotproduct.xml
@@ -3,41 +3,89 @@
     <item weight="2">i</item>
     <item weight="4">j</item>
   </a>
+  <a2>
+    <item weight="1">a</item>
+    <item weight="1">b</item>
+    <item weight="2">k</item>
+    <item weight="4">l</item>
+    <item weight="3">i</item>
+    <item weight="7">j</item>
+  </a2>
   <b>
     <item weight="8">i</item>
     <item weight="16">j</item>
   </b>
+  <b2>
+    <item weight="1">a</item>
+    <item weight="1">b</item>
+    <item weight="2">k</item>
+    <item weight="4">l</item>
+    <item weight="9">i</item>
+    <item weight="17">j</item>
+  </b2>
   <i>
     <item>2</item>
     <item>4</item>
   </i>
+  <i2>
+    <item>3</item>
+    <item>7</item>
+  </i2>
   <f>
     <item>2.5</item>
     <item>4.5</item>
   </f>
+  <f2>
+    <item>3.5</item>
+    <item>7.5</item>
+  </f2>
   <l>
     <item>2</item>
     <item>4</item>
   </l>
+  <l2>
+    <item>3</item>
+    <item>7</item>
+  </l2>
   <d>
     <item>2.5</item>
     <item>4.5</item>
   </d>
+  <d2>
+    <item>3.5</item>
+    <item>7.5</item>
+  </d2>
   <fi>
     <item>2</item>
     <item>4</item>
   </fi>
+  <fi2>
+    <item>3</item>
+    <item>7</item>
+  </fi2>
   <ff>
     <item>2.5</item>
     <item>4.5</item>
   </ff>
+  <ff2>
+    <item>3.5</item>
+    <item>7.5</item>
+  </ff2>
   <fl>
     <item>2</item>
     <item>4</item>
   </fl>
+  <fl2>
+    <item>3</item>
+    <item>7</item>
+  </fl2>
   <fd>
     <item>2.5</item>
     <item>4.5</item>
   </fd>
+  <fd2>
+    <item>3.5</item>
+    <item>7.5</item>
+  </fd2>
 </document>
 

--- a/tests/search/dotproductfeature/dotproductfeature.rb
+++ b/tests/search/dotproductfeature/dotproductfeature.rb
@@ -16,30 +16,38 @@ class DotProductFeature < IndexedStreamingSearchTest
     start
     feed_and_wait_for_docs("dotproduct", 1, :file => selfdir + "dotproduct.xml")
 
-    assert_dotproduct({"dotProduct(a,x)" => 0,  "dotProduct(b,x)" => 0,  "dotProduct(i,vi)" => 0, "dotProduct(f,vf)" => 0}, [])
-    assert_dotproduct({"dotProduct(a,y)" => 0,  "dotProduct(b,y)" => 0,  "dotProduct(i,vi)" => 0, "dotProduct(f,vf)" => 0}, [])
-    assert_dotproduct({"dotProduct(a,x)" => 10, "dotProduct(b,x)" => 40, "dotProduct(i,vi)" => 0, "dotProduct(f,vf)" => 0}, ["x=(i:1,j:2)"])
-    assert_dotproduct({"dotProduct(a,y)" => 0,  "dotProduct(b,y)" => 0,  "dotProduct(i,vi)" => 0, "dotProduct(f,vf)" => 0}, ["x=(i:1,j:2)"])
-    assert_dotproduct({"dotProduct(a,x)" => 10, "dotProduct(b,x)" => 40, "dotProduct(i,vi)" => 0, "dotProduct(f,vf)" => 0}, ["x=(i:1,j:2)","y=(i:0.5,j:-0.5)"])
-    assert_dotproduct({"dotProduct(a,y)" => -1, "dotProduct(b,y)" => -4, "dotProduct(i,vi)" => 0, "dotProduct(f,vf)" => 0}, ["x=(i:1,j:2)","y=(i:0.5,j:-0.5)"])
-    assert_dotproduct({"dotProduct(f,vf)" => 29}, ["vf={0:3.5,1:4.5}"])
-    assert_dotproduct({"dotProduct(f,vf)" => 29}, ["vf=(0:3.5,1:4.5)"])
-    assert_dotproduct({"dotProduct(f,vf)" => 20.25}, ["vf=(1:4.5)"])
-    assert_dotproduct({"dotProduct(f,vf)" => 8.75}, ["vf=(0:3.5)"])
-    assert_dotproduct({"dotProduct(i,vi)" => 22}, ["vi=[3 4]"])
-    assert_dotproduct({"dotProduct(f,vf)" => 29}, ["vf=[3.5 4.5]"])
-    assert_dotproduct({"dotProduct(l,vl)" => 22}, ["vl=[3 4]"])
-    assert_dotproduct({"dotProduct(d,vd)" => 29}, ["vd=[3.5 4.5]"])
-    assert_dotproduct({"dotProduct(fd,vfd)" => 29}, ["vfd=[3.5 4.5]"])
-    assert_dotproduct({"dotProduct(ff,vff)" => 29}, ["vff=[3.5 4.5]"])
-    assert_dotproduct({"dotProduct(fl,vfl)" => 22}, ["vfl=[3 4]"])
-    assert_dotproduct({"dotProduct(fi,vfi)" => 22}, ["vfi=[3 4]"])
-    assert_dotproduct({"dotProduct(i,vi)" => 22, "dotProduct(f,vf)" => 29}, ["vi=[3 4]", "vf=[3.5 4.5]"])
-    assert_dotproduct({"dotProduct(i,vi)" => -22, "dotProduct(f,vf)" => -29}, ["vi=[-3 -4]", "vf=[-3.5 -4.5]"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 0, "dotProduct(a,x)" => 0,  "dotProduct(b,x)" => 0,  "dotProduct(i,vi)" => 0, "dotProduct(f,vf)" => 0,
+                       "dotProduct(a2,x)" => 0,  "dotProduct(b2,x)" => 0,  "dotProduct(i2,vi)" => 0, "dotProduct(f2,vf)" => 0}, [])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 0, "dotProduct(a,y)" => 0,  "dotProduct(b,y)" => 0,  "dotProduct(i,vi)" => 0, "dotProduct(f,vf)" => 0,
+                       "dotProduct(a2,y)" => 0,  "dotProduct(b2,y)" => 0,  "dotProduct(i2,vi)" => 0, "dotProduct(f2,vf)" => 0}, [])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 110, "dotProduct(a,x)" => 10, "dotProduct(b,x)" => 40, "dotProduct(i,vi)" => 0, "dotProduct(f,vf)" => 0,
+                       "dotProduct(a2,x)" => 17, "dotProduct(b2,x)" => 43, "dotProduct(i2,vi)" => 0, "dotProduct(f2,vf)" => 0}, ["x=(i:1,j:2)"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 110, "dotProduct(a,y)" => 0,  "dotProduct(b,y)" => 0,  "dotProduct(i,vi)" => 0, "dotProduct(f,vf)" => 0,
+                       "dotProduct(a2,y)" => 0,  "dotProduct(b2,y)" => 0,  "dotProduct(i2,vi)" => 0, "dotProduct(f2,vf)" => 0}, ["x=(i:1,j:2)"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 99, "dotProduct(a,x)" => 10, "dotProduct(b,x)" => 40, "dotProduct(i,vi)" => 0, "dotProduct(f,vf)" => 0,
+                       "dotProduct(a2,x)" => 17, "dotProduct(b2,x)" => 43, "dotProduct(i2,vi)" => 0, "dotProduct(f2,vf)" => 0}, ["x=(i:1,j:2)","y=(i:0.5,j:-0.5)"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 99, "dotProduct(a,y)" => -1, "dotProduct(b,y)" => -4, "dotProduct(i,vi)" => 0, "dotProduct(f,vf)" => 0,
+                       "dotProduct(a2,y)" => -2, "dotProduct(b2,y)" => -4, "dotProduct(i2,vi)" => 0, "dotProduct(f2,vf)" => 0}, ["x=(i:1,j:2)","y=(i:0.5,j:-0.5)"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 75, "dotProduct(f,vf)" => 29, "dotProduct(f2,vf)" => 46}, ["vf={0:3.5,1:4.5}"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 75, "dotProduct(f,vf)" => 29, "dotProduct(f2,vf)" => 46}, ["vf=(0:3.5,1:4.5)"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 54, "dotProduct(f,vf)" => 20.25, "dotProduct(f2,vf)" => 33.75}, ["vf=(1:4.5)"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 21, "dotProduct(f,vf)" => 8.75, "dotProduct(f2,vf)" => 12.25}, ["vf=(0:3.5)"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 59, "dotProduct(i,vi)" => 22, "dotProduct(i2,vi)" => 37}, ["vi=[3 4]"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 75, "dotProduct(f,vf)" => 29, "dotProduct(f2,vf)" => 46}, ["vf=[3.5 4.5]"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 59, "dotProduct(l,vl)" => 22, "dotProduct(l2,vl)" => 37}, ["vl=[3 4]"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 75, "dotProduct(d,vd)" => 29, "dotProduct(d2,vd)" => 46}, ["vd=[3.5 4.5]"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 75, "dotProduct(fd,vfd)" => 29, "dotProduct(fd2,vfd)" => 46}, ["vfd=[3.5 4.5]"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 75, "dotProduct(ff,vff)" => 29, "dotProduct(ff2,vff)" => 46}, ["vff=[3.5 4.5]"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 59, "dotProduct(fl,vfl)" => 22, "dotProduct(fl2,vfl)" => 37}, ["vfl=[3 4]"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 59, "dotProduct(fi,vfi)" => 22, "dotProduct(fi2,vfi)" => 37}, ["vfi=[3 4]"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => 134, "dotProduct(i,vi)" => 22, "dotProduct(f,vf)" => 29,
+                       "dotProduct(i2,vi)" => 37, "dotProduct(f2,vf)" => 46}, ["vi=[3 4]", "vf=[3.5 4.5]"])
+    assert_dotproduct({"rankingExpression(sum_dp)" => -134, "dotProduct(i,vi)" => -22, "dotProduct(f,vf)" => -29,
+                       "dotProduct(i2,vi)" => -37, "dotProduct(f2,vf)" => -46}, ["vi=[-3 -4]", "vf=[-3.5 -4.5]"])
   end
 
   def assert_dotproduct(expected, vectors)
-    query = "query=sddocname:dotproduct&streaming.userid=1"
+    query = "query=sddocname:dotproduct&streaming.userid=1&ranking=sum_dotproduct&ranking.queryCache=true"
     vectors.each do |vector|
       query += "&rankproperty.dotProduct." + vector
     end


### PR DESCRIPTION
@bratseth or @geirst PR
This verifies https://github.com/vespa-engine/vespa/pull/9850 and 
https://github.com/vespa-engine/vespa/pull/9620
