### PR TITLE
Revert "Use prepare with application package instead of upload and prepare"

### DIFF
--- a/lib/nodetypes/adminserver.rb
+++ b/lib/nodetypes/adminserver.rb
@@ -61,17 +61,17 @@ class Adminserver < VespaNode
     if params[:from_url]
       cmd += " -F #{params[:from_url]}"
     end
+    upload_start = Time.now
+    execute("#{cmd} upload #{app_dir}", params)
     prepare_start = Time.now
-    out = execute("#{cmd} prepare #{app_dir}", params)
+    out = execute("#{cmd} prepare", params)
     activate_start = Time.now
     unless params[:no_activate] then
       out += execute("#{cmd} activate", params)
     end
     deploy_finished = Time.now
     if params[:collect_timing]
-      # TODO: Second item is upload time, we do prepare with app instead of upload + prepare now,
-      #       fix all usage and remove
-      [out, 0.0, (activate_start - prepare_start).to_f, (deploy_finished - activate_start).to_f]
+      [out, (prepare_start - upload_start).to_f, (activate_start - prepare_start).to_f, (deploy_finished - activate_start).to_f]
     else
       out
     end


### PR DESCRIPTION
Reverts vespa-engine/system-test#843

We have a couple of performance tests that measure prepare time (so upload time will be included now) and have a huge application package, will reapply and add parameter for specifying that upload and prepare should be done separately.