### PR TITLE
Split out a test

### DIFF
--- a/tests/search/inconsistent_replicas/inconsistent_buckets_base.rb
+++ b/tests/search/inconsistent_replicas/inconsistent_buckets_base.rb
@@ -70,6 +70,15 @@ class InconsistentBucketsBase < SearchTest
     assert_equal(nil, doc)
   end
 
+  def update_doc_with_field_value(title:, create_if_missing:, artist: nil)
+    update = DocumentUpdate.new('music', updated_doc_id)
+    update.addOperation('assign', 'title', title)
+    update.addOperation('assign', 'artist', artist) unless artist.nil?
+    # Use 'create: true' update to ensure that not performing a write repair as
+    # expected will create a document from scratch on the node.
+    vespa.document_api_v1.update(update, :create => create_if_missing)
+  end
+
   def teardown
     stop
   end

--- a/tests/search/inconsistent_replicas/updates_to_inconsistent_buckets.rb
+++ b/tests/search/inconsistent_replicas/updates_to_inconsistent_buckets.rb
@@ -35,35 +35,11 @@ class UpdatesToInconsistentBucketsTest < InconsistentBucketsBase
     vespa.document_api_v1.put(doc)
   end
 
-  def update_doc_with_field_value(title:, create_if_missing:, artist: nil)
-    update = DocumentUpdate.new('music', updated_doc_id)
-    update.addOperation('assign', 'title', title)
-    update.addOperation('assign', 'artist', artist) unless artist.nil?
-    # Use 'create: true' update to ensure that not performing a write repair as
-    # expected will create a document from scratch on the node.
-    vespa.document_api_v1.update(update, :create => create_if_missing)
-  end
-
-
-  def wait_until_no_pending_merges
-    content_cluster.wait_until_ready
-  end
-
   def verify_document_has_expected_contents(title:)
     fields = vespa.document_api_v1.get(updated_doc_id).fields
     assert_equal(title, fields['title'])
     # Existing field must have been preserved
     assert_equal('cool dude', fields['artist'])
-  end
-
-  def dump_bucket_contents
-    vespa.adminserver.execute("vespa-stat --document #{updated_doc_id} --dump")
-  end
-
-  def puts_decorated(str)
-    puts '--------'
-    puts str
-    puts '--------'
   end
 
   def verify_document_has_expected_contents_on_all_nodes(title:)
@@ -152,43 +128,4 @@ class UpdatesToInconsistentBucketsTest < InconsistentBucketsBase
     verify_document_does_not_exist
   end
 
-  def test_document_delete_visibility_for_updates_is_propagated_through_merges
-    set_description('Tests that partial updates with create: false do not create new ' +
-                    'document versions when a tombstone for the document ID in question ' +
-                    'shall have been merged from another replica prior to the operation')
-
-    puts_decorated 'Feeding initial document'
-    feed_doc_with_field_value(title: 'first title')
-    dump_bucket_contents
-
-    puts_decorated 'Taking down node 1 and removing document with single replica present'
-    mark_content_node_down(1)
-    remove_document
-    dump_bucket_contents
-
-    puts_decorated 'Unblocking merges to allow remove-entries to be merged'
-    deploy_app(make_app(three_phase_updates: @params[:enable_3phase],
-                        fast_restart: @params[:fast_restart],
-                        disable_merges: false))
-
-    puts_decorated 'Taking node 1 back up'
-    mark_content_node_up(1)
-    wait_until_no_pending_merges
-    dump_bucket_contents
-
-    puts_decorated 'Node 1 back up and all merges have completed. Taking node 0 down'
-    mark_content_node_down(0)
-    puts_decorated 'Verifying update does not operate on old document version'
-    update_doc_with_field_value(title: 'uh oh', create_if_missing: false)
-    dump_bucket_contents
-    verify_document_does_not_exist
-
-    puts_decorated 'Taking node 0 back up to verify remove-entry is visible'
-    mark_content_node_up(0)
-    dump_bucket_contents
-    wait_until_no_pending_merges
-    verify_document_does_not_exist
-  end
-
 end
-

--- a/tests/search/inconsistent_replicas/visibility_for_deleted_document_in_inconsistent_buckets.rb
+++ b/tests/search/inconsistent_replicas/visibility_for_deleted_document_in_inconsistent_buckets.rb
@@ -20,4 +20,56 @@ class VisibilityForDeletedDocumentsInInconsistentBucketsTest < InconsistentBucke
     verify_document_does_not_exist
   end
 
+  def test_document_delete_visibility_for_updates_is_propagated_through_merges
+    set_description('Tests that partial updates with create: false do not create new ' +
+                    'document versions when a tombstone for the document ID in question ' +
+                    'shall have been merged from another replica prior to the operation')
+
+    puts_decorated 'Feeding initial document'
+    feed_doc_with_field_value(title: 'first title')
+    dump_bucket_contents
+
+    puts_decorated 'Taking down node 1 and removing document with single replica present'
+    mark_content_node_down(1)
+    remove_document
+    dump_bucket_contents
+
+    puts_decorated 'Unblocking merges to allow remove-entries to be merged'
+    deploy_app(make_app(three_phase_updates: @params[:enable_3phase],
+                        fast_restart: @params[:fast_restart],
+                        disable_merges: false))
+
+    puts_decorated 'Taking node 1 back up'
+    mark_content_node_up(1)
+    wait_until_no_pending_merges
+    dump_bucket_contents
+
+    puts_decorated 'Node 1 back up and all merges have completed. Taking node 0 down'
+    mark_content_node_down(0)
+    puts_decorated 'Verifying update does not operate on old document version'
+    update_doc_with_field_value(title: 'uh oh', create_if_missing: false)
+    dump_bucket_contents
+    verify_document_does_not_exist
+
+    puts_decorated 'Taking node 0 back up to verify remove-entry is visible'
+    mark_content_node_up(0)
+    dump_bucket_contents
+    wait_until_no_pending_merges
+    verify_document_does_not_exist
+  end
+
+  def dump_bucket_contents
+    vespa.adminserver.execute("vespa-stat --document #{updated_doc_id} --dump")
+  end
+
+  def puts_decorated(str)
+    puts '--------'
+    puts str
+    puts '--------'
+  end
+
+  def wait_until_no_pending_merges
+    content_cluster.wait_until_ready
+  end
+
 end


### PR DESCRIPTION
This class has many tests (and they are parameterized with 3 different values) so often ends up running as the last tests when running all tests. Split out to reduce total test time.