### PR TITLE
Stop using obsolete URI.escape for the whole URI. Use CGI.escape inst…

### DIFF
--- a/lib/test_base.rb
+++ b/lib/test_base.rb
@@ -98,6 +98,8 @@ module TestBase
   # Max query timeout allowed by QRS.
   MAX_QUERY_TIMEOUT=600
 
+  RFC2396_PARSER = URI::RFC2396_Parser.new
+
   bundles = []
 
   def self.webhost(hostname)
@@ -202,7 +204,7 @@ module TestBase
   end
 
   def url_escape_q(q)
-    CGI.escape(q)
+    RFC2396_PARSER.escape(q, /[{};"<>\[\]@\*\|\(\)\\]?/)
   end
 
   def search_withtimeout(timeout, query, qrserver_id=0, requestheaders = {}, verbose = false, params = {})

--- a/lib/test_base.rb
+++ b/lib/test_base.rb
@@ -202,7 +202,7 @@ module TestBase
   end
 
   def url_escape_q(q)
-    URI.escape(q, /[{};"<>\[\]@\*\|\(\)\\]?/)
+    CGI.escape(q)
   end
 
   def search_withtimeout(timeout, query, qrserver_id=0, requestheaders = {}, verbose = false, params = {})

--- a/tests/search/lid_space_compaction/lid_space_compaction.rb
+++ b/tests/search/lid_space_compaction/lid_space_compaction.rb
@@ -220,7 +220,7 @@ class LidSpaceCompactionTest < SearchTest
   end
 
   def get_memory_usage(attribute)
-    uri = URI.escape("/documentdb/test/subdb/ready/attribute/#{attribute}", /[\[\]]?/)
+    uri = "documentdb/test/subdb/ready/attribute/#{CGI.escape(attribute)}"
     stats = vespa.search["search"].first.get_state_v1_custom_component(uri)
     stats["status"]["memoryUsage"]["allocatedBytes"].to_i
   end

--- a/tests/vds/documentapi/document_api_v1_part2.rb
+++ b/tests/vds/documentapi/document_api_v1_part2.rb
@@ -145,21 +145,21 @@ class DocumentApiVdsPart2 < DocumentApiV1Base
     set_description('An update with create=true and test-and-set will implicitly create a ' +
                     'missing document from scratch even if the condition does not match')
 
-    api_http_put("/document/v1/storage_test/music/number/2/9?condition=#{URI.escape('music.person.lastname=="Costanza"')}",
+    api_http_put("/document/v1/storage_test/music/number/2/9?condition=#{CGI.escape('music.person.lastname=="Costanza"')}",
                  '{"create":true,"fields":{"title":{"assign":"A Festivus for the rest of us"}, "person.lastname":{"assign":"Costanza"}}}')
     fields = JSON.parse(api_http_get('/document/v1/storage_test/music/number/2/9'))['fields']
     assert_equal({'title' => 'A Festivus for the rest of us', 'person' => {'lastname' => 'Costanza'}}, fields)
 
     # Now that the document _does_ exist, a mismatching TaS update should NOT go through
     assert_fails_with_precondition_violation {
-      api_http_put("/document/v1/storage_test/music/number/2/9?condition=#{URI.escape('music.person.lastname!="Costanza"')}",
+      api_http_put("/document/v1/storage_test/music/number/2/9?condition=#{CGI.escape('music.person.lastname!="Costanza"')}",
                    '{"create":true,"fields":{"title":{"assign":"Serenity now!!"}}}')
     }
     fields = JSON.parse(api_http_get('/document/v1/storage_test/music/number/2/9'))['fields']
     assert_equal({'title' => 'A Festivus for the rest of us', 'person' => {'lastname' => 'Costanza'}}, fields)
 
     # A matching selection should still update the document
-    api_http_put("/document/v1/storage_test/music/number/2/9?condition=#{URI.escape('music.person.lastname=="Costanza"')}",
+    api_http_put("/document/v1/storage_test/music/number/2/9?condition=#{CGI.escape('music.person.lastname=="Costanza"')}",
                  '{"create":true,"fields":{"title":{"assign":"Serenity now!!"}}}')
     fields = JSON.parse(api_http_get('/document/v1/storage_test/music/number/2/9'))['fields']
     assert_equal({'title' => 'Serenity now!!', 'person' => {'lastname' => 'Costanza'}}, fields)


### PR DESCRIPTION
…ead for the query part.

This avoids the excessive obsoletion console output in ruby 2.7.
