### PR TITLE
Ignore log message when shutting down zookeeper server

### DIFF
--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -96,7 +96,8 @@ class TestCase
       @@log_messages[:log4j_no_appenders],
       @@log_messages[:log4j_initialize],
       @@log_messages[:log4j_see_noconfig],
-      @@log_messages[:concurrent_mark_sweep]
+      @@log_messages[:concurrent_mark_sweep],
+      @@log_messages[:zookeeper_shutdown]
     ]
     @valgrind_ignorable_messages = [
       @@log_messages[:slow_processing],
@@ -729,7 +730,8 @@ class TestCase
     :log4j_no_appenders => /log4j:WARN No appenders could be found for logger/,
     :log4j_initialize => /log4j:WARN Please initialize the log4j system properly/,
     :log4j_see_noconfig => /log4j:WARN See http:\/\/logging.apache.org\/log4j\/1.2\/faq.html#noconfig/,
-    :concurrent_mark_sweep => /OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release./
+    :concurrent_mark_sweep => /OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release./,
+    :zookeeper_shutdown => /Starting non-reconfigurable ZooKeeper server failed on attempt/
   }
 
   # Allow that certain log messages may be ignored without the individual


### PR DESCRIPTION
Might happen if already running server takes some time to shut down,
then we log and die as this is the only clean solution to make
sure this happens correctly at the moment

