### PR TITLE
Allow more time.

### DIFF
--- a/tests/performance/reindexing/reindexing_and_feeding.rb
+++ b/tests/performance/reindexing/reindexing_and_feeding.rb
@@ -11,7 +11,7 @@ class ReindexingAndFeedingTest < PerformanceTest
   end
 
   def timeout_seconds
-    2500
+    3000
   end
 
   def setup


### PR DESCRIPTION
Seems like this can use up to 1000 seconds per reindexing and runs 3 times. Try to increase a bit more to avoid timeout.

