### PR TITLE
Test that numeric range search with 'fast-search' (that triggers use …

### DIFF
--- a/tests/search/struct_and_map_types/range_fast_search/docs.json
+++ b/tests/search/struct_and_map_types/range_fast_search/docs.json
@@ -1,0 +1,57 @@
+[
+{
+    "put": "id:test:test::0",
+    "fields": {
+        "assets": [
+        {
+            "type": "mp4",
+            "pixels": 786432
+        }
+        ]
+    }
+},
+{
+    "put": "id:test:test::1",
+    "fields": {
+        "assets": [
+        {
+            "type": "mp4",
+            "pixels": 1800000
+        }
+        ]
+    }
+},
+{
+    "put": "id:test:test::2",
+    "fields": {
+        "assets": [
+        {
+            "type": "mp4",
+            "pixels": 786432
+        }
+        ]
+    }
+},
+{
+    "put": "id:test:test::3",
+    "fields": {
+        "assets": [
+        {
+            "type": "mp4",
+            "pixels": 921600
+        }
+        ]
+    }
+},
+{
+    "put": "id:test:test::4",
+    "fields": {
+        "assets": [
+        {
+            "type": "mp4",
+            "pixels": 921600
+        }
+        ]
+    }
+}
+]

--- a/tests/search/struct_and_map_types/range_fast_search/test.sd
+++ b/tests/search/struct_and_map_types/range_fast_search/test.sd
@@ -1,0 +1,20 @@
+# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+search test {
+  document test {
+    struct asset {
+      field type type string {}
+      field pixels type int {}
+    }
+    field assets type array<asset> {
+      indexing: summary
+      struct-field type {
+        indexing: attribute
+        attribute: fast-search
+      }
+      struct-field pixels {
+        indexing: attribute
+        attribute: fast-search
+      }
+    }
+  }
+}


### PR DESCRIPTION
…of bit vectors) works with sameElement operator.

This reproduces the bug fixed in https://github.com/vespa-engine/vespa/pull/11188.

@havardpe please review (should be merged after https://github.com/vespa-engine/vespa/pull/11188)
@toregge FYI
