### PR TITLE
 Cleanup integration tests, part 2

### DIFF
--- a/tests/cloudconfig/integrationtests/config_test/src/main/java/com/yahoo/vespa/config/testutil/ConfigServerRunner.java
+++ b/tests/cloudconfig/integrationtests/config_test/src/main/java/com/yahoo/vespa/config/testutil/ConfigServerRunner.java
@@ -16,11 +16,11 @@ import java.util.Map;
 /**
  * A config server controller, capable of taking user input and perform actions on the config server.
  *
- * @author lulf
+ * @author Ulf Lilleengen
  */
 public class ConfigServerRunner {
 
-	private class ServerContext {
+	private static class ServerContext {
 		public final TestConfigServer server;
 		public final Thread thread;
 		

--- a/tests/cloudconfig/integrationtests/config_test/src/main/java/com/yahoo/vespa/config/testutil/TestConfigServer.java
+++ b/tests/cloudconfig/integrationtests/config_test/src/main/java/com/yahoo/vespa/config/testutil/TestConfigServer.java
@@ -47,6 +47,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -99,8 +100,14 @@ public class TestConfigServer implements RequestHandler, ReloadHandler, TenantHa
                 return null;
             }
         };
-        
-        ConfigserverConfig configServerConfig = new ConfigserverConfig(new ConfigserverConfig.Builder());
+
+        String fileReferencesDir;
+        try {
+            fileReferencesDir = Files.createTempDirectory("filereferences").toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        ConfigserverConfig configServerConfig = new ConfigserverConfig(new ConfigserverConfig.Builder().fileReferencesDir(fileReferencesDir));
         final NodeFlavors nodeFlavors = new NodeFlavors(new FlavorsConfig(new FlavorsConfig.Builder()));
         final SuperModelManager superModelManager = new SuperModelManager(configServerConfig, nodeFlavors, new GenerationCounter() {
             @Override
@@ -282,10 +289,10 @@ public class TestConfigServer implements RequestHandler, ReloadHandler, TenantHa
      * @param configDir     directory to read config files from
      */
     public synchronized void deployNewConfig(String configDir) {
-        log.info("Deploying the dir " + configDir);
         this.configDir = configDir;
         long gen = updateApplication();
-        log.log(LogLevel.INFO, "Config reloaded successfully with new application generation " + gen);
+        log.log(LogLevel.INFO, "Activated config with generation " + gen + " from directory " + configDir +
+                               " on config server using port " + port);
     }
 
     protected AtomicLong loadLiveApplication() {

--- a/tests/cloudconfig/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/BasicSubscriptionTest.java
+++ b/tests/cloudconfig/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/BasicSubscriptionTest.java
@@ -1,6 +1,9 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.subscription;
 
+import static com.yahoo.vespa.config.ConfigTester.getTestTimingValues;
+import static com.yahoo.vespa.config.ConfigTester.waitWhenExpectedFailure;
+import static com.yahoo.vespa.config.ConfigTester.waitWhenExpectedSuccess;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -14,7 +17,8 @@ import com.yahoo.config.ConfigurationRuntimeException;
 import com.yahoo.config.FooConfig;
 import com.yahoo.io.IOUtils;
 import com.yahoo.log.LogLevel;
-import com.yahoo.vespa.config.ConfigTest;
+import com.yahoo.vespa.config.ConfigTester;
+import com.yahoo.vespa.config.testutil.TestConfigServer;
 import com.yahoo.vespa.config.util.ConfigUtils;
 
 import org.junit.After;
@@ -28,7 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 
-public class BasicSubscriptionTest extends ConfigTest {
+public class BasicSubscriptionTest {
     private java.util.logging.Logger log = java.util.logging.Logger.getLogger(BasicSubscriptionTest.class.getName());
     private ConfigSubscriber subscriber;
     
@@ -44,258 +48,300 @@ public class BasicSubscriptionTest extends ConfigTest {
     
     @Test
     public void testSimpleJRTSubscription() {
-        ConfigHandle<AppConfig> appCfgHandle = subscriber.subscribe(AppConfig.class, "app.0", getTestSourceSet(), getTestTimingValues());
-        subscriber.nextConfig(waitWhenExpectedSuccess);
-        assertTrue(appCfgHandle.isChanged());
-        assertNotNull(appCfgHandle.getConfig());
-        AppConfig a = appCfgHandle.getConfig();
-        assertEquals(a.message(), "msg1");
+        try (ConfigTester tester = new ConfigTester()) {
+            tester.startOneConfigServer();
+            ConfigHandle<AppConfig> appCfgHandle = subscriber.subscribe(AppConfig.class, "app.0",
+                                                                        tester.getTestSourceSet(), getTestTimingValues());
+            subscriber.nextConfig(waitWhenExpectedSuccess);
+            assertTrue(appCfgHandle.isChanged());
+            assertNotNull(appCfgHandle.getConfig());
+            AppConfig a = appCfgHandle.getConfig();
+            assertEquals(a.message(), "msg1");
 
-        // Test that config md5 is set correctly
-        final File file = new File("configs/foo/app.cfg");
-        try {
-            String md5 = ConfigUtils.getMd5(new CfgConfigPayloadBuilder().deserialize(Arrays.asList(IOUtils.readFile(file).split("\n"))));
-            assertThat(a.getConfigMd5(), is(md5));
-        } catch (IOException e) {
-            fail("Could not read file " + file);
+            // Test that config md5 is set correctly
+            final File file = new File("configs/foo/app.cfg");
+            try {
+                String md5 = ConfigUtils.getMd5(new CfgConfigPayloadBuilder().deserialize(Arrays.asList(IOUtils.readFile(file).split("\n"))));
+                assertThat(a.getConfigMd5(), is(md5));
+            } catch (IOException e) {
+                fail("Could not read file " + file);
+            }
         }
     }
 
     @Test
     public void testStateConstraints() {
-        ConfigHandle<AppConfig> appCfgHandle = subscriber.subscribe(AppConfig.class, "app.1", getTestSourceSet(), getTestTimingValues());
-        subscriber.nextConfig(50);
-        appCfgHandle.getConfig();
-        try {
-            subscriber.subscribe(NamespaceConfig.class, "foo");
-            fail("Could subscribe after frozen");
-        } catch (Exception e) {
-            assertTrue(e instanceof IllegalStateException);
+        try (ConfigTester tester = new ConfigTester()) {
+            tester.startOneConfigServer();
+            ConfigHandle<AppConfig> appCfgHandle = subscriber.subscribe(AppConfig.class, "app.1",
+                                                                        tester.getTestSourceSet(), getTestTimingValues());
+            subscriber.nextConfig(50);
+            appCfgHandle.getConfig();
+            try {
+                subscriber.subscribe(NamespaceConfig.class, "foo");
+                fail("Could subscribe after frozen");
+            } catch (Exception e) {
+                assertTrue(e instanceof IllegalStateException);
+            }
+            subscriber.close();
+            assertFalse(subscriber.nextConfig(1));
         }
-        subscriber.close();
-        assertFalse(subscriber.nextConfig(1));
     }
 
     @Test
     public void testServerFailingNextConfigFalse() {
-        ConfigHandle<AppConfig> appCfgHandle = subscriber.subscribe(AppConfig.class, "app.2", getTestSourceSet(), getTestTimingValues());
-        boolean newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
-        assertTrue(newConf);
-        assertTrue(appCfgHandle.isChanged());
-        assertNotNull(appCfgHandle.getConfig());
-        AppConfig a = appCfgHandle.getConfig();
-        assertEquals(a.message(), "msg1");
-        cServer1.stop();
-        newConf = subscriber.nextConfig(waitWhenExpectedFailure);
-        assertFalse(newConf);
-        assertFalse(appCfgHandle.isChanged());
+        try (ConfigTester tester = new ConfigTester()) {
+            TestConfigServer configServer = tester.startOneConfigServer();
+            ConfigHandle<AppConfig> appCfgHandle = subscriber.subscribe(AppConfig.class, "app.2",
+                                                                        tester.getTestSourceSet(), getTestTimingValues());
+            boolean newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
+            assertTrue(newConf);
+            assertTrue(appCfgHandle.isChanged());
+            assertNotNull(appCfgHandle.getConfig());
+            AppConfig a = appCfgHandle.getConfig();
+            assertEquals(a.message(), "msg1");
+            configServer.stop();
+            newConf = subscriber.nextConfig(waitWhenExpectedFailure);
+            assertFalse(newConf);
+            assertFalse(appCfgHandle.isChanged());
+        }
     }
 
     @Test
     public void testNextConfigFalseWhenConfigured() {
-        ConfigHandle<AppConfig> appCfgHandle = subscriber.subscribe(AppConfig.class, "app.3", getTestSourceSet(), getTestTimingValues());
-        boolean newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
-        assertTrue(newConf);
-        assertTrue(appCfgHandle.isChanged());
-        assertNotNull(appCfgHandle.getConfig());
-        AppConfig a = appCfgHandle.getConfig();
-        assertEquals(a.message(), "msg1");
-        newConf = subscriber.nextConfig(waitWhenExpectedFailure);
-        assertFalse(newConf);
-        assertFalse(appCfgHandle.isChanged());
+        try (ConfigTester tester = new ConfigTester()) {
+            tester.startOneConfigServer();
+            ConfigHandle<AppConfig> appCfgHandle = subscriber.subscribe(AppConfig.class, "app.3",
+                                                                        tester.getTestSourceSet(), getTestTimingValues());
+            boolean newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
+            assertTrue(newConf);
+            assertTrue(appCfgHandle.isChanged());
+            assertNotNull(appCfgHandle.getConfig());
+            AppConfig a = appCfgHandle.getConfig();
+            assertEquals(a.message(), "msg1");
+            newConf = subscriber.nextConfig(waitWhenExpectedFailure);
+            assertFalse(newConf);
+            assertFalse(appCfgHandle.isChanged());
+        }
     }
 
     @Test
     public void testNextGenerationFalseWhenConfigured() {
-        ConfigHandle<AppConfig> appCfgHandle = subscriber.subscribe(AppConfig.class, "app.4", getTestSourceSet(), getTestTimingValues());
-        boolean newConf = subscriber.nextGeneration(waitWhenExpectedSuccess);
-        assertTrue(newConf);
-        assertTrue(appCfgHandle.isChanged());
-        assertNotNull(appCfgHandle.getConfig());
-        AppConfig a = appCfgHandle.getConfig();
-        assertEquals(a.message(), "msg1");
-        newConf = subscriber.nextGeneration(waitWhenExpectedFailure);
-        assertFalse(newConf);
-        assertFalse(appCfgHandle.isChanged());
+        try (ConfigTester tester = new ConfigTester()) {
+            tester.startOneConfigServer();
+            ConfigHandle<AppConfig> appCfgHandle = subscriber.subscribe(AppConfig.class, "app.4",
+                                                                        tester.getTestSourceSet(), getTestTimingValues());
+            boolean newConf = subscriber.nextGeneration(waitWhenExpectedSuccess);
+            assertTrue(newConf);
+            assertTrue(appCfgHandle.isChanged());
+            assertNotNull(appCfgHandle.getConfig());
+            AppConfig a = appCfgHandle.getConfig();
+            assertEquals(a.message(), "msg1");
+            newConf = subscriber.nextGeneration(waitWhenExpectedFailure);
+            assertFalse(newConf);
+            assertFalse(appCfgHandle.isChanged());
+        }
     }
 
     @Test
     public void testMultipleSubsSameThing() {
-        getConfigServer().deployNewConfig("configs/foo0");
-        ConfigHandle<BarConfig> bh1 = subscriber.subscribe(BarConfig.class, "b1", getTestSourceSet(), getTestTimingValues());
-        ConfigHandle<BarConfig> bh2 = subscriber.subscribe(BarConfig.class, "b2", getTestSourceSet(), getTestTimingValues());
-        ConfigHandle<FooConfig> fh1 = subscriber.subscribe(FooConfig.class, "f1", getTestSourceSet(), getTestTimingValues());
-        ConfigHandle<FooConfig> fh2 = subscriber.subscribe(FooConfig.class, "f2", getTestSourceSet(), getTestTimingValues());
-        ConfigHandle<FooConfig> fh3 = subscriber.subscribe(FooConfig.class, "f3", getTestSourceSet(), getTestTimingValues());
-        assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
-        assertTrue(bh1.isChanged());
-        assertTrue(bh2.isChanged());
-        assertTrue(fh1.isChanged());
-        assertTrue(fh2.isChanged());
-        assertTrue(fh3.isChanged());
-        assertEquals(bh1.getConfig().barValue(), "0bar");
-        assertEquals(bh2.getConfig().barValue(), "0bar");
-        assertEquals(fh1.getConfig().fooValue(), "0foo");
-        assertEquals(fh2.getConfig().fooValue(), "0foo");
-        assertEquals(fh3.getConfig().fooValue(), "0foo");
-        assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
-        assertFalse(bh1.isChanged());
-        assertFalse(bh2.isChanged());
-        assertFalse(fh1.isChanged());
-        assertFalse(fh2.isChanged());
-        assertFalse(fh3.isChanged());
-        log.info("Reconfiguring to foo1/");
-        getConfigServer().deployNewConfig("configs/foo1");
-        assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
-        assertFalse(bh1.isChanged());
-        assertFalse(bh2.isChanged());
-        assertTrue(fh1.isChanged());
-        assertTrue(fh2.isChanged());
-        assertTrue(fh3.isChanged());
-        assertEquals(bh1.getConfig().barValue(), "0bar");
-        assertEquals(bh2.getConfig().barValue(), "0bar");
-        assertEquals(fh1.getConfig().fooValue(), "1foo");
-        assertEquals(fh2.getConfig().fooValue(), "1foo");
-        assertEquals(fh3.getConfig().fooValue(), "1foo");
+        try (ConfigTester tester = new ConfigTester()) {
+            TestConfigServer configServer = tester.startOneConfigServer();
+            configServer.deployNewConfig("configs/foo0");
+            ConfigHandle<BarConfig> bh1 = subscriber.subscribe(BarConfig.class, "b1",
+                                                               tester.getTestSourceSet(), getTestTimingValues());
+            ConfigHandle<BarConfig> bh2 = subscriber.subscribe(BarConfig.class, "b2",
+                                                               tester.getTestSourceSet(), getTestTimingValues());
+            ConfigHandle<FooConfig> fh1 = subscriber.subscribe(FooConfig.class, "f1",
+                                                               tester.getTestSourceSet(), getTestTimingValues());
+            ConfigHandle<FooConfig> fh2 = subscriber.subscribe(FooConfig.class, "f2",
+                                                               tester.getTestSourceSet(), getTestTimingValues());
+            ConfigHandle<FooConfig> fh3 = subscriber.subscribe(FooConfig.class, "f3",
+                                                               tester.getTestSourceSet(), getTestTimingValues());
+            assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
+            assertTrue(bh1.isChanged());
+            assertTrue(bh2.isChanged());
+            assertTrue(fh1.isChanged());
+            assertTrue(fh2.isChanged());
+            assertTrue(fh3.isChanged());
+            assertEquals(bh1.getConfig().barValue(), "0bar");
+            assertEquals(bh2.getConfig().barValue(), "0bar");
+            assertEquals(fh1.getConfig().fooValue(), "0foo");
+            assertEquals(fh2.getConfig().fooValue(), "0foo");
+            assertEquals(fh3.getConfig().fooValue(), "0foo");
+            assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
+            assertFalse(bh1.isChanged());
+            assertFalse(bh2.isChanged());
+            assertFalse(fh1.isChanged());
+            assertFalse(fh2.isChanged());
+            assertFalse(fh3.isChanged());
+            log.info("Reconfiguring to foo1/");
+            configServer.deployNewConfig("configs/foo1");
+            assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
+            assertFalse(bh1.isChanged());
+            assertFalse(bh2.isChanged());
+            assertTrue(fh1.isChanged());
+            assertTrue(fh2.isChanged());
+            assertTrue(fh3.isChanged());
+            assertEquals(bh1.getConfig().barValue(), "0bar");
+            assertEquals(bh2.getConfig().barValue(), "0bar");
+            assertEquals(fh1.getConfig().fooValue(), "1foo");
+            assertEquals(fh2.getConfig().fooValue(), "1foo");
+            assertEquals(fh3.getConfig().fooValue(), "1foo");
+        }
     }
 
     @Test
     public void testBasicReconfig() {
-        getConfigServer().deployNewConfig("configs/foo0");
-        ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b4", getTestSourceSet(), getTestTimingValues());
-        ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "f4", getTestSourceSet(), getTestTimingValues());
+        try (ConfigTester tester = new ConfigTester()) {
+            TestConfigServer configServer = tester.startOneConfigServer();
+            configServer.deployNewConfig("configs/foo0");
+            ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b4",
+                                                              tester.getTestSourceSet(), getTestTimingValues());
+            ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "f4", tester.getTestSourceSet(), getTestTimingValues());
 
-        boolean newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
-        assertTrue(newConf);
-        assertTrue(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertEquals(bh.getConfig().barValue(), "0bar");
-        assertEquals(fh.getConfig().fooValue(), "0foo");
+            boolean newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
+            assertTrue(newConf);
+            assertTrue(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertEquals(bh.getConfig().barValue(), "0bar");
+            assertEquals(fh.getConfig().fooValue(), "0foo");
 
-        newConf = subscriber.nextConfig(2000);
-        assertFalse(newConf);
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
+            newConf = subscriber.nextConfig(2000);
+            assertFalse(newConf);
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
 
-        log.info("Reconfiguring to foo1/");
-        getConfigServer().deployNewConfig("configs/foo1");
-        newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
-        assertTrue(newConf);
-        assertFalse(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertEquals(bh.getConfig().barValue(), "0bar");
-        assertEquals(fh.getConfig().fooValue(), "1foo");
+            log.info("Reconfiguring to foo1/");
+            configServer.deployNewConfig("configs/foo1");
+            newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
+            assertTrue(newConf);
+            assertFalse(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertEquals(bh.getConfig().barValue(), "0bar");
+            assertEquals(fh.getConfig().fooValue(), "1foo");
 
-        log.info("Reconfiguring to foo2/");
-        getConfigServer().deployNewConfig("configs/foo2");
-        newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
-        assertTrue(newConf);
-        assertTrue(bh.isChanged());
-        assertFalse(fh.isChanged());
-        assertEquals(bh.getConfig().barValue(), "1bar");
-        assertEquals(fh.getConfig().fooValue(), "1foo");
+            log.info("Reconfiguring to foo2/");
+            configServer.deployNewConfig("configs/foo2");
+            newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
+            assertTrue(newConf);
+            assertTrue(bh.isChanged());
+            assertFalse(fh.isChanged());
+            assertEquals(bh.getConfig().barValue(), "1bar");
+            assertEquals(fh.getConfig().fooValue(), "1foo");
 
-        log.info("Redeploying foo2/");
-        getConfigServer().deployNewConfig("configs/foo2");
-        newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
-        assertFalse(newConf);
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
+            log.info("Redeploying foo2/");
+            configServer.deployNewConfig("configs/foo2");
+            newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
+            assertFalse(newConf);
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
+        }
     }
 
     @Test
     public void testBasicGenerationChange() {
-        getConfigServer().deployNewConfig("configs/foo0");
-        ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b5", getTestSourceSet(), getTestTimingValues());
-        ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "f5", getTestSourceSet(), getTestTimingValues());
+        try (ConfigTester tester = new ConfigTester()) {
+            TestConfigServer configServer = tester.startOneConfigServer();
+            configServer.deployNewConfig("configs/foo0");
+            ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b5", tester.getTestSourceSet(), getTestTimingValues());
+            ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "f5", tester.getTestSourceSet(), getTestTimingValues());
 
-        boolean newConf = subscriber.nextGeneration(waitWhenExpectedSuccess);
-        long lastGen = subscriber.getGeneration();
-        assertTrue(newConf);
-        assertTrue(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertEquals(bh.getConfig().barValue(), "0bar");
-        assertEquals(fh.getConfig().fooValue(), "0foo");
+            boolean newConf = subscriber.nextGeneration(waitWhenExpectedSuccess);
+            long lastGen = subscriber.getGeneration();
+            assertTrue(newConf);
+            assertTrue(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertEquals(bh.getConfig().barValue(), "0bar");
+            assertEquals(fh.getConfig().fooValue(), "0foo");
 
-        newConf = subscriber.nextGeneration(2000);
-        assertFalse(newConf);
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
+            newConf = subscriber.nextGeneration(2000);
+            assertFalse(newConf);
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
 
-        log.info("Reconfiguring to foo1/");
-        getConfigServer().deployNewConfig("configs/foo1");
-        newConf = subscriber.nextGeneration(waitWhenExpectedSuccess);
-        assertTrue(newConf);
-        assertTrue(subscriber.getGeneration() > lastGen);
-        lastGen = subscriber.getGeneration();
-        assertFalse(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertEquals(bh.getConfig().barValue(), "0bar");
-        assertEquals(fh.getConfig().fooValue(), "1foo");
+            log.info("Reconfiguring to foo1/");
+            configServer.deployNewConfig("configs/foo1");
+            newConf = subscriber.nextGeneration(waitWhenExpectedSuccess);
+            assertTrue(newConf);
+            assertTrue(subscriber.getGeneration() > lastGen);
+            lastGen = subscriber.getGeneration();
+            assertFalse(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertEquals(bh.getConfig().barValue(), "0bar");
+            assertEquals(fh.getConfig().fooValue(), "1foo");
 
-        log.info("Reconfiguring to foo2/");
-        getConfigServer().deployNewConfig("configs/foo2");
-        newConf = subscriber.nextGeneration(waitWhenExpectedSuccess);
-        assertTrue(newConf);
-        assertTrue(subscriber.getGeneration() > lastGen);
-        lastGen = subscriber.getGeneration();
-        assertTrue(bh.isChanged());
-        assertFalse(fh.isChanged());
-        assertEquals(bh.getConfig().barValue(), "1bar");
-        assertEquals(fh.getConfig().fooValue(), "1foo");
+            log.info("Reconfiguring to foo2/");
+            configServer.deployNewConfig("configs/foo2");
+            newConf = subscriber.nextGeneration(waitWhenExpectedSuccess);
+            assertTrue(newConf);
+            assertTrue(subscriber.getGeneration() > lastGen);
+            lastGen = subscriber.getGeneration();
+            assertTrue(bh.isChanged());
+            assertFalse(fh.isChanged());
+            assertEquals(bh.getConfig().barValue(), "1bar");
+            assertEquals(fh.getConfig().fooValue(), "1foo");
 
-        log.info("Redeploying foo2/");
-        getConfigServer().deployNewConfig("configs/foo2");
-        newConf = subscriber.nextGeneration(waitWhenExpectedSuccess);
-        assertTrue(newConf);
-        assertTrue(subscriber.getGeneration() > lastGen);
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
+            log.info("Redeploying foo2/");
+            configServer.deployNewConfig("configs/foo2");
+            newConf = subscriber.nextGeneration(waitWhenExpectedSuccess);
+            assertTrue(newConf);
+            assertTrue(subscriber.getGeneration() > lastGen);
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
+        }
     }
 
     @Test
     public void testQuickReconfigs() throws InterruptedException {
-        getConfigServer().deployNewConfig("configs/foo0");
-        ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b6", getTestSourceSet(), getTestTimingValues());
-        ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "f6", getTestSourceSet(), getTestTimingValues());
+        try (ConfigTester tester = new ConfigTester()) {
+            TestConfigServer configServer = tester.startOneConfigServer();
+            configServer.deployNewConfig("configs/foo0");
+            ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b6", tester.getTestSourceSet(), getTestTimingValues());
+            ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "f6", tester.getTestSourceSet(), getTestTimingValues());
 
-        boolean newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
-        assertTrue(newConf);
-        assertTrue(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertEquals(bh.getConfig().barValue(), "0bar");
-        assertEquals(fh.getConfig().fooValue(), "0foo");
-        long generation = waitForServerSwitch(0);
+            boolean newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
+            assertTrue(newConf);
+            assertTrue(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertEquals(bh.getConfig().barValue(), "0bar");
+            assertEquals(fh.getConfig().fooValue(), "0foo");
+            long generation = waitForServerSwitch(configServer, 0);
 
-        // reconfiguring twice before calling nextConfig again
-        getConfigServer().deployNewConfig("configs/foo1");
-        generation = waitForServerSwitch(generation);
-        getConfigServer().deployNewConfig("configs/foo4");
-        waitForServerSwitch(generation);
-        newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
-        assertTrue(newConf);
-        assertTrue(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertEquals(bh.getConfig().barValue(), "4bar");
-        assertEquals(fh.getConfig().fooValue(), "4foo");
+            // reconfiguring twice before calling nextConfig again
+            configServer.deployNewConfig("configs/foo1");
+            generation = waitForServerSwitch(configServer, generation);
+            configServer.deployNewConfig("configs/foo4");
+            waitForServerSwitch(configServer, generation);
+            newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
+            assertTrue(newConf);
+            assertTrue(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertEquals(bh.getConfig().barValue(), "4bar");
+            assertEquals(fh.getConfig().fooValue(), "4foo");
+        }
     }
 
-    private long waitForServerSwitch(long currentGeneration) throws InterruptedException {
+    private long waitForServerSwitch(TestConfigServer configServer, long currentGeneration) throws InterruptedException {
         long endTime = System.currentTimeMillis() + 60_000;
-        while (System.currentTimeMillis() < endTime && getConfigServer().getApplicationGeneration() <= currentGeneration) {
+        while (System.currentTimeMillis() < endTime && configServer.getApplicationGeneration() <= currentGeneration) {
             Thread.sleep(100);
         }
-        long nextGeneration = getConfigServer().getApplicationGeneration();
+        long nextGeneration = configServer.getApplicationGeneration();
         assertTrue(nextGeneration > currentGeneration);
         return nextGeneration;
     }
 
     @Test
     public void testExtendSuccessTimeout() {
-        ConfigHandle<AppConfig> appCfgHandle = subscriber.subscribe(AppConfig.class, "app.5", getTestSourceSet(), getTestTimingValues());
-        assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
-        assertTrue(appCfgHandle.isChanged());
-        assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
+        try (ConfigTester tester = new ConfigTester()) {
+            tester.startOneConfigServer();
+            ConfigHandle<AppConfig> appCfgHandle = subscriber.subscribe(AppConfig.class, "app.5",
+                                                                        tester.getTestSourceSet(), getTestTimingValues());
+            assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
+            assertTrue(appCfgHandle.isChanged());
+            assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
+        }
     }
 
     /*
@@ -305,39 +351,46 @@ public class BasicSubscriptionTest extends ConfigTest {
     @Test
     @Ignore
     public void testEmptyPayloadWhenUnHandledReqPreviously() throws InterruptedException {
-        log.log(LogLevel.INFO, "Starting testEmptyPayloadWhenUnHandledReqPreviously");
-        getConfigServer().deployNewConfig("configs/foo0");
-        ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b7", getTestSourceSet(), getTestTimingValues());
-        ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "f7", getTestSourceSet(), getTestTimingValues());
-        getConfigServer().deployNewConfig("configs/foo0");
-        Thread.sleep(1000);
-        log.log(LogLevel.INFO, "Calling nextConfig 1st time");
-        assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
-        assertTrue(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertEquals(bh.getConfig().barValue(), "0bar");
-        assertEquals(fh.getConfig().fooValue(), "0foo");
-        getConfigServer().deployNewConfig("configs/foo1");
-        Thread.sleep(1000);
-        getConfigServer().deployNewConfig("configs/foo1");
-        log.log(LogLevel.INFO, "Calling nextConfig 2nd time");
-        assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
-        assertFalse(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertEquals(bh.getConfig().barValue(), "0bar");
-        assertEquals(fh.getConfig().fooValue(), "1foo");
+        try (ConfigTester tester = new ConfigTester()) {
+            TestConfigServer configServer = tester.startOneConfigServer();
+            configServer.deployNewConfig("configs/foo0");
+            ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b7",
+                                                              tester.getTestSourceSet(), getTestTimingValues());
+            ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "f7",
+                                                              tester.getTestSourceSet(), getTestTimingValues());
+            configServer.deployNewConfig("configs/foo0");
+            Thread.sleep(1000);
+            log.log(LogLevel.INFO, "Calling nextConfig 1st time");
+            assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
+            assertTrue(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertEquals(bh.getConfig().barValue(), "0bar");
+            assertEquals(fh.getConfig().fooValue(), "0foo");
+            configServer.deployNewConfig("configs/foo1");
+            Thread.sleep(1000);
+            configServer.deployNewConfig("configs/foo1");
+            log.log(LogLevel.INFO, "Calling nextConfig 2nd time");
+            assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
+            assertFalse(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertEquals(bh.getConfig().barValue(), "0bar");
+            assertEquals(fh.getConfig().fooValue(), "1foo");
+        }
     }
 
     @Test
     public void testSubscribeTimeout() {
-        getConfigServer().setGetConfDelayTimeMillis(1000);
-        getConfigServer().deployNewConfig("configs/foo0");
-        try {
-            subscriber.subscribe(BarConfig.class, "b8", getTestSourceSet(), getTestTimingValues().setSubscribeTimeout(200));
-            fail("Subscribe should have timed out and thrown");
-        } catch (Exception e) {
-            assertTrue(e instanceof ConfigurationRuntimeException);
-            assertTrue(e.getMessage().matches(".*timed out.*"));
+        try (ConfigTester tester = new ConfigTester()) {
+            TestConfigServer configServer = tester.startOneConfigServer();
+            configServer.setGetConfDelayTimeMillis(1000);
+            configServer.deployNewConfig("configs/foo0");
+            try {
+                subscriber.subscribe(BarConfig.class, "b8", tester.getTestSourceSet(), getTestTimingValues().setSubscribeTimeout(200));
+                fail("Subscribe should have timed out and thrown");
+            } catch (Exception e) {
+                assertTrue(e instanceof ConfigurationRuntimeException);
+                assertTrue(e.getMessage().matches(".*timed out.*"));
+            }
         }
     }
 

--- a/tests/cloudconfig/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/FailoverTest.java
+++ b/tests/cloudconfig/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/FailoverTest.java
@@ -5,20 +5,22 @@ import com.yahoo.config.FooConfig;
 import com.yahoo.config.subscription.impl.JRTConfigSubscription;
 import com.yahoo.foo.BarConfig;
 import com.yahoo.log.LogLevel;
-import com.yahoo.vespa.config.ConfigTest;
+import com.yahoo.vespa.config.ConfigTester;
 import com.yahoo.vespa.config.Connection;
 import com.yahoo.vespa.config.ConnectionPool;
 import com.yahoo.vespa.config.testutil.TestConfigServer;
 import org.junit.After;
 import org.junit.Test;
 
+import static com.yahoo.vespa.config.ConfigTester.waitWhenExpectedFailure;
+import static com.yahoo.vespa.config.ConfigTester.waitWhenExpectedSuccess;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class FailoverTest extends ConfigTest {
+public class FailoverTest {
     private java.util.logging.Logger log = java.util.logging.Logger.getLogger(BasicSubscriptionTest.class.getName());
 
     private ConfigSubscriber subscriber;
@@ -33,176 +35,185 @@ public class FailoverTest extends ConfigTest {
      * Basic functionality of the API when we programmatically execute failover of sources inside the subscriptions
      */
     public void testBasicFailoverInduced() {
-        ConfigSourceSet sources = setUp3ConfigServers("configs/foo0");
+        try (ConfigTester tester = new ConfigTester()) {
+            ConfigSourceSet sources = tester.setUp3ConfigServers("configs/foo0");
 
-        subscriber = new ConfigSubscriber(sources);
-        ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b", sources, getTestTimingValues());
-        ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "f", sources, getTestTimingValues());
+            subscriber = new ConfigSubscriber(sources);
+            ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b", sources, ConfigTester.getTestTimingValues());
+            ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "f", sources, ConfigTester.getTestTimingValues());
 
-        boolean newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
-        assertTrue(newConf);
-        assertTrue(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertEquals(bh.getConfig().barValue(), "0bar");
-        assertEquals(fh.getConfig().fooValue(), "0foo");
-        ConnectionPool connectionPool = ((JRTConfigSubscription<FooConfig>) fh.subscription()).requester().getConnectionPool();
-        Connection currentConnection = connectionPool.getCurrent();
-        log.log(LogLevel.INFO, "current source=" + currentConnection.getAddress());
-        stopConfigServerMatchingSource(currentConnection);
+            boolean newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
+            assertTrue(newConf);
+            assertTrue(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertEquals(bh.getConfig().barValue(), "0bar");
+            assertEquals(fh.getConfig().fooValue(), "0foo");
+            ConnectionPool connectionPool = ((JRTConfigSubscription<FooConfig>) fh.subscription()).requester().getConnectionPool();
+            Connection currentConnection = connectionPool.getCurrent();
+            log.log(LogLevel.INFO, "current source=" + currentConnection.getAddress());
+            tester.stopConfigServerMatchingSource(currentConnection);
 
-        newConf = subscriber.nextConfig(waitWhenExpectedFailure);
-        assertFalse(newConf);
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
+            newConf = subscriber.nextConfig(waitWhenExpectedFailure);
+            assertFalse(newConf);
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
 
-        log.info("Reconfiguring to foo1/");
-        deployOn3ConfigServers("configs/foo1");
-        // Find next that is not current
-        Connection newConnection;
-        do {
-            newConnection = connectionPool.setNewCurrentConnection();
-        } while (currentConnection.getAddress().equals(newConnection.getAddress()));
-        log.log(LogLevel.INFO, "newConnection=" + newConnection.getAddress());
-        stopConfigServerMatchingSource(newConnection);
-        newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
-        assertTrue(newConf);
-        assertFalse(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertEquals("0bar", bh.getConfig().barValue());
-        assertEquals("1foo", fh.getConfig().fooValue());
+            log.info("Reconfiguring to foo1/");
+            tester.deployOn3ConfigServers("configs/foo1");
+            // Find next that is not current
+            Connection newConnection;
+            do {
+                newConnection = connectionPool.setNewCurrentConnection();
+            } while (currentConnection.getAddress().equals(newConnection.getAddress()));
+            log.log(LogLevel.INFO, "newConnection=" + newConnection.getAddress());
+            tester.stopConfigServerMatchingSource(newConnection);
+            newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
+            assertTrue(newConf);
+            assertFalse(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertEquals("0bar", bh.getConfig().barValue());
+            assertEquals("1foo", fh.getConfig().fooValue());
 
-        log.info("Reconfiguring to foo2/");
-        deployOn3ConfigServers("configs/foo2");
-        newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
-        assertTrue(newConf);
-        assertTrue(bh.isChanged());
-        assertFalse(fh.isChanged());
-        assertEquals("1bar", bh.getConfig().barValue());
-        assertEquals("1foo", fh.getConfig().fooValue());
+            log.info("Reconfiguring to foo2/");
+            tester.deployOn3ConfigServers("configs/foo2");
+            newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
+            assertTrue(newConf);
+            assertTrue(bh.isChanged());
+            assertFalse(fh.isChanged());
+            assertEquals("1bar", bh.getConfig().barValue());
+            assertEquals("1foo", fh.getConfig().fooValue());
 
-        log.info("Redeploying foo2/");
-        deployOn3ConfigServers("configs/foo2");
-        newConf = subscriber.nextConfig(waitWhenExpectedFailure);
-        assertFalse(newConf);
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
+            log.info("Redeploying foo2/");
+            tester.deployOn3ConfigServers("configs/foo2");
+            newConf = subscriber.nextConfig(waitWhenExpectedFailure);
+            assertFalse(newConf);
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
+        }
     }
 
     @Test
     public void testFailoverInvisibleToSubscriber() {
-        ConfigSourceSet sources = setUp3ConfigServers("configs/foo0");
+        try (ConfigTester tester = new ConfigTester()) {
+            ConfigSourceSet sources = tester.setUp3ConfigServers("configs/foo0");
 
-        subscriber = new ConfigSubscriber(sources);
-        ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b", sources, getTestTimingValues());
-        ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "f", sources, getTestTimingValues());
+            subscriber = new ConfigSubscriber(sources);
+            ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b", sources, ConfigTester.getTestTimingValues());
+            ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "f", sources, ConfigTester.getTestTimingValues());
 
-        boolean newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
-        ConnectionPool connectionPool = ((JRTConfigSubscription<FooConfig>) fh.subscription()).requester().getConnectionPool();
-        Connection current = connectionPool.getCurrent();
-        stopConfigServerMatchingSource(current);
-        assertTrue(newConf);
-        assertTrue(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertEquals(bh.getConfig().barValue(), "0bar");
-        assertEquals(fh.getConfig().fooValue(), "0foo");
+            boolean newConf = subscriber.nextConfig(waitWhenExpectedSuccess);
+            ConnectionPool connectionPool = ((JRTConfigSubscription<FooConfig>) fh.subscription()).requester().getConnectionPool();
+            Connection current = connectionPool.getCurrent();
+            tester.stopConfigServerMatchingSource(current);
+            assertTrue(newConf);
+            assertTrue(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertEquals(bh.getConfig().barValue(), "0bar");
+            assertEquals(fh.getConfig().fooValue(), "0foo");
 
-        newConf = subscriber.nextConfig(waitWhenExpectedFailure);
-        assertFalse(newConf);
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
+            newConf = subscriber.nextConfig(waitWhenExpectedFailure);
+            assertFalse(newConf);
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
 
-        TestConfigServer inUse = getInUse(subscriber, sources);
-        inUse.stop();
-        newConf = subscriber.nextConfig(waitWhenExpectedFailure);
-        assertFalse(newConf);
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
-        
-        newConf = subscriber.nextConfig(waitWhenExpectedFailure);
-        assertFalse(newConf);
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
-        assertEquals(bh.getConfig().barValue(), "0bar");
-        assertEquals(fh.getConfig().fooValue(), "0foo");
+            TestConfigServer inUse = tester.getInUse(subscriber, sources);
+            inUse.stop();
+            newConf = subscriber.nextConfig(waitWhenExpectedFailure);
+            assertFalse(newConf);
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
 
-        newConf = subscriber.nextConfig(waitWhenExpectedFailure);
-        assertFalse(newConf);
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
-        newConf = subscriber.nextConfig(waitWhenExpectedFailure);
-        assertFalse(newConf);
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
-        newConf = subscriber.nextConfig(waitWhenExpectedFailure);
-        assertFalse(newConf);
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
-        newConf = subscriber.nextConfig(waitWhenExpectedFailure);
-        assertFalse(newConf);
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
+            newConf = subscriber.nextConfig(waitWhenExpectedFailure);
+            assertFalse(newConf);
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
+            assertEquals(bh.getConfig().barValue(), "0bar");
+            assertEquals(fh.getConfig().fooValue(), "0foo");
+
+            newConf = subscriber.nextConfig(waitWhenExpectedFailure);
+            assertFalse(newConf);
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
+            newConf = subscriber.nextConfig(waitWhenExpectedFailure);
+            assertFalse(newConf);
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
+            newConf = subscriber.nextConfig(waitWhenExpectedFailure);
+            assertFalse(newConf);
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
+            newConf = subscriber.nextConfig(waitWhenExpectedFailure);
+            assertFalse(newConf);
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
+        }
     }
 
     @Test
     public void testFailoverOneSpec() {
-        ConfigSourceSet set = getTestSourceSet();
-        getConfigServer().deployNewConfig("configs/foo0");
+        try (ConfigTester tester = new ConfigTester()) {
+            tester.startOneConfigServer();
+            ConfigSourceSet set = tester.getTestSourceSet();
+            tester.getConfigServer().deployNewConfig("configs/foo0");
 
-        subscriber = new ConfigSubscriber(set);
-        ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b", set, getTestTimingValues());
+            subscriber = new ConfigSubscriber(set);
+            ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b", set, ConfigTester.getTestTimingValues());
 
-        ConnectionPool connectionPool = ((JRTConfigSubscription<BarConfig>) bh.subscription()).requester().getConnectionPool();
-        String s1 = connectionPool.getCurrent().getAddress();
-        assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
-        assertTrue(bh.isChanged());
+            ConnectionPool connectionPool = ((JRTConfigSubscription<BarConfig>) bh.subscription()).requester().getConnectionPool();
+            String s1 = connectionPool.getCurrent().getAddress();
+            assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
+            assertTrue(bh.isChanged());
 
-        connectionPool.setNewCurrentConnection();
-        String s2 = connectionPool.getCurrent().getAddress();
-        connectionPool.setNewCurrentConnection();
-        String s3 = connectionPool.getCurrent().getAddress();
-        connectionPool.setNewCurrentConnection();
-        String s4 = connectionPool.getCurrent().getAddress();
-        
-        assertEquals(s1, s2);
-        assertEquals(s2, s3);        
-        assertEquals(s3, s4);  
-        
-        getConfigServer().deployNewConfig("configs/foo2");
-        assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
-        assertTrue(bh.isChanged());
+            connectionPool.setNewCurrentConnection();
+            String s2 = connectionPool.getCurrent().getAddress();
+            connectionPool.setNewCurrentConnection();
+            String s3 = connectionPool.getCurrent().getAddress();
+            connectionPool.setNewCurrentConnection();
+            String s4 = connectionPool.getCurrent().getAddress();
+
+            assertEquals(s1, s2);
+            assertEquals(s2, s3);
+            assertEquals(s3, s4);
+
+            tester.getConfigServer().deployNewConfig("configs/foo2");
+            assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
+            assertTrue(bh.isChanged());
+        }
     }
     
     @Test
     public void testBasicFailover() throws InterruptedException {
-        ConfigSourceSet sources = setUp3ConfigServers("configs/foo0");
-        subscriber = new ConfigSubscriber(sources);
-        ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b", sources, getTestTimingValues());
-        ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "f", sources, getTestTimingValues());
-        ConnectionPool connectionPool = ((JRTConfigSubscription<BarConfig>) bh.subscription()).requester().getConnectionPool();
-        Connection current = connectionPool.getCurrent();
-        assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
-        assertEquals(subscriber.requesters().size(), 1);
-        // Kill current source, wait for failover
-        log.log(LogLevel.INFO, "current=" + current.getAddress());
-        stopConfigServerMatchingSource(current);
-        Thread.sleep(getTestTimingValues().getSubscribeTimeout()*2);
-        assertNotEquals(current.toString(), connectionPool.getCurrent().toString());
-        //assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
-        // Change config on servers (including whatever one we stopped earlier, not in use anyway), verify subscriber is working
-        log.info("Reconfiguring to foo1/, current generation " + subscriber.getGeneration());
-        deployOn3ConfigServers("configs/foo1");
+        try (ConfigTester tester = new ConfigTester()) {
+            ConfigSourceSet sources = tester.setUp3ConfigServers("configs/foo0");
+            subscriber = new ConfigSubscriber(sources);
+            ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "b", sources, ConfigTester.getTestTimingValues());
+            ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "f", sources, ConfigTester.getTestTimingValues());
+            ConnectionPool connectionPool = ((JRTConfigSubscription<BarConfig>) bh.subscription()).requester().getConnectionPool();
+            Connection current = connectionPool.getCurrent();
+            assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
+            assertEquals(subscriber.requesters().size(), 1);
+            // Kill current source, wait for failover
+            log.log(LogLevel.INFO, "current=" + current.getAddress());
+            tester.stopConfigServerMatchingSource(current);
+            Thread.sleep(ConfigTester.getTestTimingValues().getSubscribeTimeout() * 2);
+            assertNotEquals(current.toString(), connectionPool.getCurrent().toString());
+            //assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
+            // Change config on servers (including whatever one we stopped earlier, not in use anyway), verify subscriber is working
+            log.info("Reconfiguring to foo1/, current generation " + subscriber.getGeneration());
+            tester.deployOn3ConfigServers("configs/foo1");
 
-        // Want to see a reconfig here, sooner or later
-        for (int i = 0 ; i<10 ; i++) {
-            if (subscriber.nextConfig(waitWhenExpectedSuccess)) {
-                assertFalse(bh.isChanged());
-                assertTrue(fh.isChanged());
-                assertEquals(bh.getConfig().barValue(), "0bar");
-                assertEquals(fh.getConfig().fooValue(), "1foo");
-                break;
+            // Want to see a reconfig here, sooner or later
+            for (int i = 0; i < 10; i++) {
+                if (subscriber.nextConfig(waitWhenExpectedSuccess)) {
+                    assertFalse(bh.isChanged());
+                    assertTrue(fh.isChanged());
+                    assertEquals(bh.getConfig().barValue(), "0bar");
+                    assertEquals(fh.getConfig().fooValue(), "1foo");
+                    break;
+                }
+                log.info("i=" + i + ", generation=" + subscriber.getGeneration());
+                if (i == 9) fail("No reconfig");
             }
-            log.info("i=" + i + ", generation=" + subscriber.getGeneration());
-            if (i==9) fail("No reconfig");
         }
     }
 

--- a/tests/cloudconfig/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/GenericSubscriptionTest.java
+++ b/tests/cloudconfig/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/GenericSubscriptionTest.java
@@ -7,11 +7,12 @@ import com.yahoo.config.subscription.impl.GenericConfigHandle;
 import com.yahoo.config.subscription.impl.GenericConfigSubscriber;
 import com.yahoo.config.subscription.impl.JRTConfigRequester;
 import com.yahoo.foo.BarConfig;
+import com.yahoo.log.LogSetup;
 import com.yahoo.vespa.config.ConfigKey;
-import com.yahoo.vespa.config.ConfigTest;
+import com.yahoo.vespa.config.ConfigTester;
 import com.yahoo.vespa.config.JRTConnectionPool;
 import com.yahoo.vespa.config.RawConfig;
-import com.yahoo.vespa.config.TimingValues;
+import com.yahoo.vespa.config.testutil.TestConfigServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,12 +22,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import static com.yahoo.vespa.config.ConfigTester.waitWhenExpectedFailure;
+import static com.yahoo.vespa.config.ConfigTester.waitWhenExpectedSuccess;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class GenericSubscriptionTest extends ConfigTest {
+public class GenericSubscriptionTest {
 
     private GenericConfigSubscriber subscriber;
     
@@ -34,7 +37,7 @@ public class GenericSubscriptionTest extends ConfigTest {
     public void createSubscriber() {
         ConfigSourceSet sourceSet = JRTConfigRequester.defaultSourceSet;
         Map<ConfigSourceSet, JRTConfigRequester> requesterMap = new HashMap<>();
-        requesterMap.put(sourceSet, new JRTConfigRequester(new JRTConnectionPool(sourceSet), new TimingValues()));
+        requesterMap.put(sourceSet, new JRTConfigRequester(new JRTConnectionPool(sourceSet), ConfigTester.getTestTimingValues()));
         subscriber = new GenericConfigSubscriber(requesterMap);
     }
     
@@ -45,151 +48,191 @@ public class GenericSubscriptionTest extends ConfigTest {
     
     @Test
     public void testGenericJRTSubscription() {
-        GenericConfigHandle handle = subscriber.subscribe(new ConfigKey<>("app", "app.0", "config"), Arrays.asList(AppConfig.CONFIG_DEF_SCHEMA), getTestSourceSet(), getTestTimingValues());
-        assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
-        assertTrue(handle.isChanged());
-        String payloadS = handle.getRawConfig().getPayload().toString();
-        assertConfigMatches(payloadS, ".*message.*msg1.*");
-        assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
-        assertFalse(handle.isChanged());
-        assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
-        assertFalse(handle.isChanged());
-        assertThat(subscriber.getGeneration(), is(getConfigServer().getApplicationGeneration()));
-        assertThat(handle.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
-        assertThat(handle.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
+        try (ConfigTester tester = new ConfigTester()) {
+            tester.startOneConfigServer();
+            GenericConfigHandle handle = subscriber.subscribe(new ConfigKey<>("app", "app.0", "config"),
+                                                              Arrays.asList(AppConfig.CONFIG_DEF_SCHEMA),
+                                                              tester.getTestSourceSet(),
+                                                              ConfigTester.getTestTimingValues());
+            assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
+            assertTrue(handle.isChanged());
+            String payloadS = handle.getRawConfig().getPayload().toString();
+            assertConfigMatches(payloadS, ".*message.*msg1.*");
+            assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
+            assertFalse(handle.isChanged());
+            assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
+            assertFalse(handle.isChanged());
+            assertThat(subscriber.getGeneration(), is(tester.getConfigServer().getApplicationGeneration()));
+            assertThat(handle.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
+            assertThat(handle.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
 
-        // Reconfiguring to bar/
-        getConfigServer().deployNewConfig("configs/bar");
-        assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
-        assertTrue(handle.isChanged());
-        payloadS = handle.getRawConfig().getPayload().toString();
-        assertConfigMatches(payloadS, ".*message.*msg2.*");
-        assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
-        assertFalse(handle.isChanged());
+            // Reconfiguring to bar/
+            tester.getConfigServer().deployNewConfig("configs/bar");
+            assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
+            assertTrue(handle.isChanged());
+            payloadS = handle.getRawConfig().getPayload().toString();
+            assertConfigMatches(payloadS, ".*message.*msg2.*");
+            assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
+            assertFalse(handle.isChanged());
+        }
     }
     
     @Test
     public void testNextGeneration() {
-        GenericConfigHandle handle = subscriber.subscribe(new ConfigKey<>("app", "app.0", "config"), Arrays.asList(AppConfig.CONFIG_DEF_SCHEMA), getTestSourceSet(), getTestTimingValues());
-        assertTrue(subscriber.nextGeneration(waitWhenExpectedSuccess));
-        assertTrue(handle.isChanged());
-        String payloadS = handle.getRawConfig().getPayload().toString();
-        assertConfigMatches(payloadS, ".*message.*msg1.*");
-        assertFalse(subscriber.nextGeneration(waitWhenExpectedFailure));
-        assertFalse(handle.isChanged());
-        assertFalse(subscriber.nextGeneration(waitWhenExpectedFailure));
-        assertFalse(handle.isChanged());
+        try (ConfigTester tester = new ConfigTester()) {
+            tester.startOneConfigServer();
+            GenericConfigHandle handle = subscriber.subscribe(new ConfigKey<>("app", "app.0", "config"),
+                                                              Arrays.asList(AppConfig.CONFIG_DEF_SCHEMA),
+                                                              tester.getTestSourceSet(),
+                                                              ConfigTester.getTestTimingValues());
+            assertTrue(subscriber.nextGeneration(waitWhenExpectedSuccess));
+            assertTrue(handle.isChanged());
+            String payloadS = handle.getRawConfig().getPayload().toString();
+            assertConfigMatches(payloadS, ".*message.*msg1.*");
+            assertFalse(subscriber.nextGeneration(waitWhenExpectedFailure));
+            assertFalse(handle.isChanged());
+            assertFalse(subscriber.nextGeneration(waitWhenExpectedFailure));
+            assertFalse(handle.isChanged());
 
-        // Reconfiguring to bar/
-        getConfigServer().deployNewConfig("configs/bar");
-        assertTrue(subscriber.nextGeneration(waitWhenExpectedSuccess));
-        assertTrue(handle.isChanged());
-        payloadS = handle.getRawConfig().getPayload().toString();
-        assertConfigMatches(payloadS, ".*message.*msg2.*");
-        assertThat(subscriber.getGeneration(), is(getConfigServer().getApplicationGeneration()));
-        assertThat(handle.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
-        assertThat(handle.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
+            // Reconfiguring to bar/
+            tester.getConfigServer().deployNewConfig("configs/bar");
+            assertTrue(subscriber.nextGeneration(waitWhenExpectedSuccess));
+            assertTrue(handle.isChanged());
+            payloadS = handle.getRawConfig().getPayload().toString();
+            assertConfigMatches(payloadS, ".*message.*msg2.*");
+            assertThat(subscriber.getGeneration(), is(tester.getConfigServer().getApplicationGeneration()));
+            assertThat(handle.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
+            assertThat(handle.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
+        }
     }
     
     @Test
     public void testServerFailingNextConfigFalse() {
-        GenericConfigHandle handle = subscriber.subscribe(new ConfigKey<>("app", "app.0", "config"), Arrays.asList(AppConfig.CONFIG_DEF_SCHEMA), getTestSourceSet(), getTestTimingValues());
-        assertTrue(subscriber.nextGeneration(waitWhenExpectedSuccess));
-        assertTrue(handle.isChanged());
-        String payloadS = handle.getRawConfig().getPayload().toString();
-        assertConfigMatches(payloadS, ".*message.*msg1.*");
-        cServer1.stop();
-        assertFalse(subscriber.nextGeneration(waitWhenExpectedFailure));
-        assertFalse(handle.isChanged());
+        try (ConfigTester tester = new ConfigTester()) {
+            tester.startOneConfigServer();
+            GenericConfigHandle handle = subscriber.subscribe(new ConfigKey<>("app", "app.0", "config"),
+                                                              Arrays.asList(AppConfig.CONFIG_DEF_SCHEMA),
+                                                              tester.getTestSourceSet(),
+                                                              ConfigTester.getTestTimingValues());
+            assertTrue(subscriber.nextGeneration(waitWhenExpectedSuccess));
+            assertTrue(handle.isChanged());
+            String payloadS = handle.getRawConfig().getPayload().toString();
+            assertConfigMatches(payloadS, ".*message.*msg1.*");
+            tester.getConfigServer().stop();
+            assertFalse(subscriber.nextGeneration(waitWhenExpectedFailure));
+            assertFalse(handle.isChanged());
+        }
     }
 
     @Test
     public void testMultipleSubsSameThing() {
-        getConfigServer().deployNewConfig("configs/foo0");
-        GenericConfigHandle bh1 = subscriber.subscribe(new ConfigKey<>("bar", "b1", "foo"), Arrays.asList(BarConfig.CONFIG_DEF_SCHEMA), getTestSourceSet(), getTestTimingValues());
-        GenericConfigHandle bh2 = subscriber.subscribe(new ConfigKey<>("bar", "b2", "foo"), Arrays.asList(BarConfig.CONFIG_DEF_SCHEMA),getTestSourceSet(), getTestTimingValues());
-        GenericConfigHandle fh1 = subscriber.subscribe(new ConfigKey<>("foo", "f1", "config"), Arrays.asList(FooConfig.CONFIG_DEF_SCHEMA),getTestSourceSet(), getTestTimingValues());
-        GenericConfigHandle fh2 = subscriber.subscribe(new ConfigKey<>("foo", "f2", "config"), Arrays.asList(FooConfig.CONFIG_DEF_SCHEMA),getTestSourceSet(), getTestTimingValues());
-        GenericConfigHandle fh3 = subscriber.subscribe(new ConfigKey<>("foo", "f3", "config"), Arrays.asList(FooConfig.CONFIG_DEF_SCHEMA),getTestSourceSet(), getTestTimingValues());
-        assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
-        assertTrue(bh1.isChanged());
-        assertTrue(bh2.isChanged());
-        assertTrue(fh1.isChanged());
-        assertTrue(fh2.isChanged());
-        assertTrue(fh3.isChanged());
-        assertConfigMatches(bh1.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
-        assertConfigMatches(bh2.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
-        assertConfigMatches(fh1.getRawConfig().getPayload().toString(), ".*fooValue.*0foo.*");
-        assertConfigMatches(fh2.getRawConfig().getPayload().toString(), ".*fooValue.*0foo.*");
-        assertConfigMatches(fh3.getRawConfig().getPayload().toString(), ".*fooValue.*0foo.*");
-        assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
-        assertFalse(bh1.isChanged());
-        assertFalse(bh2.isChanged());
-        assertFalse(fh1.isChanged());
-        assertFalse(fh2.isChanged());
-        assertFalse(fh3.isChanged());
-        
-        // Reconfiguring to foo1/
-        getConfigServer().deployNewConfig("configs/foo1");
-        assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
-        assertFalse(bh1.isChanged());
-        assertFalse(bh2.isChanged());
-        assertTrue(fh1.isChanged());
-        assertTrue(fh2.isChanged());
-        assertTrue(fh3.isChanged());
-        assertConfigMatches(bh1.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
-        assertConfigMatches(bh2.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
-        assertConfigMatches(fh1.getRawConfig().getPayload().toString(), ".*fooValue.*1foo.*");
-        assertConfigMatches(fh2.getRawConfig().getPayload().toString(), ".*fooValue.*1foo.*");
-        assertConfigMatches(fh3.getRawConfig().getPayload().toString(), ".*fooValue.*1foo.*");
+        try (ConfigTester tester = new ConfigTester()) {
+            tester.startOneConfigServer();
+            tester.getConfigServer().deployNewConfig("configs/foo0");
+            GenericConfigHandle bh1 = subscriber.subscribe(new ConfigKey<>("bar", "b1", "foo"),
+                                                           Arrays.asList(BarConfig.CONFIG_DEF_SCHEMA), tester.getTestSourceSet(),
+                                                           ConfigTester.getTestTimingValues());
+            GenericConfigHandle bh2 = subscriber.subscribe(new ConfigKey<>("bar", "b2", "foo"),
+                                                           Arrays.asList(BarConfig.CONFIG_DEF_SCHEMA),
+                                                           tester.getTestSourceSet(),
+                                                           ConfigTester.getTestTimingValues());
+            GenericConfigHandle fh1 = subscriber.subscribe(new ConfigKey<>("foo", "f1", "config"),
+                                                           Arrays.asList(FooConfig.CONFIG_DEF_SCHEMA),
+                                                           tester.getTestSourceSet(),
+                                                           ConfigTester.getTestTimingValues());
+            GenericConfigHandle fh2 = subscriber.subscribe(new ConfigKey<>("foo", "f2", "config"),
+                                                           Arrays.asList(FooConfig.CONFIG_DEF_SCHEMA),
+                                                           tester.getTestSourceSet(),
+                                                           ConfigTester.getTestTimingValues());
+            GenericConfigHandle fh3 = subscriber.subscribe(new ConfigKey<>("foo", "f3", "config"),
+                                                           Arrays.asList(FooConfig.CONFIG_DEF_SCHEMA),
+                                                           tester.getTestSourceSet(),
+                                                           ConfigTester.getTestTimingValues());
+            assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
+            assertTrue(bh1.isChanged());
+            assertTrue(bh2.isChanged());
+            assertTrue(fh1.isChanged());
+            assertTrue(fh2.isChanged());
+            assertTrue(fh3.isChanged());
+            assertConfigMatches(bh1.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
+            assertConfigMatches(bh2.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
+            assertConfigMatches(fh1.getRawConfig().getPayload().toString(), ".*fooValue.*0foo.*");
+            assertConfigMatches(fh2.getRawConfig().getPayload().toString(), ".*fooValue.*0foo.*");
+            assertConfigMatches(fh3.getRawConfig().getPayload().toString(), ".*fooValue.*0foo.*");
+            assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
+            assertFalse(bh1.isChanged());
+            assertFalse(bh2.isChanged());
+            assertFalse(fh1.isChanged());
+            assertFalse(fh2.isChanged());
+            assertFalse(fh3.isChanged());
 
-        // TODO fix
-        //assertFalse(fh1.getRawConfig().getPayload().toString().matches(".*fooValue.*foo.*"));
-        //assertFalse(fh2.getRawConfig().getPayload().toString().matches(".*fooValue.*foo.*"));
-        //assertFalse(fh3.getRawConfig().getPayload().toString().matches(".*fooValue.*foo.*"));
+            // Reconfiguring to foo1/
+            tester.getConfigServer().deployNewConfig("configs/foo1");
+            assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
+            assertFalse(bh1.isChanged());
+            assertFalse(bh2.isChanged());
+            assertTrue(fh1.isChanged());
+            assertTrue(fh2.isChanged());
+            assertTrue(fh3.isChanged());
+            assertConfigMatches(bh1.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
+            assertConfigMatches(bh2.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
+            assertConfigMatches(fh1.getRawConfig().getPayload().toString(), ".*fooValue.*1foo.*");
+            assertConfigMatches(fh2.getRawConfig().getPayload().toString(), ".*fooValue.*1foo.*");
+            assertConfigMatches(fh3.getRawConfig().getPayload().toString(), ".*fooValue.*1foo.*");
+
+            // TODO fix
+            //assertFalse(fh1.getRawConfig().getPayload().toString().matches(".*fooValue.*foo.*"));
+            //assertFalse(fh2.getRawConfig().getPayload().toString().matches(".*fooValue.*foo.*"));
+            //assertFalse(fh3.getRawConfig().getPayload().toString().matches(".*fooValue.*foo.*"));
+        }
     }
 
     @Test
     public void testBasicReconfig() {
-        getConfigServer().deployNewConfig("configs/foo0");
-        GenericConfigHandle bh = subscriber.subscribe(new ConfigKey<>("bar", "b4", "foo"), Arrays.asList(BarConfig.CONFIG_DEF_SCHEMA), getTestSourceSet(), getTestTimingValues());
-        GenericConfigHandle fh = subscriber.subscribe(new ConfigKey<>("foo", "f4", "config"), Arrays.asList(FooConfig.CONFIG_DEF_SCHEMA), getTestSourceSet(), getTestTimingValues());
-        assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
-        assertTrue(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertConfigMatches(bh.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
-        assertConfigMatches(fh.getRawConfig().getPayload().toString(), ".*fooValue.*0foo.*");
-        assertThat(subscriber.getGeneration(), is(getConfigServer().getApplicationGeneration()));
-        assertThat(bh.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
-        assertThat(fh.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
+        try (ConfigTester tester = new ConfigTester()) {
+            TestConfigServer configServer = tester.startOneConfigServer();
+            configServer.deployNewConfig("configs/foo0");
+            GenericConfigHandle bh = subscriber.subscribe(new ConfigKey<>("bar", "b4", "foo"), Arrays.asList(BarConfig.CONFIG_DEF_SCHEMA),
+                                                          tester.getTestSourceSet(), ConfigTester.getTestTimingValues());
+            GenericConfigHandle fh = subscriber.subscribe(new ConfigKey<>("foo", "f4", "config"), Arrays.asList(FooConfig.CONFIG_DEF_SCHEMA),
+                                                          tester.getTestSourceSet(), ConfigTester.getTestTimingValues());
+            assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
+            assertTrue(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertConfigMatches(bh.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
+            assertConfigMatches(fh.getRawConfig().getPayload().toString(), ".*fooValue.*0foo.*");
+            assertThat(subscriber.getGeneration(), is(configServer.getApplicationGeneration()));
+            assertThat(bh.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
+            assertThat(fh.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
 
-        assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
-        
-        getConfigServer().deployNewConfig("configs/foo1");
-        assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
-        assertFalse(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertConfigMatches(bh.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
-        assertConfigMatches(fh.getRawConfig().getPayload().toString(), ".*fooValue.*1foo.*");
-        
-        getConfigServer().deployNewConfig("configs/foo2");
-        assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
-        assertTrue(bh.isChanged());
-        assertFalse(fh.isChanged());
-        assertConfigMatches(bh.getRawConfig().getPayload().toString(), ".*barValue.*1bar.*");
-        assertConfigMatches(fh.getRawConfig().getPayload().toString(), ".*fooValue.*1foo.*");
-        assertThat(subscriber.getGeneration(), is(getConfigServer().getApplicationGeneration()));
-        assertThat(bh.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
-        assertThat(bh.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
+            assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
 
-        getConfigServer().deployNewConfig("configs/foo2");
-        assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
+            configServer.deployNewConfig("configs/foo1");
+            assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
+            assertFalse(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertConfigMatches(bh.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
+            assertConfigMatches(fh.getRawConfig().getPayload().toString(), ".*fooValue.*1foo.*");
+
+            configServer.deployNewConfig("configs/foo2");
+            assertTrue(subscriber.nextConfig(waitWhenExpectedSuccess));
+            assertTrue(bh.isChanged());
+            assertFalse(fh.isChanged());
+            assertConfigMatches(bh.getRawConfig().getPayload().toString(), ".*barValue.*1bar.*");
+            assertConfigMatches(fh.getRawConfig().getPayload().toString(), ".*fooValue.*1foo.*");
+            assertThat(subscriber.getGeneration(), is(configServer.getApplicationGeneration()));
+            assertThat(bh.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
+            assertThat(bh.getRawConfig().getGeneration(), is(subscriber.getGeneration()));
+
+            configServer.deployNewConfig("configs/foo2");
+            assertFalse(subscriber.nextConfig(waitWhenExpectedFailure));
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
+        }
     }
-    
+
     private void assertConfigMatches(String cfg, String regex) {
         int pFlags = Pattern.MULTILINE+Pattern.DOTALL;
         Pattern pattern = Pattern.compile(regex, pFlags);
@@ -198,35 +241,40 @@ public class GenericSubscriptionTest extends ConfigTest {
     
     @Test
     public void testBasicGenerationChange() {
-        getConfigServer().deployNewConfig("configs/foo0");
-        GenericConfigHandle bh = subscriber.subscribe(new ConfigKey<>("bar", "b4", "foo"), Arrays.asList(BarConfig.CONFIG_DEF_SCHEMA), getTestSourceSet(), getTestTimingValues());
-        GenericConfigHandle fh = subscriber.subscribe(new ConfigKey<>("foo", "f4", "config"), Arrays.asList(FooConfig.CONFIG_DEF_SCHEMA), getTestSourceSet(), getTestTimingValues());
-        assertTrue(subscriber.nextGeneration(waitWhenExpectedSuccess));
-        assertTrue(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertConfigMatches(bh.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
-        assertConfigMatches(fh.getRawConfig().getPayload().toString(), ".*fooValue.*0foo.*");
-        assertFalse(subscriber.nextGeneration(waitWhenExpectedFailure));
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
-        
-        getConfigServer().deployNewConfig("configs/foo1");
-        assertTrue(subscriber.nextGeneration(waitWhenExpectedSuccess));
-        assertFalse(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertConfigMatches(bh.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
-        assertConfigMatches(fh.getRawConfig().getPayload().toString(), ".*fooValue.*1foo.*");
-        
-        getConfigServer().deployNewConfig("configs/foo2");
-        assertTrue(subscriber.nextGeneration(waitWhenExpectedSuccess));
-        assertTrue(bh.isChanged());
-        assertFalse(fh.isChanged());
-        assertConfigMatches(bh.getRawConfig().getPayload().toString(), ".*barValue.*1bar.*");
-        assertConfigMatches(fh.getRawConfig().getPayload().toString(), ".*fooValue.*1foo.*");
-        getConfigServer().deployNewConfig("configs/foo2");
-        assertTrue(subscriber.nextGeneration(waitWhenExpectedSuccess));
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());        
+        try (ConfigTester tester = new ConfigTester()) {
+            TestConfigServer configServer = tester.startOneConfigServer();
+            configServer.deployNewConfig("configs/foo0");
+            GenericConfigHandle bh = subscriber.subscribe(new ConfigKey<>("bar", "b4", "foo"), Arrays.asList(BarConfig.CONFIG_DEF_SCHEMA),
+                                                          tester.getTestSourceSet(), ConfigTester.getTestTimingValues());
+            GenericConfigHandle fh = subscriber.subscribe(new ConfigKey<>("foo", "f4", "config"), Arrays.asList(FooConfig.CONFIG_DEF_SCHEMA),
+                                                          tester.getTestSourceSet(), ConfigTester.getTestTimingValues());
+            assertTrue(subscriber.nextGeneration(waitWhenExpectedSuccess));
+            assertTrue(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertConfigMatches(bh.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
+            assertConfigMatches(fh.getRawConfig().getPayload().toString(), ".*fooValue.*0foo.*");
+            assertFalse(subscriber.nextGeneration(waitWhenExpectedFailure));
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
+
+            configServer.deployNewConfig("configs/foo1");
+            assertTrue(subscriber.nextGeneration(waitWhenExpectedSuccess));
+            assertFalse(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertConfigMatches(bh.getRawConfig().getPayload().toString(), ".*barValue.*0bar.*");
+            assertConfigMatches(fh.getRawConfig().getPayload().toString(), ".*fooValue.*1foo.*");
+
+            configServer.deployNewConfig("configs/foo2");
+            assertTrue(subscriber.nextGeneration(waitWhenExpectedSuccess));
+            assertTrue(bh.isChanged());
+            assertFalse(fh.isChanged());
+            assertConfigMatches(bh.getRawConfig().getPayload().toString(), ".*barValue.*1bar.*");
+            assertConfigMatches(fh.getRawConfig().getPayload().toString(), ".*fooValue.*1foo.*");
+            configServer.deployNewConfig("configs/foo2");
+            assertTrue(subscriber.nextGeneration(waitWhenExpectedSuccess));
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
+        }
     }
 
     /**
@@ -234,55 +282,46 @@ public class GenericSubscriptionTest extends ConfigTest {
      */
     @Test
     public void testFailoverGenericSubscriberNextGenerationLoop() {
-        // TODO: Make ConfigTest a tester and don't subclass it to avoid this mess
-        startConfigServer();
-        ConfigSourceSet sources = setUp3ConfigServers("configs/foo0");
+        LogSetup.initVespaLogging("test");
+        try (ConfigTester tester = new ConfigTester()) {
+            ConfigSourceSet sources = tester.setUp3ConfigServers("configs/foo0");
 
-        Map<ConfigSourceSet, JRTConfigRequester> requesterMap = new HashMap<>();
-        requesterMap.put(sources, new JRTConfigRequester(new JRTConnectionPool(sources), new TimingValues()));
-        GenericConfigSubscriber genSubscriber = new GenericConfigSubscriber(requesterMap);
-        GenericConfigHandle bh = genSubscriber.subscribe(new ConfigKey<>(BarConfig.getDefName(), "b", BarConfig.getDefNamespace()),
-                                                         Arrays.asList(BarConfig.CONFIG_DEF_SCHEMA), sources, getTestTimingValues());
-        GenericConfigHandle fh = genSubscriber.subscribe(new ConfigKey<>(FooConfig.getDefName(), "f", FooConfig.getDefNamespace()),
-                                                         Arrays.asList(FooConfig.CONFIG_DEF_SCHEMA), sources, getTestTimingValues());
-        assertTrue(genSubscriber.nextConfig(waitWhenExpectedSuccess));
-        assertTrue(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertPayloadMatches(bh, ".*barValue.*0bar.*");
-        assertPayloadMatches(fh, ".*fooValue.*0foo.*");
-        assertFalse(genSubscriber.nextGeneration(waitWhenExpectedFailure));
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
-        assertFalse(genSubscriber.nextGeneration(waitWhenExpectedFailure));
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
-        stop(getInUse(genSubscriber, sources));
-        assertFalse(genSubscriber.nextGeneration(waitWhenExpectedFailure));
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
+            Map<ConfigSourceSet, JRTConfigRequester> requesterMap = new HashMap<>();
+            requesterMap.put(sources, new JRTConfigRequester(new JRTConnectionPool(sources), ConfigTester.getTestTimingValues()));
+            GenericConfigSubscriber genSubscriber = new GenericConfigSubscriber(requesterMap);
+            GenericConfigHandle bh = genSubscriber.subscribe(new ConfigKey<>(BarConfig.getDefName(), "b", BarConfig.getDefNamespace()),
+                                                             Arrays.asList(BarConfig.CONFIG_DEF_SCHEMA), sources, ConfigTester.getTestTimingValues());
+            GenericConfigHandle fh = genSubscriber.subscribe(new ConfigKey<>(FooConfig.getDefName(), "f", FooConfig.getDefNamespace()),
+                                                             Arrays.asList(FooConfig.CONFIG_DEF_SCHEMA), sources, ConfigTester.getTestTimingValues());
+            assertTrue(genSubscriber.nextConfig(waitWhenExpectedSuccess));
+            assertTrue(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertPayloadMatches(bh, ".*barValue.*0bar.*");
+            assertPayloadMatches(fh, ".*fooValue.*0foo.*");
+            assertFalse(genSubscriber.nextGeneration(waitWhenExpectedFailure));
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
 
-        assertFalse(genSubscriber.nextGeneration(waitWhenExpectedFailure));
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
-        assertPayloadMatches(bh, ".*barValue.*0bar.*");
-        assertPayloadMatches(fh, ".*fooValue.*0foo.*");
+            System.out.println("\nDEBUG DEBUG DEBUG right before stopping config server\n");
+            tester.stopConfigServer(tester.getInUse(genSubscriber, sources));
+            assertFalse(genSubscriber.nextGeneration(waitWhenExpectedFailure));
+            assertFalse(bh.isChanged());
+            assertFalse(fh.isChanged());
+            assertPayloadMatches(bh, ".*barValue.*0bar.*");
+            assertPayloadMatches(fh, ".*fooValue.*0foo.*");
 
-        assertFalse(genSubscriber.nextGeneration(waitWhenExpectedFailure));
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
-        assertFalse(genSubscriber.nextGeneration(waitWhenExpectedFailure));
-        assertFalse(bh.isChanged());
-        assertFalse(fh.isChanged());
+            // Redeploy some time after a failover
+            tester.deployOn3ConfigServers("configs/foo1");
+            System.out.println("\nDEBUG DEBUG DEBUG calling nextConfig()\n");
+            assertTrue(genSubscriber.nextConfig(waitWhenExpectedSuccess));
+            System.out.println("\nDEBUG DEBUG DEBUG after calling nextConfig()\n");
+            assertFalse(bh.isChanged());
+            assertTrue(fh.isChanged());
+            assertPayloadMatches(bh, ".*barValue.*0bar.*");
+            assertPayloadMatches(fh, ".*fooValue.*1foo.*");
 
-        // A redeploy some time after a failover
-        deployOn3ConfigServers("configs/foo1");
-        assertTrue(genSubscriber.nextConfig(waitWhenExpectedSuccess));
-        assertFalse(bh.isChanged());
-        assertTrue(fh.isChanged());
-        assertPayloadMatches(bh, ".*barValue.*0bar.*");
-        assertPayloadMatches(fh, ".*fooValue.*1foo.*");
-
-        genSubscriber.close();
+            genSubscriber.close();
+        }
     }
 
     private void assertPayloadMatches(GenericConfigHandle bh, String regex) {

--- a/tests/cloudconfig/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/StressTest.java
+++ b/tests/cloudconfig/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/StressTest.java
@@ -1,6 +1,8 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.subscription;
 
+import static com.yahoo.vespa.config.ConfigTester.waitWhenExpectedFailure;
+import static com.yahoo.vespa.config.ConfigTester.waitWhenExpectedSuccess;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
@@ -58,10 +60,10 @@ public class StressTest {
         @Override
         public void run() {
             ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "bar");
-            allOK = subscriber.nextConfig(ConfigTester.waitWhenExpectedSuccess);
+            allOK = subscriber.nextConfig(waitWhenExpectedSuccess);
             allOK = allOK && bh.isChanged();
             allOK = allOK && (bh.getConfig().barValue().equals("0bar"));
-            allOK = allOK && !subscriber.nextConfig(ConfigTester.waitWhenExpectedFailure);
+            allOK = allOK && !subscriber.nextConfig(waitWhenExpectedFailure);
             allOK = allOK && !bh.isChanged();
             subscriber.close();
         }
@@ -78,10 +80,10 @@ public class StressTest {
         @Override
         public void run() {
             ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "foo");
-            allOK = subscriber.nextConfig(ConfigTester.waitWhenExpectedSuccess);
+            allOK = subscriber.nextConfig(waitWhenExpectedSuccess);
             allOK = allOK && fh.isChanged();
             allOK = allOK && (fh.getConfig().fooValue().equals("0foo"));
-            allOK = allOK && !subscriber.nextConfig(ConfigTester.waitWhenExpectedFailure);
+            allOK = allOK && !subscriber.nextConfig(waitWhenExpectedFailure);
             allOK = allOK && !fh.isChanged();
             subscriber.close();
         }

--- a/tests/cloudconfig/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/StressTest.java
+++ b/tests/cloudconfig/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/StressTest.java
@@ -10,38 +10,40 @@ import com.yahoo.config.FooConfig;
 import org.junit.Test;
 
 import com.yahoo.foo.BarConfig;
-import com.yahoo.vespa.config.ConfigTest;
+import com.yahoo.vespa.config.ConfigTester;
 
-public class StressTest extends ConfigTest {
+public class StressTest {
 
     @Test
     public void testManySubscribers() throws InterruptedException {
-        ConfigSourceSet sources = setUp3ConfigServers("configs/foo0");
-        Map<Integer, BarSubscriberThread> barSubscribers = new HashMap<>();
-        Map<Integer, FooSubscriberThread> fooSubscribers = new HashMap<>();
-        Map<Integer, Thread> barThreads = new HashMap<>();
-        Map<Integer, Thread> fooThreads = new HashMap<>();
+        try (ConfigTester tester = new ConfigTester()) {
+            ConfigSourceSet sources = tester.setUp3ConfigServers("configs/foo0");
+            Map<Integer, BarSubscriberThread> barSubscribers = new HashMap<>();
+            Map<Integer, FooSubscriberThread> fooSubscribers = new HashMap<>();
+            Map<Integer, Thread> barThreads = new HashMap<>();
+            Map<Integer, Thread> fooThreads = new HashMap<>();
 
-        int threads = 10;
-        for (int i = 0; i < threads; i++) {
-            final BarSubscriberThread barSubscriberThread = new BarSubscriberThread(sources);
-            barSubscribers.put(i, barSubscriberThread);
-            barThreads.put(i, new Thread(barSubscriberThread));
-            final FooSubscriberThread fooSubscriberThread = new FooSubscriberThread(sources);
-            fooSubscribers.put(i, fooSubscriberThread);
-            fooThreads.put(i, new Thread(fooSubscriberThread));
-        }
-        for (int i = 0; i < threads; i++) {
-            barThreads.get(i).start();
-            fooThreads.get(i).start();
-        }
-        for (int i = 0; i < threads; i++) {
-            barThreads.get(i).join();
-            fooThreads.get(i).join();
-        }
-        for (int i = 0; i < threads; i++) {
-            assertTrue(barSubscribers.get(i).allOK);
-            assertTrue(fooSubscribers.get(i).allOK);
+            int threads = 10;
+            for (int i = 0; i < threads; i++) {
+                final BarSubscriberThread barSubscriberThread = new BarSubscriberThread(sources);
+                barSubscribers.put(i, barSubscriberThread);
+                barThreads.put(i, new Thread(barSubscriberThread));
+                final FooSubscriberThread fooSubscriberThread = new FooSubscriberThread(sources);
+                fooSubscribers.put(i, fooSubscriberThread);
+                fooThreads.put(i, new Thread(fooSubscriberThread));
+            }
+            for (int i = 0; i < threads; i++) {
+                barThreads.get(i).start();
+                fooThreads.get(i).start();
+            }
+            for (int i = 0; i < threads; i++) {
+                barThreads.get(i).join();
+                fooThreads.get(i).join();
+            }
+            for (int i = 0; i < threads; i++) {
+                assertTrue(barSubscribers.get(i).allOK);
+                assertTrue(fooSubscribers.get(i).allOK);
+            }
         }
     }
 
@@ -56,10 +58,10 @@ public class StressTest extends ConfigTest {
         @Override
         public void run() {
             ConfigHandle<BarConfig> bh = subscriber.subscribe(BarConfig.class, "bar");
-            allOK = subscriber.nextConfig(waitWhenExpectedSuccess);
+            allOK = subscriber.nextConfig(ConfigTester.waitWhenExpectedSuccess);
             allOK = allOK && bh.isChanged();
             allOK = allOK && (bh.getConfig().barValue().equals("0bar"));
-            allOK = allOK && !subscriber.nextConfig(waitWhenExpectedFailure);
+            allOK = allOK && !subscriber.nextConfig(ConfigTester.waitWhenExpectedFailure);
             allOK = allOK && !bh.isChanged();
             subscriber.close();
         }
@@ -76,10 +78,10 @@ public class StressTest extends ConfigTest {
         @Override
         public void run() {
             ConfigHandle<FooConfig> fh = subscriber.subscribe(FooConfig.class, "foo");
-            allOK = subscriber.nextConfig(waitWhenExpectedSuccess);
+            allOK = subscriber.nextConfig(ConfigTester.waitWhenExpectedSuccess);
             allOK = allOK && fh.isChanged();
             allOK = allOK && (fh.getConfig().fooValue().equals("0foo"));
-            allOK = allOK && !subscriber.nextConfig(waitWhenExpectedFailure);
+            allOK = allOK && !subscriber.nextConfig(ConfigTester.waitWhenExpectedFailure);
             allOK = allOK && !fh.isChanged();
             subscriber.close();
         }

--- a/tests/cloudconfig/integrationtests/config_test/src/test/java/com/yahoo/vespa/config/ConfigClientTest.java
+++ b/tests/cloudconfig/integrationtests/config_test/src/test/java/com/yahoo/vespa/config/ConfigClientTest.java
@@ -31,29 +31,33 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Harald Musum
  */
-public class ConfigClientTest extends ConfigTest {
+public class ConfigClientTest {
 
-    @SuppressWarnings({"UnusedDeclaration"})
-    private java.util.logging.Logger log = java.util.logging.Logger.getLogger(ConfigClientTest.class.getName());
+    public static final String DEF_NAME = "app";
+    public static final String CONFIG_MD5 = "";
 
     // getConfig parameters
     private static final String CONFIG_ID = "client-test.0";
     private static final long SERVER_TIMEOUT = 5000; //msecs
     private static final double CLIENT_TIMEOUT = 10.0; //secs
 
+    ConfigTester tester;
     private Supervisor supervisor;
     private Target target;
 
     @Before
     public void setUp() {
+        tester = new ConfigTester();
+        tester.startOneConfigServer();
         supervisor = new Supervisor(new Transport());
-        target = supervisor.connect(getConfigServerSpec());
+        target = supervisor.connect(tester.getConfigServerSpec());
     }
 
     @After public void tearDown() {
         supervisor.transport().shutdown().join();
         supervisor = null;
         if (target != null) target.close();
+        tester.close();
     }
 
     public ConfigClientTest() {
@@ -129,7 +133,7 @@ public class ConfigClientTest extends ConfigTest {
         String configMd5 = req.getNewConfigMd5();
 
         // reload and check that we really get a new config
-        cServer1.deployNewConfig("configs/baz");
+        tester.getConfigServer().deployNewConfig("configs/baz");
 
         JRTClientConfigRequest  newReq = createRequest(DEF_NAME, configMd5);
 
@@ -156,7 +160,7 @@ public class ConfigClientTest extends ConfigTest {
         long generation = req.getNewGeneration();
 
         // reload same config to set new generation
-        cServer1.deployNewConfig("configs/foo");
+        tester.getConfigServer().deployNewConfig("configs/foo");
 
         JRTClientConfigRequest newReq = createRequest(DEF_NAME, configMd5, generation);
 


### PR DESCRIPTION
Use a tester instead of extending ConfigTest. Make the tester auto-closable.
Some other minor changes needed to get the tests working.
