### PR TITLE
Revert "Reapply: Sleep up to 3 times to wait for core dumps."

### DIFF
--- a/tests/search/coredump/coredump.rb
+++ b/tests/search/coredump/coredump.rb
@@ -40,14 +40,8 @@ class CoreDump < SearchTest
     before = vespa.adminserver.find_coredumps(@starttime, corefile)
 
     vespa.adminserver.execute("/bin/kill -SIGSEGV " + pid)
-
+    sleep @coredump_sleep
     after = vespa.adminserver.find_coredumps(@starttime, corefile)
-
-    3.times do
-      break unless after.empty?
-      sleep @coredump_sleep
-      after = vespa.adminserver.find_coredumps(@starttime, corefile)
-    end
 
     assert_equal(0, before.size, "Expected no coredumps.")
     assert_equal(1, after.size, "Expected one coredump.")


### PR DESCRIPTION
Reverts vespa-engine/system-test#1059

Fails with:
[20:57:22.043] systest120$ /usr/bin/lz4 -d < /opt/vespa/var/crash/vespa-proton-bi.core.12550.lz4 > /opt/vespa/var/crash/vespa-proton-bi.core.12550.lz4.core
[20:57:22.135] Error 68 : Unfinished stream 
[20:57:22.145] ExecuteError: non-zero exit status (68) from ( /usr/bin/lz4 -d < /opt/vespa/var/crash/vespa-proton-bi.core.12550.lz4 > /opt/vespa/var/crash/vespa-proton-bi.core.12550.lz4.core ) 2>&1

Looks like file isn't written completely when we try to read it, might need a sleep before trying to do that