### PR TITLE
A stopped job due to too many outstanding operations will incorrectly…

### DIFF
--- a/lib/nodetypes/storagenode.rb
+++ b/lib/nodetypes/storagenode.rb
@@ -19,6 +19,13 @@ class StorageNode < VDSNode
   # after all move operations have been completed. However, as mentioned, this
   # time window should be very limited.
   def wait_until_no_pending_bucket_moves
+    wait_until_no_pending_bucket_moves_once
+    for i in 1...2 do
+        sleep 1
+        wait_until_no_pending_bucket_moves_once
+    end
+  end
+  def wait_until_no_pending_bucket_moves_once
     while true
       move_ops = get_metrics_matching('content.proton.documentdb\\{.*\\}.job.bucket_move', true)
       max_moves_found = 0.0


### PR DESCRIPTION
… seem complete.

If we require it to happen at least 3 times in a row with 1s between each sample we should probably be fine.
However a better mechanism should exist. A metric for pending buckets to move, and pending lids to compact is probably better.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
