### PR TITLE
Docker image vespa-dev has been renamed to vespa-build-centos7.

### DIFF
--- a/travis/start-docker-container.sh
+++ b/travis/start-docker-container.sh
@@ -4,5 +4,5 @@
 
 set -e
 
-docker run --rm -v $(pwd):/source --entrypoint /source/travis/run-unit-tests.sh docker.io/vespaengine/vespa-dev:latest
+docker run --rm -v $(pwd):/source --entrypoint /source/travis/run-unit-tests.sh docker.io/vespaengine/vespa-build-centos7:latest
 exit $?


### PR DESCRIPTION
@aressem please review