### PR TITLE
Allow more than one log entry

### DIFF
--- a/tests/cloudconfig/permanentservices/permanentservices.rb
+++ b/tests/cloudconfig/permanentservices/permanentservices.rb
@@ -25,7 +25,7 @@ class PermanentServices < CloudConfigTest
     @node.copy("#{selfdir}/permanent-services.xml", Environment.instance.vespa_home + "/conf/configserver-app/")
     deploy_app(CloudconfigApp.new)
     start
-    wait_for_log_matches(Regexp.compile("pinglo\\s.*icmp_seq"), 1)
+    wait_for_atleast_log_matches(Regexp.compile("pinglo\\s.*icmp_seq"), 1)
   end
 
   def teardown


### PR DESCRIPTION
Wait for more services when starting, so we might end up with more
than one log entry when service is started again.
