### PR TITLE
Temporarily disable test that hampers other performnace tests MERGEOK

### DIFF
--- a/tests/performance/garbagecollect/garbagecollectbm.rb
+++ b/tests/performance/garbagecollect/garbagecollectbm.rb
@@ -664,7 +664,7 @@ class GarbageCollectBM < PerformanceTest
     graphs
   end
 
-  def test_garbage_collect_bm
+  def ignored_test_garbage_collect_bm
     @graphs = make_graphs
     puts "Before Deploy: #{@vespa.to_s}\n"
     perchunk = @perchunk


### PR DESCRIPTION
Reverts vespa-engine/system-test#316

Disable again until we understand why this one is hanging (and not all tests).