### PR TITLE
Lower number of threads to match test hardware

### DIFF
--- a/tests/search/httpclient_docproc/massive_http_client_feeding.rb
+++ b/tests/search/httpclient_docproc/massive_http_client_feeding.rb
@@ -4,7 +4,7 @@ require 'document_set'
 
 class MassiveHttpClientFeedingTest < SearchTest
   
-  DOCUMENTS = 50000
+  DOCUMENTS = 100000
   
   def generate_documents(docid_begin, num_docs)
     ds = DocumentSet.new()
@@ -26,7 +26,7 @@ class MassiveHttpClientFeedingTest < SearchTest
                             jvmargs("-Xms4096m -Xmx4096m").
                             search(Searching.new).
                             gateway(ContainerDocumentApi.new).
-                            config(ConfigOverride.new("container.handler.threadpool").add("maxthreads", 50))
+                            config(ConfigOverride.new("container.handler.threadpool").add("maxthreads", 4))
     output = deploy_app(SearchApp.new.
                 cluster(SearchCluster.new.sd(SEARCH_DATA+"music.sd")).
                 container(container_cluster))
@@ -37,7 +37,7 @@ class MassiveHttpClientFeedingTest < SearchTest
     generate_documents(0, DOCUMENTS).write_vespafeed_xml(@feed_file)
     gw = @vespa.container.values.first
     wait_for_application(gw, output)
-    feedfile(@feed_file, {:client => :vespa_http_client, :host => gw.name, :port => gw.http_port, :num_persistent_connections_per_endpoint => 500})
+    feedfile(@feed_file, {:client => :vespa_http_client, :host => gw.name, :port => gw.http_port, :num_persistent_connections_per_endpoint => 16})
 
     # Don't care if we do not hit the spawned documents, we only care about feeding not getting stuck in this test.
     wait_for_hitcount("ronny", DOCUMENTS)


### PR DESCRIPTION
- Reduce container threads to 4 and client threads to 16
- Increase number of documents back to 100k.