### PR TITLE
Revert "Print search chains with current syntax (<chain>)."

### DIFF
--- a/lib/app_generator/container.rb
+++ b/lib/app_generator/container.rb
@@ -136,7 +136,7 @@ class Searching
     XmlHelper.new(indent)\
       .tag_always("search")\
       .to_xml(@config)\
-      .to_xml(@chains, :to_container_xml)\
+      .to_xml(@chains)\
       .to_xml(@renderers)\
       .to_s
   end


### PR DESCRIPTION
This reverts commit 0129f8b5fd355232a11e1b1f1a3d9f1f5b3a8039.

@toregge please review
@gjoranv FYI
