### PR TITLE
Split out test

### DIFF
--- a/tests/search/inconsistent_replicas/inconsistent_buckets_base.rb
+++ b/tests/search/inconsistent_replicas/inconsistent_buckets_base.rb
@@ -1,0 +1,77 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+require 'search_test'
+
+class InconsistentBucketsBase < SearchTest
+
+  def param_setup(params)
+    @params = params
+    setup_impl(params[:enable_3phase], params[:fast_restart])
+  end
+
+  def self.testparameters
+    # TODO remove parameterization once 3-phase updates are enabled by default.
+    { 'LEGACY'              => { :enable_3phase => false, :fast_restart => false },
+      'LEGACY_FAST_RESTART' => { :enable_3phase => false, :fast_restart => true },
+      'THREE_PHASE'         => { :enable_3phase => true,  :fast_restart => false } } # 3-phase implicitly enables fast restart
+  end
+
+  def setup_impl(enable_3phase, enable_fast_restart)
+    deploy_app(make_app(three_phase_updates: enable_3phase, fast_restart: enable_fast_restart))
+    start
+  end
+
+  def make_app(fast_restart:, three_phase_updates:, disable_merges: true)
+    SearchApp.new.sd(SEARCH_DATA + 'music.sd').
+      cluster_name('storage').
+      num_parts(2).redundancy(2).ready_copies(2).
+      enable_http_gateway.
+      storage(StorageCluster.new('storage', 2).distribution_bits(8)).
+      config(ConfigOverride.new('vespa.config.content.core.stor-distributormanager').
+             add('merge_operations_disabled', disable_merges).
+             add('restart_with_fast_update_path_if_all_get_timestamps_are_consistent', fast_restart).
+             add('enable_metadata_only_fetch_phase_for_inconsistent_updates', three_phase_updates))
+  end
+
+  def updated_doc_id
+    'id:storage_test:music:n=1:foo'
+  end
+
+  def feed_doc_with_field_value(title:)
+    # Also add a second field that updates won't touch so that we can detect if
+    # a 'create: true' update erroneously resets the state on any replica.
+    doc = Document.new('music', updated_doc_id).
+        add_field('title', title).
+        add_field('artist', 'cool dude')
+    vespa.document_api_v1.put(doc)
+  end
+
+  def remove_document
+    vespa.document_api_v1.remove(updated_doc_id)
+  end
+
+  def content_cluster
+    vespa.storage['storage']
+  end
+
+  def mark_node_in_state(idx, state)
+    content_cluster.get_master_fleet_controller().set_node_state('storage', idx, "s:#{state}");
+  end
+
+  def mark_content_node_down(idx)
+    mark_node_in_state(idx, 'd')
+  end
+
+  def mark_content_node_up(idx)
+    mark_node_in_state(idx, 'u')
+  end
+
+  def verify_document_does_not_exist
+    doc = vespa.document_api_v1.get(updated_doc_id)
+    assert_equal(nil, doc)
+  end
+
+  def teardown
+    stop
+  end
+
+end

--- a/tests/search/inconsistent_replicas/updates_to_inconsistent_buckets.rb
+++ b/tests/search/inconsistent_replicas/updates_to_inconsistent_buckets.rb
@@ -1,25 +1,11 @@
-# Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-require 'search_test'
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+require_relative 'inconsistent_buckets_base'
 
-class UpdatesToInconsistentBucketsTest < SearchTest
+class UpdatesToInconsistentBucketsTest < InconsistentBucketsBase
 
-  def param_setup(params)
-    @params = params
-    setup_impl(params[:enable_3phase], params[:fast_restart])
-  end
-
-  def self.testparameters
-    # TODO remove parameterization once 3-phase updates are enabled by default.
-    { 'LEGACY'              => { :enable_3phase => false, :fast_restart => false },
-      'LEGACY_FAST_RESTART' => { :enable_3phase => false, :fast_restart => true },
-      'THREE_PHASE'         => { :enable_3phase => true,  :fast_restart => false } } # 3-phase implicitly enables fast restart
-  end
-
-  def setup_impl(enable_3phase, enable_fast_restart)
+  def setup
     set_owner('vekterli')
-    deploy_app(make_app(three_phase_updates: enable_3phase, fast_restart: enable_fast_restart))
-    start
-    maybe_enable_debug_logging(false)
+    super
   end
 
   def maybe_enable_debug_logging(enable)
@@ -31,45 +17,12 @@ class UpdatesToInconsistentBucketsTest < SearchTest
     end
   end
 
