### PR TITLE
Ignore warning about invalid cookie headers. This is a bug in the Apa…

### DIFF
--- a/tests/cloudconfig/config_class_plugin/config_class_plugin.rb
+++ b/tests/cloudconfig/config_class_plugin/config_class_plugin.rb
@@ -20,7 +20,11 @@ class ConfigClassPlugin < CloudConfigTest
     @node.copy(selfdir + "app", destproject)
     output = @node.execute("cd #{destproject} && #{maven_command} compile && #{maven_command} javadoc:javadoc")
     output.split("\n").each { |line|
-      if line =~ /\[WARNING\] Could not apply configuration for yahoo-public-repo/ or line =~ /\[WARNING\] Could not transfer metadata/ or line =~ /Failure to transfer com.yahoo.vespa:configgen/ or line =~ /\[WARNING\] Checksum validation failed/
+      if line =~ /\[WARNING\] Could not apply configuration for yahoo-public-repo/ or
+          line =~ /\[WARNING\] Could not transfer metadata/ or
+          line =~ /Failure to transfer com.yahoo.vespa:configgen/ or
+          line =~ /\[WARNING\] Checksum validation failed/ or
+          line =~ /\[WARNING\] Invalid cookie header/
         next
       end
       if /WARNING/ =~ line


### PR DESCRIPTION
…che Http Client that Maven 3.5 use in Centos 7.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
