### PR TITLE
Use faster wand searcher for testing hash lookup performance.

### DIFF
--- a/tests/performance/lookup/lookup.rb
+++ b/tests/performance/lookup/lookup.rb
@@ -62,15 +62,14 @@ class LookupPerformance < PerformanceTest
     assert_hitcount("sddocname:test", num_docs)
 
     @queryfile = "#{dirs.tmpdir}/query.txt"
-    container.execute("#{dirs.tmpdir}/query #{num_queries} #{keys_per_query} #{upper_limit} f1 > #{dirs.tmpdir}/query.txt")
+    container.execute("#{dirs.tmpdir}/query #{num_queries} #{keys_per_query} #{upper_limit} > #{@queryfile}")
     run_fbench(container, 8, 20)
     restart_proton("test", num_docs)
 
     ["f1", "f1_hash"].each do |field|
-        @queryfile = "#{dirs.tmpdir}/q.#{field}.txt"
-        container.execute("#{dirs.tmpdir}/query #{num_queries} #{keys_per_query} #{upper_limit} #{field} > #{@queryfile}")
         profiler_start
-        run_fbench(container, num_clients, 60, [parameter_filler('legend', "lookup_#{field}")], {:single_query_file => true})
+        run_fbench(container, num_clients, 60, [parameter_filler('legend', "lookup_#{field}")],
+                   {:single_query_file => true, :append_str => "&hits=1&summary=minimal&ranking=unranked&wand.type=dotProduct&wand.field=#{field}"})
         profiler_report("lookup_#{field}")
     end
   end

--- a/tests/performance/lookup/query.cpp
+++ b/tests/performance/lookup/query.cpp
@@ -6,14 +6,13 @@
 #include <sstream>
 
 void
-query(const char * field, unsigned int keys_per_query, unsigned long upper_limit) {
+query(unsigned int keys_per_query, unsigned long upper_limit) {
     std::ostringstream keys;
-    keys << "%22" << (rand()%upper_limit) << "%22%3A1";
+    keys << (rand()%upper_limit) << "%3A1";
     for (unsigned int i(1); i < keys_per_query; i++) {
-        keys << ",%22" << (rand()%upper_limit) << "%22%3A1";
+        keys << "," << (rand()%upper_limit) << "%3A1";
     }
-    const char * queryPrefix = "/search/?summary=minimal&ranking=unranked&hits=1&yql=select%20*%20from%20sources%20*%20where%20weightedSet";
-    printf("%s(%s,%7B%s%7D)%3B\n", queryPrefix, field, keys.str().c_str());
+    printf("/search/?wand.tokens=%7B%s%7D\n", keys.str().c_str());
 }
 
 int
@@ -21,10 +20,9 @@ main(int argc, char **argv) {
     long numQueries = atoi(argv[1]);
     long keys_per_query = atoi(argv[2]);
     long upper_limit = atoi(argv[3]);
-    const char * field = argv[4];
     srand(1);
     for (long i = 0; i < numQueries; i++) {
-        query(field, keys_per_query, upper_limit);
+        query(keys_per_query, upper_limit);
     }
     return 0;
 }


### PR DESCRIPTION
iYql is too costly for this use.

@toregge or @geirst PR