### PR TITLE
Keep a small fixed lidbloat so that documents does not move for small…

### DIFF
--- a/lib/app_generator/search_app.rb
+++ b/lib/app_generator/search_app.rb
@@ -13,6 +13,7 @@ class SearchApp < App
                   :garbagecollectioninterval => :garbagecollectioninterval,
                   :doc_type => :doc_type,
                   :threads_per_search => :threads_per_search,
+                  :allowedlidbloat => :allowedlidbloat,
                   :num_summary_threads => :num_summary_threads,
                   :initialize_threads => :initialize_threads,
                   :hwinfo_disk_writespeed => :hwinfo_disk_writespeed,

--- a/lib/app_generator/search_app.rb
+++ b/lib/app_generator/search_app.rb
@@ -13,7 +13,7 @@ class SearchApp < App
                   :garbagecollectioninterval => :garbagecollectioninterval,
                   :doc_type => :doc_type,
                   :threads_per_search => :threads_per_search,
-                  :allowedlidbloat => :allowedlidbloat,
+                  :allowed_lid_bloat => :allowed_lid_bloat,
                   :num_summary_threads => :num_summary_threads,
                   :initialize_threads => :initialize_threads,
                   :hwinfo_disk_writespeed => :hwinfo_disk_writespeed,

--- a/lib/app_generator/search_cluster.rb
+++ b/lib/app_generator/search_cluster.rb
@@ -19,7 +19,7 @@ class SearchCluster
   chained_setter :garbagecollection
   chained_setter :garbagecollectioninterval
   chained_setter :threads_per_search
-  chained_setter :allowedlidbloat
+  chained_setter :allowed_lid_bloat
   chained_setter :num_summary_threads
   chained_setter :initialize_threads
   chained_setter :hwinfo_disk_writespeed
@@ -65,7 +65,7 @@ class SearchCluster
     @garbagecollection = nil
     @garbagecollectioninterval = nil
     @threads_per_search = 4
-    @allowedlidbloat = 100
+    @allowed_lid_bloat = 100
     @num_summary_threads = nil
     @initialize_threads = 16
     @dispatch = nil
@@ -145,7 +145,7 @@ class SearchCluster
     proton.add("numthreadspersearch", @threads_per_search)
     proton.add("numsummarythreads", @num_summary_threads) if @num_summary_threads != nil
     proton.add("initialize", ConfigValue.new("threads", @initialize_threads))
-    proton.add("lidspacecompaction", ConfigValue.new("allowedlidbloat", @allowedlidbloat))
+    proton.add("lidspacecompaction", ConfigValue.new("allowedlidbloat", @allowed_lid_bloat))
     if @hwinfo_disk_shared || !@hwinfo_disk_writespeed.nil?
       values = ConfigValues.new
       if @hwinfo_disk_shared

--- a/lib/app_generator/search_cluster.rb
+++ b/lib/app_generator/search_cluster.rb
@@ -19,6 +19,7 @@ class SearchCluster
   chained_setter :garbagecollection
   chained_setter :garbagecollectioninterval
   chained_setter :threads_per_search
+  chained_setter :allowedlidbloat
   chained_setter :num_summary_threads
   chained_setter :initialize_threads
   chained_setter :hwinfo_disk_writespeed
@@ -64,6 +65,7 @@ class SearchCluster
     @garbagecollection = nil
     @garbagecollectioninterval = nil
     @threads_per_search = 4
+    @allowedlidbloat = 100
     @num_summary_threads = nil
     @initialize_threads = 16
     @dispatch = nil
@@ -143,6 +145,7 @@ class SearchCluster
     proton.add("numthreadspersearch", @threads_per_search)
     proton.add("numsummarythreads", @num_summary_threads) if @num_summary_threads != nil
     proton.add("initialize", ConfigValue.new("threads", @initialize_threads))
+    proton.add("lidspacecompaction", ConfigValue.new("allowedlidbloat", @allowedlidbloat))
     if @hwinfo_disk_shared || !@hwinfo_disk_writespeed.nil?
       values = ConfigValues.new
       if @hwinfo_disk_shared

--- a/lib/app_generator/test/complex_elastic.xml
+++ b/lib/app_generator/test/complex_elastic.xml
@@ -28,6 +28,9 @@
       <initialize>
         <threads>16</threads>
       </initialize>
