### PR TITLE
Valgrind must be set after initializing the testrun because the decis…

### DIFF
--- a/lib/testrunner.rb
+++ b/lib/testrunner.rb
@@ -111,8 +111,7 @@ class TestRunner
                                                               :nostop => @keeprunning,
                                                               :nostop_if_failure => @keeprunning,
                                                               :configserverhostlist => [],
-                                                              :ignore_performance => @ignore_performance,
-                                                              :valgrind => @backend.use_valgrind ? "all" : nil })
+                                                              :ignore_performance => @ignore_performance })
 
             # No need to do more as performance is a test class property
             break if @performance != testclass.performance?
@@ -158,6 +157,8 @@ class TestRunner
     @backend.initialize_testrun(@test_objects)
 
     @backend.sort_testcases(@test_objects).each do |testcase, test_method|
+
+      testcase.valgrind = @backend.use_valgrind ? "all" : nil
 
       @log.info "#{testcase.class}::#{test_method.to_s} requesting nodes"
 


### PR DESCRIPTION
…ion to run valgrind or not is piggy backed in the initialization response.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
