### PR TITLE
Swap the order of label type string and number tests.

### DIFF
--- a/tests/performance/mixed_tensors/mixed_tensor_base.rb
+++ b/tests/performance/mixed_tensors/mixed_tensor_base.rb
@@ -38,15 +38,15 @@ class MixedTensorPerfTestBase < PerformanceTest
   end
 
   def feed_and_profile_cases(data_gen_params_prefix)
-    feed_and_profile("#{data_gen_params_prefix} puts", PUTS, NUMBER)
-    feed_and_profile("#{data_gen_params_prefix} updates assign", UPDATES_ASSIGN, NUMBER)
-    feed_and_profile("#{data_gen_params_prefix} updates add", UPDATES_ADD, NUMBER)
-    feed_and_profile("#{data_gen_params_prefix} updates remove", UPDATES_REMOVE, NUMBER)
-
     feed_and_profile("#{data_gen_params_prefix} -s puts", PUTS, STRING)
     feed_and_profile("#{data_gen_params_prefix} -s updates assign", UPDATES_ASSIGN, STRING)
     feed_and_profile("#{data_gen_params_prefix} -s updates add", UPDATES_ADD, STRING)
     feed_and_profile("#{data_gen_params_prefix} -s updates remove", UPDATES_REMOVE, STRING)
+
+    feed_and_profile("#{data_gen_params_prefix} puts", PUTS, NUMBER)
+    feed_and_profile("#{data_gen_params_prefix} updates assign", UPDATES_ASSIGN, NUMBER)
+    feed_and_profile("#{data_gen_params_prefix} updates add", UPDATES_ADD, NUMBER)
+    feed_and_profile("#{data_gen_params_prefix} updates remove", UPDATES_REMOVE, NUMBER)
   end
 
   def feed_and_profile(data_gen_params, feed_type, label_type)


### PR DESCRIPTION
This is to find out why test_multi_model_vec_32 has unstable performance for label type number.

@toregge or @arnej27959 or @havardpe please review