### PR TITLE
Revert "Override environment settings"

### DIFF
--- a/tests/cloudconfig/multienvironment/multienvironment.rb
+++ b/tests/cloudconfig/multienvironment/multienvironment.rb
@@ -34,12 +34,14 @@ class MultiEnvironment < CloudConfigTest
   end
 
   def set_env_and_region(node, environment, region)
-    override_environment_setting(node, "cloudconfig_server.environment", environment)
-    override_environment_setting(node, "cloudconfig_server.region", region)
-    @dirty_environment_settings = true
+    node.execute("yinst set cloudconfig_server.environment=#{environment}")
+    node.execute("yinst set cloudconfig_server.region=#{region}")
   end
 
   def teardown
+    @node.execute("yinst unset cloudconfig_server.environment")
+    @node.execute("yinst unset cloudconfig_server.region")
+    @dirty_environment_settings = true
     stop
   end
 end

--- a/tests/search/jvmtuning/jvmtuning.rb
+++ b/tests/search/jvmtuning/jvmtuning.rb
@@ -11,7 +11,7 @@ class JvmTuning < SearchTest
 
   def setup
     set_owner("musum")
-    set_description("Test setting jvmargs in services.xml or with environment settings")
+    set_description("Test setting jvmargs in services.xml or with yinst settings")
   end
 
   def deploy_jvmtuning


### PR DESCRIPTION
Reverts vespa-engine/system-test#476

yinst settings are run in lib-internal/environment.rb::set_addr_configserver, which is not what I expected (expected lib/environment.rb::set_addr_configserver to be run, need to understand how this works)