### PR TITLE
Extend matched-elements-only tests with case where the map struct has…

### DIFF
--- a/tests/search/struct_and_map_types/attribute_fields/test.sd
+++ b/tests/search/struct_and_map_types/attribute_fields/test.sd
@@ -5,6 +5,12 @@ search test {
       field name type string {}
       field weight type int {}
     }
+    struct complex_elem {
+      field name type string {}
+      field weight type int {}
+      # This field is not searchable
+      field str_map type map<string, int> {}
+    }
     field elem_array type array<elem> {
       # All struct-fields are attributes
       indexing: summary
@@ -49,6 +55,16 @@ search test {
         attribute: fast-search
       }
       struct-field value {
+        indexing: attribute
+      }
+    }
+    field complex_elem_map type map<string, complex_elem> {
+      # Some struct-fields are attributes
+      indexing: summary
+      struct-field key {
+        indexing: attribute
+      }
+      struct-field value.weight {
         indexing: attribute
       }
     }
@@ -103,6 +119,17 @@ search test {
         indexing: attribute
       }
     }
+    field complex_elem_map_meo type map<string, complex_elem> {
+      # Some struct-fields are attributes
+      indexing: summary
+      summary: matched-elements-only
+      struct-field key {
+        indexing: attribute
+      }
+      struct-field value.weight {
+        indexing: attribute
+      }
+    }
   }
   document-summary filtered {
     summary documentid type string {}
@@ -120,6 +147,10 @@ search test {
     }
     summary str_int_map_filtered type map<string, int> {
       source: str_int_map
+      matched-elements-only
+    }
+    summary complex_elem_map_filtered type map<string, complex_elem> {
+      source: complex_elem_map
       matched-elements-only
     }
   }

--- a/tests/search/struct_and_map_types/docs_search.json
+++ b/tests/search/struct_and_map_types/docs_search.json
@@ -49,6 +49,22 @@
         "@bar": 20,
         "@baz": 30
       },
+      "complex_elem_map": {
+        "@foo": {
+          "name": "foo",
+          "weight": 10,
+          "str_map": {
+            "aa": 11
+          }
+        },
+        "@bar": {
+          "name": "bar",
+          "weight": 20,
+          "str_map": {
+            "bb": 21
+          }
+        }
+      },
       "elem_array_meo": [
         {
           "name": "foo",
@@ -95,6 +111,22 @@
         "@foo": 10,
         "@bar": 20,
         "@baz": 30
+      },
+      "complex_elem_map_meo": {
+        "@foo": {
+          "name": "foo",
+          "weight": 10,
+          "str_map": {
+            "aa": 11
+          }
+        },
+        "@bar": {
+          "name": "bar",
+          "weight": 20,
+          "str_map": {
+            "bb": 21
+          }
+        }
       }
     }
   },

--- a/tests/search/struct_and_map_types/streaming_fields/test.sd
+++ b/tests/search/struct_and_map_types/streaming_fields/test.sd
@@ -5,6 +5,11 @@ search test {
       field name type string {}
       field weight type int {}
     }
+    struct complex_elem {
+      field name type string {}
+      field weight type int {}
+      field str_map type map<string, int> {}
+    }
     field elem_array type array<elem> {
       indexing: index | summary
     }
@@ -15,6 +20,9 @@ search test {
       indexing: index | summary
     }
     field str_int_map type map<string, int> {
+      indexing: index | summary
+    }
+    field complex_elem_map type map<string, complex_elem> {
       indexing: index | summary
     }
     field elem_array_meo type array<elem> {
@@ -30,6 +38,10 @@ search test {
       summary: matched-elements-only
     }
     field str_int_map_meo type map<string, int> {
+      indexing: index | summary
+      summary: matched-elements-only
+    }
+    field complex_elem_map_meo type map<string, complex_elem> {
       indexing: index | summary
       summary: matched-elements-only
     }
@@ -50,6 +62,10 @@ search test {
     }
     summary str_int_map_filtered type map<string, int> {
       source: str_int_map
+      matched-elements-only
+    }
+    summary complex_elem_map_filtered type map<string, complex_elem> {
+      source: complex_elem_map
       matched-elements-only
     }
   }

--- a/tests/search/struct_and_map_types/struct_and_map_types.rb
+++ b/tests/search/struct_and_map_types/struct_and_map_types.rb
@@ -152,35 +152,49 @@ class StructAndMapTypesTest < IndexedStreamingSearchTest
     map_filtered = {"@bar" => elem("bar", 20)}
     prim_map_full = {"@foo" => 10, "@bar" => 20, "@baz" => 30}
     prim_map_filtered = {"@bar" => 20}
+    complex_map_full = {"@foo" => complex_elem("foo", 10, "aa", 11), "@bar" => complex_elem("bar", 20, "bb", 21)}
+    complex_map_filtered = {"@bar" => complex_elem("bar", 20, "bb", 21)}
+
+    map_same_elem_query = "key contains '@bar', value.weight contains '20'"
 
     assert_same_element_summary("elem_array",     "name contains 'bar', weight contains '20'", "default",  "elem_array",          array_full)
     assert_same_element_summary("elem_array",     "name contains 'bar', weight contains '20'", "filtered", "elem_array_filtered", array_filtered)
     assert_same_element_summary("elem_array_meo", "name contains 'bar', weight contains '20'", "default",  "elem_array_meo",      array_filtered)
 