-  def teardown
-    stop
-  end
-
-  def make_app(fast_restart:, three_phase_updates:, disable_merges: true)
-    SearchApp.new.sd(SEARCH_DATA + 'music.sd').
-      cluster_name('storage').
-      num_parts(2).redundancy(2).ready_copies(2).
-      enable_http_gateway.
-      storage(StorageCluster.new('storage', 2).distribution_bits(8)).
-      config(ConfigOverride.new('vespa.config.content.core.stor-distributormanager').
-             add('merge_operations_disabled', disable_merges).
-             add('restart_with_fast_update_path_if_all_get_timestamps_are_consistent', fast_restart).
-             add('enable_metadata_only_fetch_phase_for_inconsistent_updates', three_phase_updates))
-  end
-
-  def updated_doc_id
-    'id:storage_test:music:n=1:foo'
-  end
-
   def incidental_doc_id
     'id:storage_test:music:n=1:bar' # Must be in same location as updated_doc_id
   end
 
   def another_incidental_doc_id
     'id:storage_test:music:n=1:baz' # Must be in same location as updated_doc_id
-  end
-
-  def feed_doc_with_field_value(title:)
-    # Also add a second field that updates won't touch so that we can detect if
-    # a 'create: true' update erroneously resets the state on any replica.
-    doc = Document.new('music', updated_doc_id).
-        add_field('title', title).
-        add_field('artist', 'cool dude')
-    vespa.document_api_v1.put(doc)
-  end
-
-  def remove_document
-    vespa.document_api_v1.remove(updated_doc_id)
   end
 
   def feed_incidental_doc_to_same_bucket
@@ -91,21 +44,6 @@ class UpdatesToInconsistentBucketsTest < SearchTest
     vespa.document_api_v1.update(update, :create => create_if_missing)
   end
 
-  def content_cluster
-    vespa.storage['storage']
-  end
-
-  def mark_node_in_state(idx, state)
-    content_cluster.get_master_fleet_controller().set_node_state('storage', idx, "s:#{state}");
-  end
-
-  def mark_content_node_down(idx)
-    mark_node_in_state(idx, 'd')
-  end
-
-  def mark_content_node_up(idx)
-    mark_node_in_state(idx, 'u')
-  end
 
   def wait_until_no_pending_merges
     content_cluster.wait_until_ready
@@ -116,11 +54,6 @@ class UpdatesToInconsistentBucketsTest < SearchTest
     assert_equal(title, fields['title'])
     # Existing field must have been preserved
     assert_equal('cool dude', fields['artist'])
-  end
-
-  def verify_document_does_not_exist
-    doc = vespa.document_api_v1.get(updated_doc_id)
-    assert_equal(nil, doc)
   end
 
   def dump_bucket_contents
@@ -202,19 +135,6 @@ class UpdatesToInconsistentBucketsTest < SearchTest
   def test_non_create_if_missing_update_fails_if_no_existing_document_on_any_replicas
     make_replicas_inconsistent_and_contain_incidental_documents_only
     update_doc_with_field_value(title: 'really neat title', create_if_missing: false)
-
-    verify_document_does_not_exist
-  end
-
-  # TODO this does not really belong here since it doesn't do any updates.
-  def test_deleted_document_not_visible_by_get_when_replicas_inconsistent
-    set_description('Test that tombstone only present on a subset of replicas ' +
-                    'is taken into account during Get read-repair')
-
-    feed_doc_with_field_value(title: 'first title')
-    mark_content_node_down(1)
-    remove_document
-    mark_content_node_up(1)
 
     verify_document_does_not_exist
   end

--- a/tests/search/inconsistent_replicas/visibility_for_deleted_document_in_inconsistent_buckets.rb
+++ b/tests/search/inconsistent_replicas/visibility_for_deleted_document_in_inconsistent_buckets.rb
@@ -1,0 +1,23 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+require_relative 'inconsistent_buckets_base'
+
+class VisibilityForDeletedDocumentsInInconsistentBucketsTest < InconsistentBucketsBase
+
+  def setup
+    super
+    set_owner('vekterli')
+  end
+
+  def test_deleted_document_not_visible_by_get_when_replicas_inconsistent
+    set_description('Test that tombstone only present on a subset of replicas ' +
+                    'is taken into account during Get read-repair')
+
+    feed_doc_with_field_value(title: 'first title')
+    mark_content_node_down(1)
+    remove_document
+    mark_content_node_up(1)
+
+    verify_document_does_not_exist
+  end
+
+end


### PR DESCRIPTION
Many tests and variant and tests running serially inside a class
makes this the test class that finishes last when running. Split out
due to that and since the comment indicates it belongs in its own
class anyway

Please review only