+      <lidspacecompaction>
+        <allowedlidbloat>100</allowedlidbloat>
+      </lidspacecompaction>
       <hwinfo>
         <disk>
           <shared>true</shared>

--- a/lib/app_generator/test/default_elastic.xml
+++ b/lib/app_generator/test/default_elastic.xml
@@ -25,6 +25,9 @@
       <initialize>
         <threads>16</threads>
       </initialize>
+      <lidspacecompaction>
+        <allowedlidbloat>100</allowedlidbloat>
+      </lidspacecompaction>
       <hwinfo>
         <disk>
           <shared>true</shared>

--- a/lib/app_generator/test/default_streaming.xml
+++ b/lib/app_generator/test/default_streaming.xml
@@ -25,6 +25,9 @@
       <initialize>
         <threads>16</threads>
       </initialize>
+      <lidspacecompaction>
+        <allowedlidbloat>100</allowedlidbloat>
+      </lidspacecompaction>
       <hwinfo>
         <disk>
           <shared>true</shared>

--- a/lib/app_generator/test/docproc_and_search_in_same_container.xml
+++ b/lib/app_generator/test/docproc_and_search_in_same_container.xml
@@ -28,6 +28,9 @@
       <initialize>
         <threads>16</threads>
       </initialize>
+      <lidspacecompaction>
+        <allowedlidbloat>100</allowedlidbloat>
+      </lidspacecompaction>
       <hwinfo>
         <disk>
           <shared>true</shared>

--- a/lib/app_generator/test/processing_and_search_in_same_container.xml
+++ b/lib/app_generator/test/processing_and_search_in_same_container.xml
@@ -28,6 +28,9 @@
       <initialize>
         <threads>16</threads>
       </initialize>
+      <lidspacecompaction>
+        <allowedlidbloat>100</allowedlidbloat>
+      </lidspacecompaction>
       <hwinfo>
         <disk>
           <shared>true</shared>

--- a/lib/app_generator/test/test.rb
+++ b/lib/app_generator/test/test.rb
@@ -134,7 +134,7 @@ class SearchAppGenTest < Test::Unit::TestCase
                      visibility_delay(5).selection("doc_sel").
                      flush_on_shutdown(true).
                      use_local_node(true).
-                     redundancy(3).ready_copies(2).num_parts(3).threads_per_search(2).allowedlidbloat(3)).
+                     redundancy(3).ready_copies(2).num_parts(3).threads_per_search(2).allowed_lid_bloat(3)).
              services_xml
 
     expected_substr = '

--- a/lib/app_generator/test/test.rb
+++ b/lib/app_generator/test/test.rb
@@ -134,7 +134,7 @@ class SearchAppGenTest < Test::Unit::TestCase
                      visibility_delay(5).selection("doc_sel").
                      flush_on_shutdown(true).
                      use_local_node(true).
-                     redundancy(3).ready_copies(2).num_parts(3).threads_per_search(2)).
+                     redundancy(3).ready_copies(2).num_parts(3).threads_per_search(2).allowedlidbloat(3)).
              services_xml
 
     expected_substr = '
@@ -150,6 +150,9 @@ class SearchAppGenTest < Test::Unit::TestCase
           <initialize>
             <threads>16</threads>
           </initialize>
+          <lidspacecompaction>
+            <allowedlidbloat>3</allowedlidbloat>
+          </lidspacecompaction>
           <hwinfo>
             <disk>
               <shared>true</shared>

--- a/tests/performance/lid_space_compaction/lid_space_compaction.rb
+++ b/tests/performance/lid_space_compaction/lid_space_compaction.rb
@@ -30,6 +30,7 @@ class LidSpaceCompactionPerfTest < PerformanceTest
 
   def get_app(lid_bloat_factor = 0.2)
     SearchApp.new.cluster(SearchCluster.new.sd(selfdir + "test.sd").
+                          allowedlidbloat(10).
                           config(ConfigOverride.new("vespa.config.search.core.proton").
                                  add("maintenancejobs", ConfigValues.new.
                                      add("maxoutstandingmoveops", 100)).
@@ -38,7 +39,6 @@ class LidSpaceCompactionPerfTest < PerformanceTest
                                          add("io", "NORMAL"))).
                                  add("lidspacecompaction", ConfigValues.new.
                                      add("interval", 2.0).
-                                     add("allowedlidbloat", 10).
                                      add("allowedlidbloatfactor", lid_bloat_factor)))).
                           search_dir(selfdir + "app")
   end

