### PR TITLE
Remove leftover, incomplete variable printing remnants in title string

### DIFF
--- a/tests/performance/state_transition/gets_during_state_transitions.rb
+++ b/tests/performance/state_transition/gets_during_state_transitions.rb
@@ -211,7 +211,7 @@ class GetsDuringStateTransitionsTest < PerformanceTest
     {
       :x => 'legend',
       :y => 'latency',
-      :title => "Historic Get latency with DB type #{db_type}, stale reads #{stale_reads}, edge #{edge}'}",
+      :title => "Historic Get latency with DB type #{db_type}, stale reads #{stale_reads}, edge #{edge}",
       :filter => { DB_TYPE => db_type, STALE_READS => stale_reads, EDGE => edge},
       :historic => true
     }


### PR DESCRIPTION
@geirst please review. This might be what is borking the graphs.