### PR TITLE
add a graph with all rank profiles

### DIFF
--- a/tests/performance/tensor_replace_max_reduce_prod_join/tensor_replace_max_reduce_prod_join.rb
+++ b/tests/performance/tensor_replace_max_reduce_prod_join/tensor_replace_max_reduce_prod_join.rb
@@ -38,6 +38,12 @@ class TensorReplaceMaxReduceProdJoinPerfTest < PerformanceTest
 
   def get_graphs
     [
+      {
+        :x => 'rank_profile',
+        :y => 'latency',
+        :title => 'Historic latency for all rank profiles',
+        :historic => true
+      },
       get_graph("without_replacement", 21, 50),
       get_graph("halfmodern", 5, 30),
       get_graph("halfmoderndirect", 5, 30),


### PR DESCRIPTION
* for easier comparison of latencies

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@geirst please review
we can probably simplify and drop one of the new rank-profiles also.