### PR TITLE
Revert "Double timeout to try to stabilize test"

### DIFF
--- a/tests/vds/multinode/clustercontroller_multinode.rb
+++ b/tests/vds/multinode/clustercontroller_multinode.rb
@@ -54,7 +54,7 @@ class ClusterControllerMultiNodeTest < VdsTest
     puts "[progress] #{@four} DEPLOYED"
   end
 
-  def verify_node_count(count, timeout = 120)
+  def verify_node_count(count, timeout = 60)
     current = nil
     timeout.times { |i|
         page = vespa.clustercontrollers["0"].get_status_page("/cluster/v2/storage/storage")


### PR DESCRIPTION
Reverts vespa-engine/system-test#1450

Real issue fixed in https://github.com/vespa-engine/vespa/pull/17215