### PR TITLE
really old bug causing bogus distance with bounding box is now fixed

### DIFF
--- a/tests/search/distanceranking/dist_cutoff.result
+++ b/tests/search/distanceranking/dist_cutoff.result
@@ -13,7 +13,7 @@
       <struct-field name="x">-117745400</struct-field>
     </field>
     <field name="ll.position"><position x="-117745400" y="33503900" latlong="N33.503900;W117.745400" /></field>
-    <field name="ll.distance">122419322</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://12/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -29,7 +29,7 @@
       <struct-field name="x">-117745200</struct-field>
     </field>
     <field name="ll.position"><position x="-117745200" y="33503700" latlong="N33.503700;W117.745200" /></field>
-    <field name="ll.distance">122419075</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://3/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -45,7 +45,7 @@
       <struct-field name="x">-117781800</struct-field>
     </field>
     <field name="ll.position"><position x="-117781800" y="33542000" latlong="N33.542000;W117.781800" /></field>
-    <field name="ll.distance">122464762</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://2/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -61,7 +61,7 @@
       <struct-field name="x">-117775100</struct-field>
     </field>
     <field name="ll.position"><position x="-117775100" y="33533100" latlong="N33.533100;W117.775100" /></field>
-    <field name="ll.distance">122455881</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://19/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -77,7 +77,7 @@
       <struct-field name="x">-117752900</struct-field>
     </field>
     <field name="ll.position"><position x="-117752900" y="33544000" latlong="N33.544000;W117.752900" /></field>
-    <field name="ll.distance">122437516</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://0/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -93,7 +93,7 @@
       <struct-field name="x">-117745300</struct-field>
     </field>
     <field name="ll.position"><position x="-117745300" y="33503800" latlong="N33.503800;W117.745300" /></field>
-    <field name="ll.distance">122419199</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://4/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -109,7 +109,7 @@
       <struct-field name="x">-117774500</struct-field>
     </field>
     <field name="ll.position"><position x="-117774500" y="33555700" latlong="N33.555700;W117.774500" /></field>
-    <field name="ll.distance">122461495</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://6/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -125,7 +125,7 @@
       <struct-field name="x">-117800300</struct-field>
     </field>
     <field name="ll.position"><position x="-117800300" y="33552200" latlong="N33.552200;W117.800300" /></field>
-    <field name="ll.distance">122485349</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://9/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -141,7 +141,7 @@
       <struct-field name="x">-117745100</struct-field>
     </field>
     <field name="ll.position"><position x="-117745100" y="33503600" latlong="N33.503600;W117.745100" /></field>
-    <field name="ll.distance">122418951</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://1/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -157,7 +157,7 @@
       <struct-field name="x">-117776500</struct-field>
     </field>
     <field name="ll.position"><position x="-117776500" y="33543000" latlong="N33.543000;W117.776500" /></field>
-    <field name="ll.distance">122459939</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://10/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -173,7 +173,7 @@
       <struct-field name="x">-117808000</struct-field>
     </field>
     <field name="ll.position"><position x="-117808000" y="33587200" latlong="N33.587200;W117.808000" /></field>
-    <field name="ll.distance">122502346</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://7/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -189,7 +189,7 @@
       <struct-field name="x">-117795400</struct-field>
     </field>
     <field name="ll.position"><position x="-117795400" y="33548200" latlong="N33.548200;W117.795400" /></field>
-    <field name="ll.distance">122479541</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://21/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -205,7 +205,7 @@
       <struct-field name="x">-117805900</struct-field>
     </field>
     <field name="ll.position"><position x="-117805900" y="33550200" latlong="N33.550200;W117.805900" /></field>
-    <field name="ll.distance">122490187</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://24/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -221,7 +221,7 @@
       <struct-field name="x">-117806000</struct-field>
     </field>
     <field name="ll.position"><position x="-117806000" y="33551200" latlong="N33.551200;W117.806000" /></field>
-    <field name="ll.distance">122490557</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://23/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -237,7 +237,7 @@
       <struct-field name="x">-117759300</struct-field>
     </field>
     <field name="ll.position"><position x="-117759300" y="33541300" latlong="N33.541300;W117.759300" /></field>
-    <field name="ll.distance">122442931</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://28/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -253,7 +253,7 @@
       <struct-field name="x">-117745500</struct-field>
     </field>
     <field name="ll.position"><position x="-117745500" y="33504600" latlong="N33.504600;W117.745500" /></field>
-    <field name="ll.distance">122419610</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://30/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -269,7 +269,7 @@
       <struct-field name="x">-117760600</struct-field>
     </field>
     <field name="ll.position"><position x="-117760600" y="33546600" latlong="N33.546600;W117.760600" /></field>
-    <field name="ll.distance">122445633</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://27/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -285,7 +285,7 @@
       <struct-field name="x">-117745500</struct-field>
     </field>
     <field name="ll.position"><position x="-117745500" y="33504700" latlong="N33.504700;W117.745500" /></field>
-    <field name="ll.distance">122419637</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://32/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -301,7 +301,7 @@
       <struct-field name="x">-117772300</struct-field>
     </field>
     <field name="ll.position"><position x="-117772300" y="33553000" latlong="N33.553000;W117.772300" /></field>
-    <field name="ll.distance">122458639</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://40/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -317,7 +317,7 @@
       <struct-field name="x">-117763900</struct-field>
     </field>
     <field name="ll.position"><position x="-117763900" y="33564600" latlong="N33.564600;W117.763900" /></field>
-    <field name="ll.distance">122453740</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://43/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -333,7 +333,7 @@
       <struct-field name="x">-117773000</struct-field>
     </field>
     <field name="ll.position"><position x="-117773000" y="33548000" latlong="N33.548000;W117.773000" /></field>
-    <field name="ll.distance">122457943</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://46/</field>
   </hit>
   <hit relevancy="0.0" source="search">
@@ -349,7 +349,7 @@
       <struct-field name="x">-117781400</struct-field>
     </field>
     <field name="ll.position"><position x="-117781400" y="33544900" latlong="N33.544900;W117.781400" /></field>
-    <field name="ll.distance">122465172</field>
+    <field name="ll.distance">0</field>
     <field name="documentid">id:test:local::pushyss://45/</field>
   </hit>
 </result>

--- a/tests/search/geosearch/example/foo-bb.xml
+++ b/tests/search/geosearch/example/foo-bb.xml
@@ -5,7 +5,7 @@
     <field name="sddocname">point</field>
     <field name="title">pizza hut sunnyvale</field>
     <field name="latlong.position"><position x="-122057174" y="37374821" latlong="N37.374821;W122.057174" /></field>
-    <field name="latlong.distance">127651208</field>
+    <field name="latlong.distance">0</field>
     <field name="documentid">id:test:point::1</field>
   </hit>
 </result>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@geirst or @toregge please review and merge

note: the "distance" that was produced by docsum field writer when searching with a bounding box was just distance from [0,0] (greenwich/equator), now a bounding box always produces distance 0.

we may want to produce distance from the bounding box instead, but with the old way (location is always ANDed on top) documents outside the box won't match.
