### PR TITLE
Revert "Enable distributor B-tree database for system tests"

### DIFF
--- a/lib/app_generator/search_app.rb
+++ b/lib/app_generator/search_app.rb
@@ -31,8 +31,6 @@ class SearchApp < App
                add("min_distributor_up_ratio", 0.1).
                add("min_storage_up_ratio", 0.1).
                add("storage_transition_time", 0))
-    config(ConfigOverride.new('vespa.config.content.core.stor-distributormanager').
-               add('use_btree_database', true))
   end
 
   def cluster(search_cluster)

--- a/lib/app_generator/storage_app.rb
+++ b/lib/app_generator/storage_app.rb
@@ -31,8 +31,6 @@ class StorageApp < App
     @content.search_type(:none)
     @content.provider(:proton)
     @transition_time = 0
-    config(ConfigOverride.new('vespa.config.content.core.stor-distributormanager').
-               add('use_btree_database', true))
   end
 
   def default_cluster(name="storage")

--- a/lib/app_generator/test/complex_elastic.xml
+++ b/lib/app_generator/test/complex_elastic.xml
@@ -10,9 +10,6 @@
     <min_storage_up_ratio>0.1</min_storage_up_ratio>
     <storage_transition_time>0</storage_transition_time>
   </config>
-  <config name="vespa.config.content.core.stor-distributormanager">
-    <use_btree_database>true</use_btree_database>
-  </config>
   <config name="stor-distribution">
     <ready_copies>2</ready_copies>
   </config>

--- a/lib/app_generator/test/default_elastic.xml
+++ b/lib/app_generator/test/default_elastic.xml
@@ -10,9 +10,6 @@
     <min_storage_up_ratio>0.1</min_storage_up_ratio>
     <storage_transition_time>0</storage_transition_time>
   </config>
-  <config name="vespa.config.content.core.stor-distributormanager">
-    <use_btree_database>true</use_btree_database>
-  </config>
 
   <container id="default" version="1.0">
     <search />

--- a/lib/app_generator/test/default_streaming.xml
+++ b/lib/app_generator/test/default_streaming.xml
@@ -10,9 +10,6 @@
     <min_storage_up_ratio>0.1</min_storage_up_ratio>
     <storage_transition_time>0</storage_transition_time>
   </config>
-  <config name="vespa.config.content.core.stor-distributormanager">
-    <use_btree_database>true</use_btree_database>
-  </config>
 
   <container id="default" version="1.0">
     <search />

--- a/lib/app_generator/test/storageapp_configoverride.xml
+++ b/lib/app_generator/test/storageapp_configoverride.xml
@@ -4,9 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-distributormanager">
-    <use_btree_database>true</use_btree_database>
-  </config>
   <config name="metricsmanager">
     <consumers operation="append">
       <name>myconsumer</name>

--- a/lib/app_generator/test/storageapp_configoverride2.xml
+++ b/lib/app_generator/test/storageapp_configoverride2.xml
@@ -4,9 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-distributormanager">
-    <use_btree_database>true</use_btree_database>
-  </config>
   <config name="metricsmanager">
     <snapshot>
       <periods operation="append">10</periods>

--- a/lib/app_generator/test/storageapp_default_dummy.xml
+++ b/lib/app_generator/test/storageapp_default_dummy.xml
@@ -4,10 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-distributormanager">
-    <use_btree_database>true</use_btree_database>
-  </config>
-
   <container id="default" version="1.0">
     <search />
     <document-processing />

--- a/lib/app_generator/test/storageapp_default_proton.xml
+++ b/lib/app_generator/test/storageapp_default_proton.xml
@@ -4,10 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-distributormanager">
-    <use_btree_database>true</use_btree_database>
-  </config>
-
   <container id="default" version="1.0">
     <search />
     <document-processing />

--- a/lib/app_generator/test/storageapp_default_storage_content.xml
+++ b/lib/app_generator/test/storageapp_default_storage_content.xml
@@ -4,10 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-distributormanager">
-    <use_btree_database>true</use_btree_database>
-  </config>
-
   <container id="default" version="1.0">
     <search />
     <document-processing />

--- a/lib/app_generator/test/storageapp_default_storage_content_explicit_doctype_decls.xml
+++ b/lib/app_generator/test/storageapp_default_storage_content_explicit_doctype_decls.xml
@@ -4,10 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-distributormanager">
-    <use_btree_database>true</use_btree_database>
-  </config>
-
   <container id="default" version="1.0">
     <search />
     <document-processing />

--- a/lib/app_generator/test/storageapp_default_storage_content_streaming.xml
+++ b/lib/app_generator/test/storageapp_default_storage_content_streaming.xml
@@ -4,10 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-distributormanager">
-    <use_btree_database>true</use_btree_database>
-  </config>
-
   <container id="default" version="1.0">
     <search />
     <document-processing />

--- a/lib/app_generator/test/storageapp_storage_content_with_thread_config.xml
+++ b/lib/app_generator/test/storageapp_storage_content_with_thread_config.xml
@@ -4,10 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-distributormanager">
-    <use_btree_database>true</use_btree_database>
-  </config>
-
   <container id="default" version="1.0">
     <search />
     <document-processing />


### PR DESCRIPTION
@geirst please review. Seeing if this is the cause of some minor feeding performance test regressions.

Reverts vespa-engine/system-test#397