### PR TITLE
Require Vespa TLS when running system tests

### DIFF
--- a/lib/tls_env.rb
+++ b/lib/tls_env.rb
@@ -65,6 +65,5 @@ class TlsEnv
     @ssl_ctx = ssl_ctx_from_pems(ca_pem, cert_pem, privkey_pem)
   end
 
-
 end
 


### PR DESCRIPTION
@bjorncs please review. A pragmatic way to propagate the TLS config env 🦄
@aressem FYI

Transparently set `VESPA_TLS_CONFIG_FILE` environment variable
when running if this has not been set explicitly. Reuses existing
locally generated (or set) system testing certificates and keys.

Since running tests with TLS requires a `localhost` DNS SAN entry
due to node servers connecting to local HTTPS endpoints via it,
this is explicitly checked when the node server is launched.
Emits a hopefully helpful error message if existing host certificate
does not meet the requirements.

