### PR TITLE
Fix such that the query profile types are actually used in the defaul…

### DIFF
--- a/tests/performance/tensor_eval/search/query-profiles/default.xml
+++ b/tests/performance/tensor_eval/search/query-profiles/default.xml
@@ -1,0 +1,2 @@
+<query-profile id="default" type="root">
+</query-profile>


### PR DESCRIPTION
…t query profile.

Before this fix deployment gives the following warning:
"This application define query profile types, but has no query profiles referencing them so they have no effect.
 In particular, the tensors (query(q_dense_float_vector_500) ...) will be interpreted as strings, not tensors if sent in requests."

Tensors from the query have been evaluated as double values,
and the performance measurements have most likely been a bit off.

@arnej27959 please review
@havardpe FYI