### PR TITLE
Test read/write repair interaction with tombstones

### DIFF
--- a/tests/search/inconsistent_replicas/updates_to_inconsistent_buckets.rb
+++ b/tests/search/inconsistent_replicas/updates_to_inconsistent_buckets.rb
@@ -68,6 +68,10 @@ class UpdatesToInconsistentBucketsTest < SearchTest
     vespa.document_api_v1.put(doc)
   end
 
+  def remove_document
+    vespa.document_api_v1.remove(updated_doc_id)
+  end
+
   def feed_incidental_doc_to_same_bucket
     doc = Document.new('music', incidental_doc_id).add_field('title', 'hello world')
     vespa.document_api_v1.put(doc)
@@ -181,6 +185,32 @@ class UpdatesToInconsistentBucketsTest < SearchTest
     make_replicas_inconsistent_and_contain_incidental_documents_only
     update_doc_with_field_value(title: 'really neat title', create_if_missing: false)
 
+    verify_document_does_not_exist
+  end
+
+  # TODO this does not really belong here since it doesn't do any updates.
+  def test_deleted_document_not_visible_by_get_when_replicas_inconsistent
+    set_description('Test that tombstone only present on a subset of replicas ' +
+                    'is taken into account during Get read-repair')
+
+    feed_doc_with_field_value(title: 'first title')
+    mark_content_node_down(1)
+    remove_document
+    mark_content_node_up(1)
+
+    verify_document_does_not_exist
+  end
+
+  def test_deleted_document_not_resurrected_by_update
+    set_description('Test that tombstone only present on a subset of replicas ' +
+                    'is taken into account during Update write-repair')
+
+    feed_doc_with_field_value(title: 'first title')
+    mark_content_node_down(1)
+    remove_document
+    mark_content_node_up(1)
+
+    update_doc_with_field_value(title: 'uh oh', create_if_missing: false)
     verify_document_does_not_exist
   end
 


### PR DESCRIPTION
@geirst please review. These are currently broken, I will annotate tests internally once they are in.

When a newer tombstone is present on at least one replica,
older document versions (that are logically deleted) should
not be visible for read or write operations.

This relates to https://github.com/vespa-engine/vespa/issues/13356

