### PR TITLE
Add uri_escape method to allow specifying which symbols to replace.

### DIFF
--- a/lib/test_base.rb
+++ b/lib/test_base.rb
@@ -204,7 +204,11 @@ module TestBase
   end
 
   def url_escape_q(q)
-    RFC2396_PARSER.escape(q, /[{};"<>\[\]@\*\|\(\)\\]?/)
+    uri_escape(q, /[{};"<>\[\]@\*\|\(\)\\]?/)
+  end
+
+  def uri_escape(uri, regex)
+    RFC2396_PARSER.escape(uri, regex)
   end
 
   def search_withtimeout(timeout, query, qrserver_id=0, requestheaders = {}, verbose = false, params = {})

--- a/tests/search/lid_space_compaction/lid_space_compaction.rb
+++ b/tests/search/lid_space_compaction/lid_space_compaction.rb
@@ -220,7 +220,7 @@ class LidSpaceCompactionTest < SearchTest
   end
 
   def get_memory_usage(attribute)
-    uri = "documentdb/test/subdb/ready/attribute/#{CGI.escape(attribute)}"
+    uri = uri_escape("documentdb/test/subdb/ready/attribute/#{attribute}", /[\[\]]?/)
     stats = vespa.search["search"].first.get_state_v1_custom_component(uri)
     stats["status"]["memoryUsage"]["allocatedBytes"].to_i
   end


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Should fix the lid_space_compaction.rb test.