### PR TITLE
Add workaround for performance tests on ruby >= 2.6

### DIFF
--- a/lib/node_server.rb
+++ b/lib/node_server.rb
@@ -1029,6 +1029,14 @@ def main(callback_endpoint)
 end
 
 if __FILE__ == $0
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6.0')
+    # Ruby version >= 2.6.0 disables transparent hugepages for the process. This has negative effects
+    # for forked processes and leads to a high number of interrupts (at least for the vespa-feed-perf client).
+    # We fix this here by enabling the THP here before doing anything else.
+    require 'process_ctrl'
+    ProcessCtrl.set_thp_disable(0)
+  end
+
   callback_endpoint = nil
 
   o = OptionParser.new

--- a/lib/process_ctrl.rb
+++ b/lib/process_ctrl.rb
@@ -1,0 +1,23 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+require 'ffi'
+
+class ProcessCtrl
+  module LibC
+    PR_SET_THP_DISABLE = 41
+    PR_GET_THP_DISABLE = 42
+
+    extend FFI::Library
+    ffi_lib FFI::Platform::LIBC
+    attach_function :prctl, [:int, :long, :long, :long, :long], :int
+  end
+
+  class << self
+    def set_thp_disable(value)
+      LibC.prctl(LibC::PR_SET_THP_DISABLE, value, 0, 0, 0)
+    end
+    def get_thp_disable
+      LibC.prctl(LibC::PR_GET_THP_DISABLE, value, 0, 0, 0)
+    end
+  end
+end


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
