### PR TITLE
Allow to run independently of the time of day.

### DIFF
--- a/tests/performance/feeding_and_recovery/feeding_and_recovery.rb
+++ b/tests/performance/feeding_and_recovery/feeding_and_recovery.rb
@@ -4,10 +4,6 @@ require 'performance_test'
 require 'app_generator/search_app'
 require 'environment'
 
-mytime = Time.new
-
-if mytime.hour < 5 or mytime.hour > 15
-
 class FeedingAndRecoveryTest < PerformanceTest
 
   def timeout_seconds
@@ -443,6 +439,4 @@ class FeedingAndRecoveryTest < PerformanceTest
   def teardown
     super
   end
-end
-
 end


### PR DESCRIPTION
@hmusum or @aressem PR
It is now down to under 1800s and it seems to trigger distribution issues so it is better to run it every time.
It will probably add 5-6% to perf runtime.