### PR TITLE
Arnej/add tensor result utility

### DIFF
--- a/lib/assertions.rb
+++ b/lib/assertions.rb
@@ -2,6 +2,7 @@
 
 require 'assertionfailederror'
 require 'backtracefilter'
+require 'tensor_result'
 
 module Assertions
 
@@ -95,6 +96,13 @@ EOT
   # equal to the JSON parsed value of actual.
   def assert_json_string_equal(expected, actual)
       assert_equal(JSON.parse(expected), JSON.parse(actual))
+  end
+
+  # Converts parsed canonical tensors to objects and compares
+  def assert_tensors_equal(expected, actual)
+      exp = TensorResult.new(expected)
+      act = TensorResult.new(actual)
+      assert_equal(exp, act, "Tensors should be equal: Expected #{exp} != Actual #{act}")
   end
 
   private

--- a/lib/tensor_result.rb
+++ b/lib/tensor_result.rb
@@ -3,6 +3,7 @@
 class TensorResult
   attr_reader :cells
   attr_reader :dimensions
+  attr_reader :value
 
   def extract_cell_dimensions(input_cells)
     dimhash = {}
@@ -28,8 +29,11 @@ class TensorResult
     @value = value
     @cells = nil
     @dimensions = nil
-    if value && value.include?('cells') && value.keys.size == 1
+    input_cells = value
+    if value.kind_of?(Hash) && value.include?('cells') && value.keys.size == 1
       input_cells = value['cells']
+    end
+    if input_cells.kind_of?(Array)
       @dimensions = extract_cell_dimensions(input_cells)
       @cells = extract_cell_values(input_cells, @dimensions)
     end
@@ -55,7 +59,12 @@ class TensorResult
   end
 
   def ==(other)
-    to_s == other.to_s
+    if @cells
+      return @dimensions == other.dimensions &&
+             @cells == other.cells
+    else
+      return @value == other || @value == other.value
+    end
   end
 
 end

--- a/lib/tensor_result.rb
+++ b/lib/tensor_result.rb
@@ -1,0 +1,61 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+class TensorResult
+  attr_reader :cells
+  attr_reader :dimensions
+
+  def extract_cell_dimensions(input_cells)
+    dimhash = {}
+    input_cells.each do |c|
+      c['address'].each { |d,v| dimhash[d] = true }
+    end
+    dimhash.keys.sort
+  end
+
+  def extract_cell_values(input_cells, dimensions)
+    cells = []
+    input_cells.each do |c|
+      addr = c['address']
+      dimvals = []
+      dimensions.each { |d| dimvals.append(addr[d]) }
+      v = [ dimvals, c['value'] ]
+      cells.append(v)
+    end
+    return cells.sort
+  end
+
+  def initialize(value)
+    @value = value
+    @cells = nil
+    @dimensions = nil
+    if value && value.include?('cells') && value.keys.size == 1
+      input_cells = value['cells']
+      @dimensions = extract_cell_dimensions(input_cells)
+      @cells = extract_cell_values(input_cells, @dimensions)
+    end
+  end
+
+  def to_s
+    if @cells && @cells.any?
+      stringval = "tensor#{@dimensions} {\n"
+      @cells.each do |cell|
+        coords = cell[0]
+        value = cell[1]
+        stringval += "  cell #{coords} : #{value}\n"
+      end
+      stringval += "}"
+      return stringval
+    else
+      return @value.to_s
+    end
+  end
+
+  def inspect
+    to_s
+  end
+
+  def ==(other)
+    to_s == other.to_s
+  end
+
+end

--- a/lib/test_base.rb
+++ b/lib/test_base.rb
@@ -19,6 +19,7 @@ require 'sentinel'
 require 'hit'
 require 'resultset'
 require 'tenant_rest_api'
+require 'tensor_result'
 require 'vespa_hosts'
 require 'vespa_coredump'
 require 'rpc/rpcwrapper'
@@ -629,12 +630,10 @@ module TestBase
   # Asserts that the result from query_or_result has the expected tensor cells in the given tensor field, for a given hit number.
   def assert_tensor_field(expected_cells, query_or_result, field_name, hit=0)
     result = (query_or_result.is_a?(String) ? search(query_or_result, 0) : query_or_result)
-    actual_cells = result.hit[hit].field[field_name]['cells']
-    sort_tensor_cells(actual_cells)
-    sort_tensor_cells(expected_cells)
-
-    explanation = "Expected hit[#{hit}].#{field_name} == '#{expected_cells}'"
-    assert_tensor_cells(expected_cells, actual_cells, explanation)
+    field_result = result.hit[hit].field[field_name]
+    exp_value = TensorResult.new(expected_cells)
+    act_value = TensorResult.new(field_result)
+    assert_equal(exp_value, act_value)
   end
 
   def assert_tensor_cells(expected_cells, actual_cells, explanation="")

--- a/tests/search/parent_child/referenced_tensor.rb
+++ b/tests/search/parent_child/referenced_tensor.rb
@@ -75,7 +75,7 @@ class ReferencedTensorTest < ParentChildTestBase
       exp_value = exp_tensors[i]
       act_value = result.hit[i].field[field_name]
       puts "#{i}: '#{exp_value}' == '#{act_value}' ?"
-      assert_tensors_equal(exp_value, act_value)
+      assert_tensor_field(exp_value, result, field_name, i)
     end
   end
 

--- a/tests/search/parent_child/referenced_tensor.rb
+++ b/tests/search/parent_child/referenced_tensor.rb
@@ -75,16 +75,7 @@ class ReferencedTensorTest < ParentChildTestBase
       exp_value = exp_tensors[i]
       act_value = result.hit[i].field[field_name]
       puts "#{i}: '#{exp_value}' == '#{act_value}' ?"
-      if (exp_value && exp_value.include?('cells'))
-        assert_equal(1, exp_value.keys.size)
-        assert(act_value.include?('cells'))
-        assert_equal(1, act_value.keys.size)
-        exp_cells = exp_value['cells'].sort_by { |cell| cell['address'].to_s }
-        act_cells = act_value['cells'].sort_by { |cell| cell['address'].to_s }
-        assert_equal(exp_cells, act_cells)
-      else
-        assert_equal(exp_value, act_value)
-      end
+      assert_tensors_equal(exp_value, act_value)
     end
   end
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

note: this should handle all existing cases, but ideally we should also handle the "vector-style" format where you only supply the values in a JSON vector; this is only used for input now but we would like to produce it on output also (both for space efficiency and readability).  But that format doesn't include the vector dimension so we would have to compare `@dimensions` differently.

@toregge please review
@geirst @lesters @havardpe FYI