-    assert_same_element_summary("elem_map",       "key contains '@bar', value.weight contains '20'", "default",  "elem_map",            map_full)
-    assert_same_element_summary("elem_map",       "key contains '@bar', value.weight contains '20'", "filtered", "elem_map_filtered",   map_filtered)
-    assert_same_element_summary("elem_map_meo",   "key contains '@bar', value.weight contains '20'", "default",  "elem_map_meo",        map_filtered)
-    assert_same_element_summary("elem_map_2",     "key contains '@bar', value.weight contains '20'", "filtered", "elem_map_2_filtered", map_filtered)
-    assert_same_element_summary("elem_map_2_meo", "key contains '@bar', value.weight contains '20'", "default",  "elem_map_2_meo",      map_filtered)
+    assert_same_element_summary("elem_map",       map_same_elem_query, "default",  "elem_map",            map_full)
+    assert_same_element_summary("elem_map",       map_same_elem_query, "filtered", "elem_map_filtered",   map_filtered)
+    assert_same_element_summary("elem_map_meo",   map_same_elem_query, "default",  "elem_map_meo",        map_filtered)
+    assert_same_element_summary("elem_map_2",     map_same_elem_query, "filtered", "elem_map_2_filtered", map_filtered)
+    assert_same_element_summary("elem_map_2_meo", map_same_elem_query, "default",  "elem_map_2_meo",      map_filtered)
 
     assert_same_element_summary("str_int_map",     "key contains '@bar', value contains '20'", "default",  "str_int_map",          prim_map_full)
     assert_same_element_summary("str_int_map",     "key contains '@bar', value contains '20'", "filtered", "str_int_map_filtered", prim_map_filtered)
     assert_same_element_summary("str_int_map_meo", "key contains '@bar', value contains '20'", "default",  "str_int_map_meo",      prim_map_filtered)
 
+    assert_same_element_summary("complex_elem_map",     map_same_elem_query, "default",  "complex_elem_map",          complex_map_full)
+    assert_same_element_summary("complex_elem_map",     map_same_elem_query, "filtered", "complex_elem_map_filtered", complex_map_filtered)
+    assert_same_element_summary("complex_elem_map_meo", map_same_elem_query, "default",  "complex_elem_map_meo",      complex_map_filtered)
+
+
+    map_key_query = "key contains '@bar'"
 
     assert_same_element_single_summary("elem_array",     "name contains 'bar'", "default",  "elem_array",          array_full)
     assert_same_element_single_summary("elem_array",     "name contains 'bar'", "filtered", "elem_array_filtered", array_filtered)
     assert_same_element_single_summary("elem_array_meo", "name contains 'bar'", "default",  "elem_array_meo",      array_filtered)
 
-    assert_same_element_single_summary("elem_map",       "key contains '@bar'", "default",  "elem_map",            map_full)
-    assert_same_element_single_summary("elem_map",       "key contains '@bar'", "filtered", "elem_map_filtered",   map_filtered)
-    assert_same_element_single_summary("elem_map_meo",   "key contains '@bar'", "default",  "elem_map_meo",        map_filtered)
-    assert_same_element_single_summary("elem_map_2",     "key contains '@bar'", "filtered", "elem_map_2_filtered", map_filtered)
-    assert_same_element_single_summary("elem_map_2_meo", "key contains '@bar'", "default",  "elem_map_2_meo",      map_filtered)
+    assert_same_element_single_summary("elem_map",       map_key_query, "default",  "elem_map",            map_full)
+    assert_same_element_single_summary("elem_map",       map_key_query, "filtered", "elem_map_filtered",   map_filtered)
+    assert_same_element_single_summary("elem_map_meo",   map_key_query, "default",  "elem_map_meo",        map_filtered)
+    assert_same_element_single_summary("elem_map_2",     map_key_query, "filtered", "elem_map_2_filtered", map_filtered)
+    assert_same_element_single_summary("elem_map_2_meo", map_key_query, "default",  "elem_map_2_meo",      map_filtered)
 
-    assert_same_element_single_summary("str_int_map",     "key contains '@bar'", "default",  "str_int_map",          prim_map_full)
-    assert_same_element_single_summary("str_int_map",     "key contains '@bar'", "filtered", "str_int_map_filtered", prim_map_filtered)
-    assert_same_element_single_summary("str_int_map_meo", "key contains '@bar'", "default",  "str_int_map_meo",      prim_map_filtered)
+    assert_same_element_single_summary("str_int_map",     map_key_query, "default",  "str_int_map",          prim_map_full)
+    assert_same_element_single_summary("str_int_map",     map_key_query, "filtered", "str_int_map_filtered", prim_map_filtered)
+    assert_same_element_single_summary("str_int_map_meo", map_key_query, "default",  "str_int_map_meo",      prim_map_filtered)
+
+    assert_same_element_single_summary("complex_elem_map",     map_key_query, "default",  "complex_elem_map",          complex_map_full)
+    assert_same_element_single_summary("complex_elem_map",     map_key_query, "filtered", "complex_elem_map_filtered", complex_map_filtered)
+    assert_same_element_single_summary("complex_elem_map_meo", map_key_query, "default",  "complex_elem_map_meo",      complex_map_filtered)
   end
 
   def assert_same_element(field, same_element, exp_hitcount, extra_params = "")
@@ -249,6 +263,10 @@ class StructAndMapTypesTest < IndexedStreamingSearchTest
 
   def elem_weight(weight)
     {"weight"=>weight}
+  end
+
+  def complex_elem(name, weight, str_map_key, str_map_value)
+    {"name" => name, "weight" => weight, "str_map" => [{"key" => str_map_key, "value" => str_map_value}]}
   end
 
   def run_baseline_test_case


### PR DESCRIPTION
… a field that is not searchable.

@toregge please review
