### PR TITLE
assert_query_errors_withouttimeout -> assert_query_errors_without_tim…

### DIFF
--- a/lib/test_base.rb
+++ b/lib/test_base.rb
@@ -459,7 +459,7 @@ module TestBase
       assert_query_errors_with_timeout(5, query, errors)
   end
 
-  def assert_query_errors_withouttimeout(query, errors = [])
+  def assert_query_errors_without_timeout(query, errors = [])
     assert_query_errors_base(search_base(query), errors)
   end
 

--- a/tests/search/searchtimeout/searchtimeout.rb
+++ b/tests/search/searchtimeout/searchtimeout.rb
@@ -15,7 +15,7 @@ class SearchTimeoutTest < IndexedSearchTest
     feed_and_wait_for_docs("banana", 20, :file => selfdir+"docs.xml")
     assert_result_with_timeout(40.0, "query=sddocname:banana&hits=1&nocache", selfdir + "result.1.xml")
     # TODO This will start failing once timeout are best effort.
-    assert_query_errors_withouttimeout("query=sddocname:banana&hits=1&nocache&timeout=5.0&ranking.softtimeout.enable=false",
+    assert_query_errors_without_timeout("query=sddocname:banana&hits=1&nocache&timeout=1.0&ranking.softtimeout.enable=false",
                                     ["Timeout while waiting for sc0.num0|Query timed out in sc0.num0"])
     assert_hitcount_withouttimeout("query=sddocname:banana&hits=1&nocache&timeout=40.0", 20)
     assert_hitcount_withouttimeout("query=sddocname:banana&hits=1&nocache&timeout=2.5&ranking.softtimeout.enable=true", 3)


### PR DESCRIPTION
…eout

Shorten timeout to increase chance for actually timing out where we want.

@hmusum PR