### PR TITLE
Revert "Set agentpath in config server jvm args for performance tests"

### DIFF
--- a/lib/environment_base.rb
+++ b/lib/environment_base.rb
@@ -74,7 +74,6 @@ class EnvironmentBase
   end
 
   def start_configserver(testcase)
-    @default_env_file.set("VESPA_CONFIGSERVER_JVMARGS", "-agentpath:#{@vespa_home}/lib64/libperfmap.so") if testcase.performance?
     @executor.execute("#{@vespa_home}/bin/vespa-start-configserver", testcase)
   end
 


### PR DESCRIPTION
Reverts vespa-engine/system-test#698

This is not compatible with the open source system tests. We have no libperfmap.so there.

FYI, @bjorncs , @baldersheim 