### PR TITLE
Use minimum of 8 distribution bits in tests and remove use of legacy distribution type 

### DIFF
--- a/lib/app_generator/search_app.rb
+++ b/lib/app_generator/search_app.rb
@@ -33,8 +33,6 @@ class SearchApp < App
                add("min_distributor_up_ratio", 0.1).
                add("min_storage_up_ratio", 0.1).
                add("storage_transition_time", 0))
-    config(ConfigOverride.new('vespa.config.content.core.stor-server').
-               add('use_content_node_btree_bucket_db', true))
   end
 
   def cluster(search_cluster)

--- a/lib/app_generator/storage_app.rb
+++ b/lib/app_generator/storage_app.rb
@@ -31,8 +31,6 @@ class StorageApp < App
     @content.search_type(:none)
     @content.provider(:proton)
     @transition_time = 0
-    config(ConfigOverride.new('vespa.config.content.core.stor-server').
-               add('use_content_node_btree_bucket_db', true))
   end
 
   def default_cluster(name="storage")

--- a/lib/app_generator/test/complex_elastic.xml
+++ b/lib/app_generator/test/complex_elastic.xml
@@ -10,9 +10,6 @@
     <min_storage_up_ratio>0.1</min_storage_up_ratio>
     <storage_transition_time>0</storage_transition_time>
   </config>
-  <config name="vespa.config.content.core.stor-server">
-    <use_content_node_btree_bucket_db>true</use_content_node_btree_bucket_db>
-  </config>
   <config name="stor-distribution">
     <ready_copies>2</ready_copies>
   </config>

--- a/lib/app_generator/test/default_elastic.xml
+++ b/lib/app_generator/test/default_elastic.xml
@@ -10,9 +10,6 @@
     <min_storage_up_ratio>0.1</min_storage_up_ratio>
     <storage_transition_time>0</storage_transition_time>
   </config>
-  <config name="vespa.config.content.core.stor-server">
-    <use_content_node_btree_bucket_db>true</use_content_node_btree_bucket_db>
-  </config>
 
   <container id="default" version="1.0">
     <search />

--- a/lib/app_generator/test/default_streaming.xml
+++ b/lib/app_generator/test/default_streaming.xml
@@ -10,9 +10,6 @@
     <min_storage_up_ratio>0.1</min_storage_up_ratio>
     <storage_transition_time>0</storage_transition_time>
   </config>
-  <config name="vespa.config.content.core.stor-server">
-    <use_content_node_btree_bucket_db>true</use_content_node_btree_bucket_db>
-  </config>
 
   <container id="default" version="1.0">
     <search />

--- a/lib/app_generator/test/storageapp_configoverride.xml
+++ b/lib/app_generator/test/storageapp_configoverride.xml
@@ -4,9 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-server">
-    <use_content_node_btree_bucket_db>true</use_content_node_btree_bucket_db>
-  </config>
   <config name="metricsmanager">
     <consumers operation="append">
       <name>myconsumer</name>

--- a/lib/app_generator/test/storageapp_configoverride2.xml
+++ b/lib/app_generator/test/storageapp_configoverride2.xml
@@ -4,9 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-server">
-    <use_content_node_btree_bucket_db>true</use_content_node_btree_bucket_db>
-  </config>
   <config name="metricsmanager">
     <snapshot>
       <periods operation="append">10</periods>

--- a/lib/app_generator/test/storageapp_default_dummy.xml
+++ b/lib/app_generator/test/storageapp_default_dummy.xml
@@ -4,10 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-server">
-    <use_content_node_btree_bucket_db>true</use_content_node_btree_bucket_db>
-  </config>
-
   <container id="default" version="1.0">
     <search />
     <document-processing />

--- a/lib/app_generator/test/storageapp_default_proton.xml
+++ b/lib/app_generator/test/storageapp_default_proton.xml
@@ -4,10 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-server">
-    <use_content_node_btree_bucket_db>true</use_content_node_btree_bucket_db>
-  </config>
-
   <container id="default" version="1.0">
     <search />
     <document-processing />

--- a/lib/app_generator/test/storageapp_default_storage_content.xml
+++ b/lib/app_generator/test/storageapp_default_storage_content.xml
@@ -4,10 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-server">
-    <use_content_node_btree_bucket_db>true</use_content_node_btree_bucket_db>
-  </config>
-
   <container id="default" version="1.0">
     <search />
     <document-processing />

--- a/lib/app_generator/test/storageapp_default_storage_content_explicit_doctype_decls.xml
+++ b/lib/app_generator/test/storageapp_default_storage_content_explicit_doctype_decls.xml
@@ -4,10 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-server">
-    <use_content_node_btree_bucket_db>true</use_content_node_btree_bucket_db>
-  </config>
-
   <container id="default" version="1.0">
     <search />
     <document-processing />

