### PR TITLE
Revert "Bjorncs/https"

### DIFF
--- a/lib/document_api_v1.rb
+++ b/lib/document_api_v1.rb
@@ -26,7 +26,7 @@ class DocumentApiV1
     @host = host
     @port = port
     @test_case = test_case
-    @connectionPool = HttpConnectionPool.new(test_case.tls_env)
+    @connectionPool = HttpConnectionPool.new
   end
 
   def request_params(params={})

--- a/lib/http_connection_pool.rb
+++ b/lib/http_connection_pool.rb
@@ -4,9 +4,9 @@ require 'thread'
 
 class Connection
 
-  def initialize(key, host, port, tls_env)
+  def initialize(key, host, port)
     @key = key
-    @connection = HttpsClient.new(tls_env).create_client(host, port)
+    @connection = Net::HTTP.new(host, port)
     @connection.start
   end
 
@@ -21,10 +21,9 @@ end
 
 class HttpConnectionPool
 
-  def initialize(tls_env)
+  def initialize
     @connections = {}
     @mutex = Mutex.new
-    @tls_env = tls_env
   end
 
   def acquire(host, port)
@@ -39,7 +38,7 @@ class HttpConnectionPool
       end
     end
     if ! connection
-      connection = Connection.new(key, host, port, @tls_env)
+      connection = Connection.new(key, host, port)
     end
     return connection
   end

--- a/lib/https_client.rb
+++ b/lib/https_client.rb
@@ -36,17 +36,9 @@ class HttpsClient
     }
   end
 
-  def get(hostname, port, path, headers={})
+  def https_get(hostname, port, path, headers={})
     with_https_connection(hostname, port, path) do |conn, uri|
       conn.request(Net::HTTP::Get.new(uri, headers))
-    end
-  end
-
-  def post(hostname, port, path, body, headers={})
-    with_https_connection(hostname, port, path) do |conn, uri|
-      request = Net::HTTP::Post.new(uri, headers)
-      request.body = body
-      conn.request(request)
     end
   end
 

--- a/lib/node_server.rb
+++ b/lib/node_server.rb
@@ -40,7 +40,7 @@ class NodeServer
     @configserver_started = false
     @tls_env = TlsEnv.new
     @executor = Executor.new(@short_hostname)
-    @https_client = HttpsClient.new(@tls_env)
+    @https_client = HttpsClient::new(@tls_env)
   end
 
   def time
@@ -924,7 +924,7 @@ class NodeServer
 
   private
   def configserver_http_ping(hostname, port)
-    response = https_client.get(hostname, port, '/state/v1/health')
+    response = https_client.https_get(hostname, port, '/state/v1/health')
     raise StandardError.new("Got response code #{response.code}") unless response.is_a?(Net::HTTPSuccess)
     json = JSON.parse(response.body)
     status = json["status"]["code"]

--- a/lib/nodetypes/container_node.rb
+++ b/lib/nodetypes/container_node.rb
@@ -11,7 +11,7 @@ class ContainerNode < VespaNode
     super(*args)
     @refs = []
     @http_port = @ports_by_tag["query"] if @ports_by_tag
-    @connectionPool = HttpConnectionPool.new(tls_env)
+    @connectionPool = HttpConnectionPool.new
   end
 
   def local_ip

--- a/lib/nodetypes/docprocnode.rb
+++ b/lib/nodetypes/docprocnode.rb
@@ -11,7 +11,8 @@ class DocprocNode < ContainerNode
     endtime = Time.now.to_i + timeout.to_i
     while Time.now.to_i < endtime
       begin
-        https_get(@name, @http_port, '/')
+        http = Net::HTTP.new(@name, @http_port)
+        status = http.get("/")
       rescue StandardError => e
         sleep 0.1
         if Time.now.to_i < endtime

--- a/lib/nodetypes/vespa_node.rb
+++ b/lib/nodetypes/vespa_node.rb
@@ -43,7 +43,7 @@ class VespaNode
   end
 
   def https_get(hostname, port, path, headers={})
-    @https_client.get(hostname, port, path, headers)
+    @https_client.https_get(hostname, port, path, headers)
   end
 
   def get_json_over_http(full_path, port, hostname = "localhost")

--- a/lib/rest_api.rb
+++ b/lib/rest_api.rb
@@ -46,9 +46,9 @@ module RestApi
         end
         break
       rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL
-        puts "Error: #{$!}, url=#{original_uri}"
+        puts "Error: #{$!}, url=#{uri}"
         if iterations == max_iterations - 1
-          puts("Request failed after #{max_iterations} attempts: #{$!}, url=#{original_uri}")
+          puts("Request failed after #{max_iterations} attempts: #{$!}, url=#{uri}")
           raise
         else
           sleep 1

--- a/lib/test/mocks/mock_node_server.rb
+++ b/lib/test/mocks/mock_node_server.rb
@@ -2,11 +2,10 @@
 
 class MockNodeServer
 
-  attr_reader :https_client, :tls_env
+  attr_reader :https_client
 
   def initialize
-    @tls_env = TlsEnv.new
-    @https_client = HttpsClient.new(tls_env)
+    @https_client = nil
   end
 
 end

--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -72,8 +72,8 @@ class TestCase
     @tenant_name = sanitize_name(self.class.name)
     @application_name = nil
     @forked = args[:forked]
-    @tls_env = TlsEnv.new()
-    @https_client = HttpsClient.new(@tls_env)
+    @tls_env = TlsEnv::new()
+    @https_client = HttpsClient::new(@tls_env)
     # To avoid mass test breakage in case of known warnings, maintain a workaround
     # set of log messages to ignore.
     # ... don't keep them around for long, though!

--- a/tests/docproc/httphandler/docproc_httphandler.rb
+++ b/tests/docproc/httphandler/docproc_httphandler.rb
@@ -18,9 +18,10 @@ class DocprocHttpHandler < DocprocTest
     container = vespa.container.values.first
     wait_until_httphandler_ready(container)
 
-    response = @https_client.post(container.name, container.http_port,'/HttpDocproc', \
+    http = Net::HTTP.new(container.name, container.http_port)
+    response = http.post('/HttpDocproc', \
                          '<document id="id:this:music::is:a:music:document" type="music"><title>Best of Wenche Myhre</title></document>',
-                         headers={'Content-Type' => 'text/xml'})
+                         {'Content-Type' => 'text/xml'})
 
     assert_equal(response.message, "OK")
     assert_equal(response.code, "200")
@@ -45,7 +46,8 @@ class DocprocHttpHandler < DocprocTest
     endtime = Time.now.to_i + timeout.to_i
     while Time.now.to_i < endtime
        begin
-         status = @https_client.get(container.name, container.http_port, '/HttpDocproc')
+         http = Net::HTTP.new(container.name, container.http_port)
+         status = http.get("/HttpDocproc")
        rescue StandardError => e
          sleep 0.1
          if Time.now.to_i < endtime


### PR DESCRIPTION
Reverts vespa-engine/system-test#187

Some system tests fail with ssl errors, e.g. `OpenSSL::SSL::SSLError: hostname "10.93.41.68" does not match the server certificate`