### PR TITLE
Use two nodes for the content cluster

### DIFF
--- a/tests/search/auto_oos/auto_oos.rb
+++ b/tests/search/auto_oos/auto_oos.rb
@@ -11,6 +11,7 @@ class AutomaticOutOfServiceTest < SearchTest
 
   def test_multicluster_stop_nodes
     deploy_app(SearchApp.new.
+        num_parts(2).
         cluster(
             SearchCluster.new("bluemusic").sd(SEARCH_DATA + "music.sd").
                 doc_type("music", "music.mid==2")).


### PR DESCRIPTION
Content clusters with just one node are not taken offline
any more, so use two nodes.