--- a/lib/app_generator/test/storageapp_default_storage_content_streaming.xml
+++ b/lib/app_generator/test/storageapp_default_storage_content_streaming.xml
@@ -4,10 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-server">
-    <use_content_node_btree_bucket_db>true</use_content_node_btree_bucket_db>
-  </config>
-
   <container id="default" version="1.0">
     <search />
     <document-processing />

--- a/lib/app_generator/test/storageapp_storage_content_with_thread_config.xml
+++ b/lib/app_generator/test/storageapp_storage_content_with_thread_config.xml
@@ -4,10 +4,6 @@
     <adminserver hostalias="node1" />
   </admin>
 
-  <config name="vespa.config.content.core.stor-server">
-    <use_content_node_btree_bucket_db>true</use_content_node_btree_bucket_db>
-  </config>
-
   <container id="default" version="1.0">
     <search />
     <document-processing />

--- a/lib/indexed_streaming_search_test.rb
+++ b/lib/indexed_streaming_search_test.rb
@@ -11,11 +11,11 @@ class IndexedStreamingSearchTest < SearchTest
   def deploy_app(app, deploy_params = {})
     app.search_type(@params[:search_type]) if @params != nil
     # Override distribution bits to ensure no whole-corpus streaming
-    # searches have to visit 64k buckets, but only 2.
+    # searches have to visit 64k buckets, but only 256.
     app.config(ConfigOverride.new('vespa.config.content.fleetcontroller').
-               add('ideal_distribution_bits', 1))
+               add('ideal_distribution_bits', 8))
     app.config(ConfigOverride.new('vespa.config.content.core.stor-distributormanager').
-               add('minsplitcount', 1))
+               add('minsplitcount', 8))
 
     super(app, deploy_params)
   end

--- a/lib/streaming_search_test.rb
+++ b/lib/streaming_search_test.rb
@@ -16,12 +16,12 @@ class StreamingSearchTest < SearchTest
   def deploy_app(app, deploy_params = {})
     app.search_type(@params[:search_type]) if @params != nil
     # Override distribution bits to ensure no whole-corpus streaming
-    # searches have to visit 64k buckets, but only 2.
+    # searches have to visit 64k buckets, but only 256.
     # If there is someone who knows how to do this in a more 'app_generator' way, feel free.
     app.config(ConfigOverride.new('vespa.config.content.fleetcontroller').
-               add('ideal_distribution_bits', 1))
+               add('ideal_distribution_bits', 8))
     app.config(ConfigOverride.new('vespa.config.content.core.stor-distributormanager').
-               add('minsplitcount', 1))
+               add('minsplitcount', 8))
     super(app, deploy_params)
   end
 

--- a/tests/search/content/singlenode-dummy-streaming/services.xml
+++ b/tests/search/content/singlenode-dummy-streaming/services.xml
@@ -6,10 +6,10 @@
     </admin>
 
     <config name='vespa.config.content.fleetcontroller'> 
-        <ideal_distribution_bits>1</ideal_distribution_bits> 
+        <ideal_distribution_bits>8</ideal_distribution_bits> 
     </config> 
     <config name='vespa.config.content.core.stor-distributormanager'> 
-        <minsplitcount>1</minsplitcount> 
+        <minsplitcount>8</minsplitcount> 
     </config>
 
     <container version="1.0" id="container" >

--- a/tests/search/content/singlenode-proton-streaming/services.xml
+++ b/tests/search/content/singlenode-proton-streaming/services.xml
@@ -6,10 +6,10 @@
     </admin>
 
     <config name='vespa.config.content.fleetcontroller'> 
-        <ideal_distribution_bits>1</ideal_distribution_bits> 
+        <ideal_distribution_bits>8</ideal_distribution_bits> 
     </config> 
     <config name='vespa.config.content.core.stor-distributormanager'> 
-        <minsplitcount>1</minsplitcount> 
+        <minsplitcount>8</minsplitcount> 
     </config>
 
     <container version="1.0" id="container" >

--- a/tests/search/content/singlenode-streaming/services.xml
+++ b/tests/search/content/singlenode-streaming/services.xml
@@ -6,10 +6,10 @@
     </admin>
 
     <config name='vespa.config.content.fleetcontroller'> 
-        <ideal_distribution_bits>1</ideal_distribution_bits> 
+        <ideal_distribution_bits>8</ideal_distribution_bits> 
     </config> 
     <config name='vespa.config.content.core.stor-distributormanager'> 
-        <minsplitcount>1</minsplitcount> 
+        <minsplitcount>8</minsplitcount> 
     </config>
 
     <container version="1.0" id="container" >

