### PR TITLE
Add framework support and test for cluster state safe condition

### DIFF
--- a/lib/nodetypes/contentclustercontroller.rb
+++ b/lib/nodetypes/contentclustercontroller.rb
@@ -66,7 +66,7 @@ class ContentClusterController < VespaNode
     return response, response.body
   end
 
-  def set_node_state(cluster, nodetype, index, state)
+  def set_node_state(cluster, nodetype, index, state, condition=nil)
     state_map = {
       's:u' => 'up',
       's:d' => 'down',
@@ -81,7 +81,11 @@ class ContentClusterController < VespaNode
 
     res = with_https_connection(hostname, @statusport, "/cluster/v2/#{cluster}/#{nodetype}/#{index}") do |conn, uri|
       put_req = Net::HTTP::Put.new(uri, { 'Content-Type' => 'application/json'})
-      put_req.body = "{ \"state\" : { \"user\" : { \"state\" : \"#{rest_state}\", \"reason\" : \"Set by system test framework\" } } }"
+      args = { 'state' => { 'user' => { 'state' => rest_state, 'reason' => 'Set by system test framework' } } }
+      if condition
+        args['condition'] = condition
+      end
+      put_req.body = args.to_json
       conn.request(put_req)
     end
 

--- a/lib/nodetypes/storage.rb
+++ b/lib/nodetypes/storage.rb
@@ -16,8 +16,8 @@ class ClusterControllerWrapper
     @clustercontroller.wait_for_stable_system(@clustername)
   end
 
-  def set_node_state(nodetype, index, state)
-    @clustercontroller.set_node_state(@clustername, nodetype, index, state)
+  def set_node_state(nodetype, index, state, condition=nil)
+    @clustercontroller.set_node_state(@clustername, nodetype, index, state, condition)
   end
 
   def get_cluster_state


### PR DESCRIPTION
@geirst please review. Before adding any edge transition tests I want to make sure we have the ability to test the same behaviors that are triggered during orchestration.

Test that setting a content node to Maintenance state with 'safe'
condition implicitly sets distributor on same node into Down state,
and that this is reversed when setting content node back Up.
