### PR TITLE
Add test case for partial updates to array of position

### DIFF
--- a/tests/vds/documentapi/document_api_v1_part2.rb
+++ b/tests/vds/documentapi/document_api_v1_part2.rb
@@ -70,6 +70,18 @@ class DocumentApiVdsPart2 < DocumentApiV1Base
                   { 'lastname' => 'Newman' }], arrayData)
   end
 
+  def test_array_of_position_can_be_assigned
+    api_http_post('/document/v1/storage_test/music/number/2/9', '{"fields":{"position_array": ["N41o40\'51;W72o56\'19", "N31o30\'41;W62o56\'18"]}}')
+    response = api_http_get('/document/v1/storage_test/music/number/2/9')
+    array_field = JSON.parse(response)['fields']['position_array']
+    assert_equal([{"y"=>41680833, "x"=>-72938611}, {"y"=>31511388, "x"=>-62938333}], array_field)
+
+    api_http_put('/document/v1/storage_test/music/number/2/9', '{"fields":{"position_array":{"assign":["N42o42\'52;W82o66\'29"]}}}')
+    response = api_http_get('/document/v1/storage_test/music/number/2/9')
+    array_field = JSON.parse(response)['fields']['position_array']
+    assert_equal([{"y"=>42714444, "x"=>-83108055}], array_field)
+  end
+
   def test_array_element_match_update_affects_specified_index
     response = api_http_post('/document/v1/storage_test/music/number/2/9', '{"fields":{"string_array": ["foo", "bar", "baz"]}}')
     assert_json_string_equal(

--- a/tests/vds/documentapi/music.sd
+++ b/tests/vds/documentapi/music.sd
@@ -34,5 +34,8 @@ search music {
     field person_array type array<personstruct> { }
 
     field person_to_age type weightedset<string> { }
+    field position_array type array<position> {
+      indexing: attribute
+    }
   }
 }


### PR DESCRIPTION
@geirst please review. This reproduces the issue where  an attribute field of`array<position>` type fails to receive partial updates when `mode="indexed"`. See https://github.com/vespa-engine/vespa/issues/11588