--- a/tests/search/proton/protonflushtarget.rb
+++ b/tests/search/proton/protonflushtarget.rb
@@ -13,8 +13,7 @@ class ProtonFlushTargetTest < IndexedSearchTest
     set_description("Test that attributes, index, and docsummary are flushed to disk")
     deploy_app(SearchApp.new.
                          sd(selfdir+"test.sd").
-                         tune_searchnode({:flushstrategy => {:native => {:component => {:maxage => 60}}}}).
-                         content_distribution_type("legacy"))
+                         tune_searchnode({:flushstrategy => {:native => {:component => {:maxage => 60}}}}))
     start
     vespa.adminserver.logctl("searchnode:proton.flushengine.flushengine", "debug=on")
     vespa.adminserver.logctl("searchnode:proton.flushengine.flushengine", "spam=on")
@@ -49,7 +48,7 @@ class ProtonFlushTargetTest < IndexedSearchTest
 
     assert_files_flushed(90, status, "snapshot-")
 
-    assert_log_matches("Pruned TLS to token 5", 20)
+    assert_log_matches("Pruned TLS to token 6", 20)
     assert_log_matches("No target to flush", 20)
     assert_log_matches("New target, Num flushed: 1", 20)
     feed(:file => selfdir + "docs.5.xml")

--- a/tests/search/schemachanges/schemachanges.rb
+++ b/tests/search/schemachanges/schemachanges.rb
@@ -198,8 +198,7 @@ class SchemaChanges < IndexedSearchTest
   def test_documentdb_addition_and_removal
     set_description("Test that document databases can be added and removed")
     @test_dir = selfdir + "docdb/"
-    deploy_output = deploy_app(SearchApp.new.sd(@test_dir + "testa.sd").
-                               content_distribution_type("legacy"))
+    deploy_output = deploy_app(SearchApp.new.sd(@test_dir + "testa.sd"))
     start
     postdeploy_wait(deploy_output)
     enable_proton_debug_log
@@ -211,8 +210,7 @@ class SchemaChanges < IndexedSearchTest
     assert_documentdbs_exist(["testa"])
 
     puts "add 'testb' documentdb"
-    deploy_output = deploy_app(SearchApp.new.sd(@test_dir + "testa.sd").sd(@test_dir + "testb.sd").
-                               content_distribution_type("legacy"))
+    deploy_output = deploy_app(SearchApp.new.sd(@test_dir + "testa.sd").sd(@test_dir + "testb.sd"))
     wait_for_content_cluster_config_generation(deploy_output)
     postdeploy_wait(deploy_output)
     vespa.adminserver.execute("vespa-configproxy-cmd -m cache")
@@ -225,8 +223,7 @@ class SchemaChanges < IndexedSearchTest
 
     puts "remove 'testb' documentdb"
     deploy_output = deploy_app(SearchApp.new.sd(@test_dir + "testa.sd").
-                               validation_override("content-type-removal").
-                               content_distribution_type("legacy"))
+                               validation_override("content-type-removal"))
     wait_for_content_cluster_config_generation(deploy_output)
     postdeploy_wait(deploy_output)
     wait_for_hitcount("d&nocache", 1)
@@ -243,8 +240,7 @@ class SchemaChanges < IndexedSearchTest
     assert_hitcount("f3:%3E29&nocache", 2)
 
     puts "re-add 'testb' documentdb"
-    deploy_output = deploy_app(SearchApp.new.sd(@test_dir + "testa.sd").sd(@test_dir + "testb.sd").
-                               content_distribution_type("legacy"))
+    deploy_output = deploy_app(SearchApp.new.sd(@test_dir + "testa.sd").sd(@test_dir + "testb.sd"))
     wait_for_content_cluster_config_generation(deploy_output)
     postdeploy_wait(deploy_output)
     wait_for_hitcount("d&nocache", 2)

--- a/tests/vds/distributionbits.rb
+++ b/tests/vds/distributionbits.rb
@@ -5,10 +5,7 @@ class DistributionBitTest < MultiProviderStorageTest
 
   def setup
     set_owner("vekterli")
-    deploy_app(default_app.distribution_bits(4))
-    #timeout = 600 # Sadly, a 5 min wait is hardcoded in the code for min bits
-                   # split updates. May make that configurable to cut down on
-                   # the time needed to run this test
+    deploy_app(default_app.distribution_bits(8))
     start
   end
 
@@ -53,7 +50,7 @@ class DistributionBitTest < MultiProviderStorageTest
     doc = Document.new("music", "id:test:music:n=1:doc2")
     vespa.document_api_v1.put(doc)
 
-    assert_equal(4, get_split_level())
+    assert_equal(8, get_split_level())
     puts "Have performed #{get_split_count()} splits"
     #assert_equal(2, get_split_count())
 


### PR DESCRIPTION
@geirst please review