### PR TITLE
Revert "Require Vespa TLS when running system tests"

### DIFF
--- a/lib/node_server.rb
+++ b/lib/node_server.rb
@@ -8,7 +8,6 @@ require 'executeerror'
 require 'nodetypes/metrics'
 require 'drb_endpoint'
 require 'digest/md5'
-require 'ssl_config'
 require 'tls_env'
 require 'environment'
 require 'executor'
@@ -960,25 +959,6 @@ def symbol_to_string_keys(hsh)
   hsh.map { |k,v| [k.to_s, v] }.to_h
 end
 
-def ensure_vespa_tls_env_is_populated
-  if not ENV['VESPA_TLS_CONFIG_FILE']
-    ssl_config = SslConfig.new(cert_path: :default)
-    if not ssl_config.cert_path_contains_certs?
-      puts "No TLS certificates/keys found; generating first-time host-local CA, keypair and Vespa TLS config file"
-      ssl_config.generate_host_specific_certs # Also generates TLS config file.
-    elsif not ssl_config.cert_path_contains_config_file?
-      puts "No Vespa TLS config file found; generating default config file pointing to existing certs/key"
-      ssl_config.generate_vespa_tls_config_file
-    elsif not ssl_config.get_existing_cert_dns_san_entries().include? 'localhost'
-      puts "Existing host certificate does not have required localhost DNS SAN entry."
-      puts "Removing the directory '#{ssl_config.cert_path}' will let the node server auto-generate appropriate certs on the next run."
-      raise 'Existing certificate not sufficient to run full Vespa TLS'
-    end
-    ENV['VESPA_TLS_CONFIG_FILE'] = ssl_config.tls_config_file
-  end
-  puts "Using Vespa TLS config file #{ENV['VESPA_TLS_CONFIG_FILE']}"
-end
-
 def main(callback_endpoint)
   # Instantiates a NodeServer object and publishes it through DRb.
   hostname = Environment.instance.vespa_hostname
@@ -991,8 +971,6 @@ def main(callback_endpoint)
   else
     service_endpoint = ":#{TestBase::DRUBY_REMOTE_PORT}"
   end
-
-  ensure_vespa_tls_env_is_populated
 
   Environment.instance.backup_environment_setting(false)
 

--- a/lib/ssl_config.rb
+++ b/lib/ssl_config.rb
@@ -9,7 +9,7 @@ class SslConfig
   PATH_OVERRIDE_ENV_VAR_NAME = 'VESPA_SYSTEM_TEST_CERT_PATH'
   USER_HOME_RELATIVE_PATH = '.vespa/system_test_certs'
 
-  attr_reader :cert_path, :use_tls, :tls_config_file
+  attr_reader :cert_path, :use_tls
   # _Paths_ to CA and host PEMs/keys.
   attr_reader :ca_cert, :host_cert, :host_private_key
 
@@ -40,7 +40,6 @@ class SslConfig
     @host_csr         = cert_file('host.csr') # May not exist
     @host_exts        = cert_file('host_exts.cnf')
     @host_private_key = cert_file('host.key')
-    @tls_config_file  = cert_file('tls-config.json')
   end
 
   def self.tls_enabled?
@@ -63,10 +62,6 @@ class SslConfig
     File.exists?(@ca_cert) &&
     File.exists?(@host_cert) &&
     File.exists?(@host_private_key)
-  end
-
-  def cert_path_contains_config_file?
-    File.exists? @tls_config_file
   end
 
   def run_or_fail(cmd)
@@ -95,7 +90,6 @@ class SslConfig
     generate_host_specific_private_key
     generate_host_specific_csr_for this_host
     sign_host_specific_cert_by_root_ca
-    generate_vespa_tls_config_file
 
     cleanup_files_after_key_and_cert_generation
   end