--- a/tests/performance/lid_space_compaction/lid_space_compaction.rb
+++ b/tests/performance/lid_space_compaction/lid_space_compaction.rb
@@ -30,7 +30,7 @@ class LidSpaceCompactionPerfTest < PerformanceTest
 
   def get_app(lid_bloat_factor = 0.2)
     SearchApp.new.cluster(SearchCluster.new.sd(selfdir + "test.sd").
-                          allowedlidbloat(10).
+                          allowed_lid_bloat(10).
                           config(ConfigOverride.new("vespa.config.search.core.proton").
                                  add("maintenancejobs", ConfigValues.new.
                                      add("maxoutstandingmoveops", 100)).

--- a/tests/search/lid_space_compaction/lid_space_compaction.rb
+++ b/tests/search/lid_space_compaction/lid_space_compaction.rb
@@ -230,9 +230,7 @@ class LidSpaceCompactionTest < SearchTest
 
   def test_lid_usage_metrics
     set_description("Test that document meta store metrics regarding lid usage is updated and reported")
-    deploy_app(SearchApp.new.
-               cluster(SearchCluster.new.sd(SEARCH_DATA + "test.sd")).
-               allowedlidbloat(1000))
+    deploy_app(SearchApp.new.sd(SEARCH_DATA + "test.sd").allowedlidbloat(1000))
     start
     feed_puts(0, 400, true)
     assert_corpus_hitcount(400)

--- a/tests/search/lid_space_compaction/lid_space_compaction.rb
+++ b/tests/search/lid_space_compaction/lid_space_compaction.rb
@@ -24,10 +24,10 @@ class LidSpaceCompactionTest < SearchTest
 
   def get_app(lid_bloat_factor = 0.2, two_nodes = false, disable_flush = false)
     cluster = SearchCluster.new.sd(SEARCH_DATA + "test.sd").
+      allowedlidbloat(1).
       config(ConfigOverride.new("vespa.config.search.core.proton").
              add("lidspacecompaction", ConfigValues.new.
                  add("interval", 2.0).
-                 add("allowedlidbloat", 1).
                  add("allowedlidbloatfactor", lid_bloat_factor))).
       tune_searchnode({:resizing => {:'amortize-count' => 0}})
     cluster.disable_flush_tuning if disable_flush
@@ -231,10 +231,8 @@ class LidSpaceCompactionTest < SearchTest
   def test_lid_usage_metrics
     set_description("Test that document meta store metrics regarding lid usage is updated and reported")
     deploy_app(SearchApp.new.
-               cluster(SearchCluster.new.sd(SEARCH_DATA + "test.sd").
-                       config(ConfigOverride.new("vespa.config.search.core.proton").
-                              add("lidspacecompaction", ConfigValues.new.
-                                  add("allowedlidbloat", 1000)))))
+               cluster(SearchCluster.new.sd(SEARCH_DATA + "test.sd")).
+               allowedlidbloat(1000))
     start
     feed_puts(0, 400, true)
     assert_corpus_hitcount(400)

--- a/tests/search/lid_space_compaction/lid_space_compaction.rb
+++ b/tests/search/lid_space_compaction/lid_space_compaction.rb
@@ -24,7 +24,7 @@ class LidSpaceCompactionTest < SearchTest
 
   def get_app(lid_bloat_factor = 0.2, two_nodes = false, disable_flush = false)
     cluster = SearchCluster.new.sd(SEARCH_DATA + "test.sd").
-      allowedlidbloat(1).
+      allowed_lid_bloat(1).
       config(ConfigOverride.new("vespa.config.search.core.proton").
              add("lidspacecompaction", ConfigValues.new.
                  add("interval", 2.0).
@@ -230,7 +230,7 @@ class LidSpaceCompactionTest < SearchTest
 
   def test_lid_usage_metrics
     set_description("Test that document meta store metrics regarding lid usage is updated and reported")
-    deploy_app(SearchApp.new.sd(SEARCH_DATA + "test.sd").allowedlidbloat(1000))
+    deploy_app(SearchApp.new.sd(SEARCH_DATA + "test.sd").allowed_lid_bloat(1000))
     start
     feed_puts(0, 400, true)
     assert_corpus_hitcount(400)


### PR DESCRIPTION
… corpus sizes during tests.

@geirst PR