### PR TITLE
Move test to another class to reduce total runtime

### DIFF
--- a/tests/search/inconsistent_replicas/updates_to_inconsistent_buckets.rb
+++ b/tests/search/inconsistent_replicas/updates_to_inconsistent_buckets.rb
@@ -115,17 +115,4 @@ class UpdatesToInconsistentBucketsTest < InconsistentBucketsBase
     verify_document_does_not_exist
   end
 
-  def test_deleted_document_not_resurrected_by_update
-    set_description('Test that tombstone only present on a subset of replicas ' +
-                    'is taken into account during Update write-repair')
-
-    feed_doc_with_field_value(title: 'first title')
-    mark_content_node_down(1)
-    remove_document
-    mark_content_node_up(1)
-
-    update_doc_with_field_value(title: 'uh oh', create_if_missing: false)
-    verify_document_does_not_exist
-  end
-
 end

--- a/tests/search/inconsistent_replicas/visibility_for_deleted_document_in_inconsistent_buckets.rb
+++ b/tests/search/inconsistent_replicas/visibility_for_deleted_document_in_inconsistent_buckets.rb
@@ -58,6 +58,19 @@ class VisibilityForDeletedDocumentsInInconsistentBucketsTest < InconsistentBucke
     verify_document_does_not_exist
   end
 
+  def test_deleted_document_not_resurrected_by_update
+    set_description('Test that tombstone only present on a subset of replicas ' +
+                    'is taken into account during Update write-repair')
+
+    feed_doc_with_field_value(title: 'first title')
+    mark_content_node_down(1)
+    remove_document
+    mark_content_node_up(1)
+
+    update_doc_with_field_value(title: 'uh oh', create_if_missing: false)
+    verify_document_does_not_exist
+  end
+
   def dump_bucket_contents
     vespa.adminserver.execute("vespa-stat --document #{updated_doc_id} --dump")
   end


### PR DESCRIPTION
UpdatesToInconsistentBucketsTest still has very high total runtime, move one more test to another class to. Ref. https://github.com/vespa-engine/system-test/pull/889
