### PR TITLE
Use the vespa_hostname when querying the local node. This fixes issue…

### DIFF
--- a/lib/nodetypes/vespa_node.rb
+++ b/lib/nodetypes/vespa_node.rb
@@ -59,7 +59,7 @@ class VespaNode
     @https_client.get(hostname, port, path, headers)
   end
 
-  def get_json_over_http(full_path, port, hostname = "localhost")
+  def get_json_over_http(full_path, port, hostname = Environment.instance.vespa_hostname)
     begin
       res = https_get(hostname, port, full_path)
       raise("error!") unless res.is_a?(Net::HTTPSuccess)


### PR DESCRIPTION
…s with Docker networks / IPv6 / localhost combinations in different environments.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
