### PR TITLE
Revert "Use TlsEnv in HttpConnectionPool"

### DIFF
--- a/lib/document_api_v1.rb
+++ b/lib/document_api_v1.rb
@@ -26,7 +26,7 @@ class DocumentApiV1
     @host = host
     @port = port
     @test_case = test_case
-    @connectionPool = HttpConnectionPool.new(test_case.tls_env)
+    @connectionPool = HttpConnectionPool.new
   end
 
   def request_params(params={})

--- a/lib/http_connection_pool.rb
+++ b/lib/http_connection_pool.rb
@@ -4,9 +4,9 @@ require 'thread'
 
 class Connection
 
-  def initialize(key, host, port, tls_env)
+  def initialize(key, host, port)
     @key = key
-    @connection = HttpsClient::new(tls_env).create_client(host, port)
+    @connection = Net::HTTP.new(host, port)
     @connection.start
   end
 
@@ -21,10 +21,9 @@ end
 
 class HttpConnectionPool
 
-  def initialize(tls_env)
+  def initialize
     @connections = {}
     @mutex = Mutex.new
-    @tls_env = tls_env
   end
 
   def acquire(host, port)
@@ -39,7 +38,7 @@ class HttpConnectionPool
       end
     end
     if ! connection
-      connection = Connection.new(key, host, port, @tls_env)
+      connection = Connection.new(key, host, port)
     end
     return connection
   end

--- a/lib/nodetypes/container_node.rb
+++ b/lib/nodetypes/container_node.rb
@@ -11,7 +11,7 @@ class ContainerNode < VespaNode
     super(*args)
     @refs = []
     @http_port = @ports_by_tag["query"] if @ports_by_tag
-    @connectionPool = HttpConnectionPool.new(tls_env)
+    @connectionPool = HttpConnectionPool.new
   end
 
   def local_ip


### PR DESCRIPTION
Reverts vespa-engine/system-test#185

Unit tests fail: `Error: test_search(TestbaseTest): NoMethodError: undefined method `tls_env' for #<MockNodeServer:0x00000003a57410 @https_client=nil>`