### PR TITLE
adjust (widen) limits

### DIFF
--- a/tests/performance/mixed_tensors/mixed_tensor_feed_multi.rb
+++ b/tests/performance/mixed_tensors/mixed_tensor_feed_multi.rb
@@ -18,14 +18,14 @@ class MixedTensorFeedMultiPerfTest < MixedTensorPerfTestBase
   def get_graphs_vec_256
     [
       get_all_feed_throughput_graphs,
-      get_feed_throughput_graph(PUTS, NUMBER, 510, 580),
-      get_feed_throughput_graph(PUTS, STRING, 530, 600),
+      get_feed_throughput_graph(PUTS, NUMBER, 510, 600),
+      get_feed_throughput_graph(PUTS, STRING, 510, 600),
       get_feed_throughput_graph(UPDATES_ASSIGN, NUMBER, 530, 600),
-      get_feed_throughput_graph(UPDATES_ASSIGN, STRING, 550, 600),
-      get_feed_throughput_graph(UPDATES_ADD, NUMBER, 3650, 4200),
-      get_feed_throughput_graph(UPDATES_ADD, STRING, 3800, 4250),
-      get_feed_throughput_graph(UPDATES_REMOVE, NUMBER, 9200, 10500),
-      get_feed_throughput_graph(UPDATES_REMOVE, STRING, 9600, 10900)
+      get_feed_throughput_graph(UPDATES_ASSIGN, STRING, 530, 600),
+      get_feed_throughput_graph(UPDATES_ADD, NUMBER, 3650, 4250),
+      get_feed_throughput_graph(UPDATES_ADD, STRING, 3650, 4250),
+      get_feed_throughput_graph(UPDATES_REMOVE, NUMBER, 9200, 10900),
+      get_feed_throughput_graph(UPDATES_REMOVE, STRING, 9200, 10900)
     ]
   end
 
@@ -48,10 +48,10 @@ class MixedTensorFeedMultiPerfTest < MixedTensorPerfTestBase
       get_feed_throughput_graph(PUTS, STRING, 135, 160),
       get_feed_throughput_graph(UPDATES_ASSIGN, NUMBER, 140, 160),
       get_feed_throughput_graph(UPDATES_ASSIGN, STRING, 140, 160),
-      get_feed_throughput_graph(UPDATES_ADD, NUMBER, 1000, 1250),
-      get_feed_throughput_graph(UPDATES_ADD, STRING, 1050, 1300),
-      get_feed_throughput_graph(UPDATES_REMOVE, NUMBER, 3500, 3900),
-      get_feed_throughput_graph(UPDATES_REMOVE, STRING, 3100, 3400)
+      get_feed_throughput_graph(UPDATES_ADD, NUMBER, 1000, 1300),
+      get_feed_throughput_graph(UPDATES_ADD, STRING, 1000, 1300),
+      get_feed_throughput_graph(UPDATES_REMOVE, NUMBER, 3100, 4100),
+      get_feed_throughput_graph(UPDATES_REMOVE, STRING, 3100, 4100)
     ]
   end
 

--- a/tests/performance/mixed_tensors/mixed_tensor_feed_single.rb
+++ b/tests/performance/mixed_tensors/mixed_tensor_feed_single.rb
@@ -18,13 +18,13 @@ class MixedTensorFeedSinglePerfTest < MixedTensorPerfTestBase
   def get_graphs_vec_256
     [
       get_all_feed_throughput_graphs,
-      get_feed_throughput_graph(PUTS, NUMBER, 5000, 5600),
-      get_feed_throughput_graph(PUTS, STRING, 5500, 5900),
-      get_feed_throughput_graph(UPDATES_ASSIGN, NUMBER, 5300, 5850),
-      get_feed_throughput_graph(UPDATES_ASSIGN, STRING, 5400, 5900),
+      get_feed_throughput_graph(PUTS, NUMBER, 5000, 5900),
+      get_feed_throughput_graph(PUTS, STRING, 5000, 5900),
+      get_feed_throughput_graph(UPDATES_ASSIGN, NUMBER, 5300, 5900),
+      get_feed_throughput_graph(UPDATES_ASSIGN, STRING, 5300, 5900),
       get_feed_throughput_graph(UPDATES_ADD, NUMBER, 12400, 14300),
-      get_feed_throughput_graph(UPDATES_ADD, STRING, 12700, 14000),
-      get_feed_throughput_graph(UPDATES_REMOVE, NUMBER, 27300, 30300),
+      get_feed_throughput_graph(UPDATES_ADD, STRING, 12400, 14300),
+      get_feed_throughput_graph(UPDATES_REMOVE, NUMBER, 27000, 32000),
       get_feed_throughput_graph(UPDATES_REMOVE, STRING, 27000, 32000)
     ]
   end
@@ -44,14 +44,14 @@ class MixedTensorFeedSinglePerfTest < MixedTensorPerfTestBase
   def get_graphs_vec_32
     [
       get_all_feed_throughput_graphs,
-      get_feed_throughput_graph(PUTS, NUMBER, 1500, 1750),
-      get_feed_throughput_graph(PUTS, STRING, 1650, 1800),
+      get_feed_throughput_graph(PUTS, NUMBER, 1500, 1800),
+      get_feed_throughput_graph(PUTS, STRING, 1500, 1800),
       get_feed_throughput_graph(UPDATES_ASSIGN, NUMBER, 1620, 1800),
       get_feed_throughput_graph(UPDATES_ASSIGN, STRING, 1620, 1800),
       get_feed_throughput_graph(UPDATES_ADD, NUMBER, 15500, 18100),
-      get_feed_throughput_graph(UPDATES_ADD, STRING, 16000, 18100),
-      get_feed_throughput_graph(UPDATES_REMOVE, NUMBER, 16300, 19000),
-      get_feed_throughput_graph(UPDATES_REMOVE, STRING, 16500, 19500)
+      get_feed_throughput_graph(UPDATES_ADD, STRING, 15500, 18100),
+      get_feed_throughput_graph(UPDATES_REMOVE, NUMBER, 16300, 20500),
+      get_feed_throughput_graph(UPDATES_REMOVE, STRING, 16300, 20500)
     ]
   end
 


### PR DESCRIPTION
* with warmup we hope that performance will be more stable,
  but use pretty wide limits in case warmup is not quite
  sufficient
* from perf reports there should no longer be much difference
  between label types, so use same limits for both type of graphs
  until we have more data
* make sure to allow the best performance we have seen so far, we
  should be able to reach that now

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@geirst or @baldersheim please review and merge

