### PR TITLE
dial back maxpending

### DIFF
--- a/tests/performance/mixed_tensors/mixed_tensor_base.rb
+++ b/tests/performance/mixed_tensors/mixed_tensor_base.rb
@@ -30,7 +30,8 @@ class MixedTensorPerfTestBase < PerformanceTest
 
   def create_app(sd_dir)
     SearchApp.new.sd(selfdir + "#{sd_dir}/test.sd").
-      search_dir(selfdir + "search")
+      search_dir(selfdir + "search").
+      tune_searchnode( { :summary => { :store => { :logstore => { :chunk => { :compression => { :level => 3 } } } } } } )
   end
 
   def compile_data_gen
@@ -58,7 +59,7 @@ class MixedTensorPerfTestBase < PerformanceTest
       parameter_filler(GRAPH_NAME, graph_name),
       parameter_filler(FEED_TYPE, feed_type),
       parameter_filler(LABEL_TYPE, label_type)
-    ], { :maxpending => 1000, :numthreads => 5 })
+    ], { :maxpending => 100, :numthreads => 2, :timeout => 1800.0 })
     profiler_report(graph_name)
   end
 


### PR DESCRIPTION
* too high maxpending causes container OOM
* go back to maxpending=100, that looked stable
* tune compression level for document store

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@geirst or @baldersheim please review and merge
