### PR TITLE
Revert "Use two nodes for the content cluster"

### DIFF
--- a/tests/search/auto_oos/auto_oos.rb
+++ b/tests/search/auto_oos/auto_oos.rb
@@ -11,7 +11,6 @@ class AutomaticOutOfServiceTest < SearchTest
 
   def test_multicluster_stop_nodes
     deploy_app(SearchApp.new.
-        num_parts(2).
         cluster(
             SearchCluster.new("bluemusic").sd(SEARCH_DATA + "music.sd").
                 doc_type("music", "music.mid==2")).


### PR DESCRIPTION
Reverts vespa-engine/system-test#628

Test should work now.