### PR TITLE
Use realpath instead of readlink 

### DIFF
--- a/lib/node_server.rb
+++ b/lib/node_server.rb
@@ -588,10 +588,10 @@ class NodeServer
     Dir.glob(expression)
   end
 
-  # Returns the name of the file referenced by the link _filename_.
-  def readlink(filename)
+  # Returns the absolute and resolved path of _filename_.
+  def realpath(filename)
     if File.exists?(filename)
-      File.readlink(filename)
+      File.realpath(filename)
     else
       nil
     end

--- a/lib/node_server.rb
+++ b/lib/node_server.rb
@@ -588,9 +588,9 @@ class NodeServer
     Dir.glob(expression)
   end
 
-  # Returns the absolute and resolved path of _filename_.
-  def realpath(filename)
-    if File.exists?(filename)
+  # Returns the absolute and resolved path of the symlink _filename_.
+  def resolve_symlink(filename)
+    if File.symlink?(filename)
       File.realpath(filename)
     else
       nil

--- a/lib/node_server_interface.rb
+++ b/lib/node_server_interface.rb
@@ -188,8 +188,8 @@ module NodeServerInterface
     @node_server.list_files(*args)
   end
 
-  def realpath(*args)
-    @node_server.realpath(*args)
+  def resolve_symlink(*args)
+    @node_server.resolve_symlink(*args)
   end
 
   def set_bash_variable(*args)

--- a/lib/node_server_interface.rb
+++ b/lib/node_server_interface.rb
@@ -188,8 +188,8 @@ module NodeServerInterface
     @node_server.list_files(*args)
   end
 
-  def readlink(*args)
-    @node_server.readlink(*args)
+  def realpath(*args)
+    @node_server.realpath(*args)
   end
 
   def set_bash_variable(*args)

--- a/tests/container/queryaccesslog/queryaccesslog.rb
+++ b/tests/container/queryaccesslog/queryaccesslog.rb
@@ -236,7 +236,7 @@ class QueryAccessLog < SearchContainerTest
   end
 
   def get_real_qrs_logname(cluster)
-    vespa.qrs[cluster].qrserver['0'].realpath(get_qrs_symlink_logname(cluster))
+    vespa.qrs[cluster].qrserver['0'].resolve_symlink(get_qrs_symlink_logname(cluster))
   end
 
   def list_qrs_log_files(cluster)

--- a/tests/container/queryaccesslog/queryaccesslog.rb
+++ b/tests/container/queryaccesslog/queryaccesslog.rb
@@ -236,7 +236,7 @@ class QueryAccessLog < SearchContainerTest
   end
 
   def get_real_qrs_logname(cluster)
-    vespa.qrs[cluster].qrserver['0'].readlink(get_qrs_symlink_logname(cluster))
+    vespa.qrs[cluster].qrserver['0'].realpath(get_qrs_symlink_logname(cluster))
   end
 
   def list_qrs_log_files(cluster)


### PR DESCRIPTION
Say /foo/slink is a symlink with content "target", and /foo/target is a file.
Then the symlink is valid and points to /foo/target.

However, if PWD is /bar and the symlink content is read, that content "target"
is NOT a valid file as there is no /bar/target file.  This is what the current
code does.  If the content of the symlink had been an absolute path name
(/foo/target), it WOULD be valid, which is why it works today.