### PR TITLE
add float tensor case

### DIFF
--- a/tests/search/tensor_dot_product/docs.json
+++ b/tests/search/tensor_dot_product/docs.json
@@ -5,11 +5,23 @@
           { "address" : { "x" : "0" }, "value": 2.0 },
           { "address" : { "x" : "1" }, "value": 3.0 }
         ]
+      },
+      "dvectorf" : {
+        "cells": [
+          { "address" : { "x" : "0" }, "value": 2.0 },
+          { "address" : { "x" : "1" }, "value": 3.0 }
+        ]
       }
     }
   },
   { "put": "id:test:test::1", "fields": { "id": 1,
       "dvector" : {
+        "cells": [
+          { "address" : { "x" : "0" }, "value": 5.0 },
+          { "address" : { "x" : "1" }, "value": 11.0 }
+        ]
+      },
+      "dvectorf" : {
         "cells": [
           { "address" : { "x" : "0" }, "value": 5.0 },
           { "address" : { "x" : "1" }, "value": 11.0 }

--- a/tests/search/tensor_dot_product/search/query-profiles/types/root.xml
+++ b/tests/search/tensor_dot_product/search/query-profiles/types/root.xml
@@ -1,3 +1,4 @@
 <query-profile-type id="root" inherits="native">
   <field name="ranking.features.query(qvector)" type="tensor(x[2])" />
+  <field name="ranking.features.query(qvectorf)" type="tensor&lt;float&gt;(x[2])" />
 </query-profile-type>

--- a/tests/search/tensor_dot_product/tensor_dot_product.rb
+++ b/tests/search/tensor_dot_product/tensor_dot_product.rb
@@ -7,6 +7,14 @@ class TensorDotProductTest < IndexedSearchTest
     set_owner("toregge")
   end
 
+  def check_result(result, r1, r2)
+    assert_equal(2, result.hit.size)
+    assert_equal(1, result.hit[0].field["id"].to_i)
+    assert_equal(r1, result.hit[0].field["relevancy"].to_f)
+    assert_equal(0, result.hit[1].field["id"].to_i)
+    assert_equal(r2, result.hit[1].field["relevancy"].to_f)
+  end
+
   def test_tensor_dot_product
     set_description("Test basic tensor dot product in ranking expression")
     deploy_app(SearchApp.new.sd(selfdir + "test.sd").
@@ -14,30 +22,22 @@ class TensorDotProductTest < IndexedSearchTest
     start
     feed_and_wait_for_docs("test", 2, :file => selfdir + "docs.json")
 
-    result = search(get_query(13,17))
-    assert_equal(2, result.hit.size)
-    assert_equal(1, result.hit[0].field["id"].to_i)
-    assert_equal(252.0, result.hit[0].field["relevancy"].to_f)
-    assert_equal(0, result.hit[1].field["id"].to_i)
-    assert_equal(77.0, result.hit[1].field["relevancy"].to_f)
+    check_result(search(get_query(13,17)), 252.0, 77.0)
+    check_result(search(get_queryf(13,17)), 252.0, 77.0)
 
-    result = search(get_query(13,18))
-    assert_equal(2, result.hit.size)
-    assert_equal(1, result.hit[0].field["id"].to_i)
-    assert_equal(263.0, result.hit[0].field["relevancy"].to_f)
-    assert_equal(0, result.hit[1].field["id"].to_i)
-    assert_equal(80.0, result.hit[1].field["relevancy"].to_f)
+    check_result(search(get_query(13,18)), 263.0, 80.0)
+    check_result(search(get_queryf(13,18)), 263.0, 80.0)
 
-    result = search(get_query(14,17))
-    assert_equal(2, result.hit.size)
-    assert_equal(1, result.hit[0].field["id"].to_i)
-    assert_equal(257.0, result.hit[0].field["relevancy"].to_f)
-    assert_equal(0, result.hit[1].field["id"].to_i)
-    assert_equal(79.0, result.hit[1].field["relevancy"].to_f)
+    check_result(search(get_query(14,17)), 257.0, 79.0)
+    check_result(search(get_queryf(14,17)), 257.0, 79.0)
   end
 
   def get_query(x_0, x_1)
     "query=sddocname:test&ranking.features.query(qvector)={{x:0}:#{x_0},{x:1}:#{x_1}}"
+  end
+
+  def get_queryf(x_0, x_1)
+    "query=sddocname:test&ranking=usefloat&ranking.features.query(qvectorf)={{x:0}:#{x_0},{x:1}:#{x_1}}"
   end
 
   def teardown

--- a/tests/search/tensor_dot_product/test.sd
+++ b/tests/search/tensor_dot_product/test.sd
@@ -7,11 +7,21 @@ search test {
     field dvector type tensor(x[2]) {
       indexing: attribute | summary
     }
+    field dvectorf type tensor(x[2]) {
+      indexing: attribute | summary
+    }
   }
   rank-profile default {
     first-phase {
       expression {
         sum(query(qvector) * attribute(dvector))
+      }
+    }
+  }
+  rank-profile usefloat {
+    first-phase {
+      expression {
+        sum(query(qvectorf) * attribute(dvectorf))
       }
     }
   }


### PR DESCRIPTION
'as float as possible' right now, which is none. query profiles ignore
cell type and .sd files do not allow it.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
