### PR TITLE
Do not expect EC keys in autogenerated cert material

### DIFF
--- a/lib/test/ssl_config_test.rb
+++ b/lib/test/ssl_config_test.rb
@@ -11,8 +11,9 @@ class SslConfigTest < Test::Unit::TestCase
       cfg.generate_host_specific_certs
       assert_equal(true, cfg.cert_path_contains_certs?)
 
-      assert cfg.get_openssl_ca_cert_info.include? "CA:TRUE"
-      assert cfg.get_openssl_host_cert_info.include? "prime256v1"
+      assert cfg.get_openssl_ca_cert_info.include? 'CA:TRUE'
+      assert cfg.get_openssl_host_cert_info.include? 'CA:FALSE'
+      assert cfg.get_openssl_host_cert_info.include? 'DNS:localhost'
     }
   end
 


### PR DESCRIPTION
@bjorncs please review.

This test has been failing since we moved from EC to RSA
(due to compatibility reasons), but for some reason it hasn't
been picked up anywhere. All tests pass now.

