### PR TITLE
Gjoranv/deconstruct classloading

### DIFF
--- a/lib/container_test.rb
+++ b/lib/container_test.rb
@@ -20,7 +20,7 @@ class ContainerTest < TestCase
   # The first app must be deployed with 'start'
   def deploy(app, params={})
     output = container_deploy(app, params)
-    @container = vespa.container.values.first
+    @container = (vespa.container.values.first || vespa.qrserver.values.first)
     wait_for_application(@container, output)
   end
 

--- a/tests/container/classloading_in_deconstruct/classloading_in_deconstruct.rb
+++ b/tests/container/classloading_in_deconstruct/classloading_in_deconstruct.rb
@@ -1,0 +1,49 @@
+# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+require 'container_test'
+require 'app_generator/container_app'
+
+class ClassloadingInDeconstruct < ContainerTest
+
+  def setup
+    set_owner("gjoranv")
+    set_description("Deploys a component that loads a new class in its deconstruct method, " +
+                        "to verify that the bundle classloader is still functioning.")
+  end
+
+  def test_classloading_in_deconstruct
+    searcher = add_bundle_dir(selfdir, "com.yahoo.vespatest.DeconstructSearcher", :name => 'searcher')
+    compile_bundles(@vespa.nodeproxies.values.first)
+
+    start(create_application('Hello, World!'), :bundles => [searcher])
+    verify_response('Hello, World!')
+
+    # Redeploy with same bundle, but modified configured message
+    deploy(create_application('Hello again!'), :bundles => [searcher])
+    verify_response('Hello again!')
+
+    sleep_period = 70
+    puts "Sleeping #{sleep_period} seconds for old searcher to be deconstructed."
+    sleep(sleep_period)
+  end
+
+  def verify_response(expected)
+    result = @container.search("/search/")
+    assert_match(/#{expected}/, result.xmldata, "Did not get expected response.")
+  end
+
+  def create_application(message)
+    config = ConfigOverride.new(:"com.yahoo.vespatest.response").
+        add("response", message)
+
+    ContainerApp.new(false).
+        container(Container.new.search(Searching.new.
+            chain(Chain.new.add(
+                Searcher.new("com.yahoo.vespatest.DeconstructSearcher").
+                    config(config)))))
+  end
+
+  def teardown
+    stop
+  end
+
+end

--- a/tests/container/classloading_in_deconstruct/src/main/java/com/yahoo/vespatest/DeconstructSearcher.java
+++ b/tests/container/classloading_in_deconstruct/src/main/java/com/yahoo/vespatest/DeconstructSearcher.java
@@ -1,0 +1,42 @@
+package com.yahoo.vespatest;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.yahoo.search.*;
+import com.yahoo.search.result.Hit;
+import com.yahoo.search.searchchain.Execution;
+
+/**
+ * A searcher loading a not previously loaded class in its deconstruct method.
+ */
+public class DeconstructSearcher extends Searcher {
+    private static final Logger log = Logger.getLogger(DeconstructSearcher.class.getName());
+
+    private final String response;
+
+    public DeconstructSearcher(ResponseConfig config) {
+        response = config.response();
+    }
+
+    @Override
+    public Result search(Query query, Execution execution) {
+        query.trace("Running simpleSearcher", true, 3);
+        Result result = execution.search(query); // Pass on to the next searcher to get results
+        Hit hit = new Hit("test");
+        hit.setField("message", response);
+        result.hits().add(hit);
+        query.trace("SimpleSearcher: result set: " + result.toString(), true, 3);
+        return result;
+    }
+
+    @Override
+    public void deconstruct() {
+        try {
+            Class<?> causesException = this.getClass().forName("com.yahoo.docproc.DocumentProcessor");
+        } catch (ClassNotFoundException e) {
+            log.log(Level.SEVERE, "Class not found when deconstructing searcher", e);
+        }
+    }
+
+}

--- a/tests/container/classloading_in_deconstruct/src/main/resources/configdefinitions/response.def
+++ b/tests/container/classloading_in_deconstruct/src/main/resources/configdefinitions/response.def
@@ -1,0 +1,3 @@
+package=com.yahoo.vespatest
+
+response string


### PR DESCRIPTION
This test will fail until the container allows duplicate application bundles. I will mark the test RELEASE_OK until that is implemented.

Note that the test sleeps for 70 sec, as there is no way (yet) to control the deconstruction delay, which is fixed at 60 sec. 

FYI: @aressem 