### PR TITLE
do warmup feeding first

### DIFF
--- a/tests/performance/mixed_tensors/mixed_tensor_base.rb
+++ b/tests/performance/mixed_tensors/mixed_tensor_base.rb
@@ -51,6 +51,12 @@ class MixedTensorPerfTestBase < PerformanceTest
     feed_and_profile("#{data_gen_params_prefix} updates remove", UPDATES_REMOVE, NUMBER)
   end
 
+  def warmup_feed(data_gen_params)
+    command = "#{@data_gen} #{data_gen_params} puts"
+    run_stream_feeder(command, [ parameter_filler(GRAPH_NAME, "warmup") ],
+                      { :maxpending => 20, :numthreads => 2 })
+  end
+
   def feed_and_profile(data_gen_params, feed_type, label_type)
     command = "#{@data_gen} #{data_gen_params}"
     profiler_start
@@ -59,7 +65,7 @@ class MixedTensorPerfTestBase < PerformanceTest
       parameter_filler(GRAPH_NAME, graph_name),
       parameter_filler(FEED_TYPE, feed_type),
       parameter_filler(LABEL_TYPE, label_type)
-    ], { :maxpending => 100, :numthreads => 2, :timeout => 1800.0 })
+    ], { :maxpending => 0, :numthreads => 2, :timeout => 1800.0 })
     profiler_report(graph_name)
   end
 

--- a/tests/performance/mixed_tensors/mixed_tensor_feed_multi.rb
+++ b/tests/performance/mixed_tensors/mixed_tensor_feed_multi.rb
@@ -10,6 +10,7 @@ class MixedTensorFeedMultiPerfTest < MixedTensorPerfTestBase
     deploy_and_compile("vec_256")
 
     @num_docs = 30000
+    warmup_feed("-d 1 -o #{@num_docs/5} -f models")
     # Tensor cells data is: 10 (model) * 3 (cat) * 256 * 4 = 30k
     feed_and_profile_cases("-d 3 -o #{@num_docs} -f models")
   end
@@ -35,6 +36,7 @@ class MixedTensorFeedMultiPerfTest < MixedTensorPerfTestBase
     deploy_and_compile("vec_32")
 
     @num_docs = 10000
+    warmup_feed("-d 1 -v 32 -o #{@num_docs/2} -f models")
     # Tensor cells data is: 10 (model) * 80 (cat) * 32 * 4 = 100k
     feed_and_profile_cases("-c 1000 -d 80 -v 32 -o #{@num_docs} -f models")
   end

--- a/tests/performance/mixed_tensors/mixed_tensor_feed_single.rb
+++ b/tests/performance/mixed_tensors/mixed_tensor_feed_single.rb
@@ -10,6 +10,7 @@ class MixedTensorFeedSinglePerfTest < MixedTensorPerfTestBase
     deploy_and_compile("vec_256")
 
     @num_docs = 240000
+    warmup_feed("-d 1 -o #{@num_docs/10} -f model")
     # Tensor cells data is: 3 * 256 * 4 = 3k
     feed_and_profile_cases("-d 3 -o #{@num_docs} -f model")
   end
@@ -35,6 +36,7 @@ class MixedTensorFeedSinglePerfTest < MixedTensorPerfTestBase
     deploy_and_compile("vec_32")
 
     @num_docs = 80000
+    warmup_feed("-d 1 -v 32 -o #{@num_docs/10} -f model")
     # Tensor cells data is: 80 * 32 * 4 = 10k
     feed_and_profile_cases("-c 1000 -d 80 -v 32 -o #{@num_docs} -f model")
   end


### PR DESCRIPTION
* the first run of feeding is still bi-stable with
  current parameters (for test_multi_model_vec_32)
* run a "warmup" run of the feeder before any
  measurements
* for measuring performance, go back to dynamic
  throttling

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@geirst please review
@baldersheim FYI