@@ -111,7 +105,7 @@ class SslConfig
   def self_sign_root_ca_certificate_for(this_host)
     run_or_fail("openssl req -new -x509 -nodes -key #{@ca_private_key} " +
                 "-sha256 -out #{@ca_cert} " +
-                "-subj '/C=NO/L=Trondheim/O=ACME Vespa/OU=Vespa system test dummy CA root/CN=#{this_host}' " +
+                "-subj '/C=NO/L=Trondheim/O=Yahoo, Inc/OU=Vespa system test dummy CA root/CN=#{this_host}' " +
                 "-days 720")
   end
 
@@ -133,7 +127,7 @@ class SslConfig
                  "DNS.2 = #{this_host}\n")
     end
     run_or_fail("openssl req -new -key #{@host_private_key} -out #{@host_csr} " +
-                "-subj '/C=NO/L=Trondheim/O=ACME Vespa/OU=Vespa system testing/CN=#{this_host}' " +
+                "-subj '/C=NO/L=Trondheim/O=Yahoo, Inc/OU=Vespa system testing/CN=#{this_host}' " +
                 "-sha256")
   end
 
@@ -147,17 +141,6 @@ class SslConfig
                 "-extfile '#{@host_exts}' " +
                 "-extensions systest_extensions " +
                 "-sha256");
-  end
-
-  def generate_vespa_tls_config_file
-    json = {
-      'files' => {
-        'ca-certificates' => @ca_cert,
-        'certificates'    => @host_cert,
-        'private-key'     => @host_private_key
-      }
-    }.to_json
-    File.open(@tls_config_file, 'w'){|f| f.syswrite(json) }
   end
 
   def cleanup_files_after_key_and_cert_generation
@@ -185,15 +168,6 @@ class SslConfig
 
   def get_openssl_host_cert_info
     get_cert_info(@host_cert)
-  end
-
-  def get_existing_cert_dns_san_entries
-    raw_sans = run_or_fail("openssl x509 -in #{@host_cert} -text -noout | grep 'DNS:' | head -1")
-    raw_sans.split(',').
-        map{|s| s.strip }.
-        select{|s| s =~ /^DNS:/ }.
-        map{|s| s.split(':')[1] }.
-        to_a
   end
 
   def to_drb_openssl_config

--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -14,7 +14,6 @@ require 'timeout'
 require 'net/http'
 require 'fileutils'
 require 'vespa_cleanup'
-require 'ssl_config'
 
 class SystemTestTimeout < Interrupt
   def message
@@ -74,7 +73,6 @@ class TestCase
     @tenant_name = sanitize_name(self.class.name)
     @application_name = nil
     @forked = args[:forked]
-    ensure_tls_env_populated
     @tls_env = TlsEnv.new()
     @https_client = HttpsClient.new(@tls_env)
     # To avoid mass test breakage in case of known warnings, maintain a workaround
@@ -138,19 +136,6 @@ class TestCase
       require 'drb/drb'
       DRb.start_service
       @controller = DRbObject.new_with_uri(@forked)
-    end
-  end
-
-  def ensure_tls_env_populated
-    # Note: we don't auto-create anything as part of this code path.
-    if not ENV['VESPA_TLS_CONFIG_FILE']
-      ssl_config = SslConfig.new(cert_path: :default)
-      if not ssl_config.cert_path_contains_certs?
-        raise "No certificates or keys found in default certificate path (#{ssl_config.cert_path}). Please re-run node server locally to regenerate."
-      elsif not ssl_config.cert_path_contains_config_file?
-        raise "No Vespa TLS config file found in path #{ssl_config.cert_path}. Please re-run node server locally to regenerate."
-      end
-      ENV['VESPA_TLS_CONFIG_FILE'] = ssl_config.tls_config_file
     end
   end
 

--- a/lib/tls_env.rb
+++ b/lib/tls_env.rb
@@ -65,5 +65,6 @@ class TlsEnv
     @ssl_ctx = ssl_ctx_from_pems(ca_pem, cert_pem, privkey_pem)
   end
 
+
 end
 


### PR DESCRIPTION
Reverts vespa-engine/system-test#728

This broke testing when running basic search as part of pull requests. See factory build for 7.224.8.