### PR TITLE
Only redeploy once.

### DIFF
--- a/tests/container/component_update_bundle_only/component_update_bundle_only.rb
+++ b/tests/container/component_update_bundle_only/component_update_bundle_only.rb
@@ -42,12 +42,8 @@ class ComponentUpdateBundleOnly < SearchContainerTest
 
     verify_handler_response("Initial handler")
 
-    for i in (1..2)
-      puts ">>>>>>>>>>>> Deploying the updated bundle for the #{i}. time"
-      redeploy("Updated handler", updated)
-      puts ">>>>>>>>>>>> Deploying the initial bundle for the #{i+1}. time"
-      redeploy("Initial handler", initial)
-    end
+    puts ">>>>>>>>>>>> Deploying the updated bundle"
+    redeploy("Updated handler", updated)
 
   end
 


### PR DESCRIPTION
Redeploying the original bundle fails when Jdisc is modified to
allow duplicate bundles. The original bundle will be invisible
until it has been uninstalled along with destructing the
component for the initial application. Re-installing it before
that point will not help, because installing an already installed
bundle is a NOP.

Alternatively, we could have added a delay between redeploys,
larger than the deconstruct delay of 60 sec, but this seems
unnecessary.
