### PR TITLE
Remove 'none' from expected message

### DIFF
--- a/tests/search/uselocalnode/uselocalnode.rb
+++ b/tests/search/uselocalnode/uselocalnode.rb
@@ -1,4 +1,4 @@
-# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 require 'search_test'
 
 class UseLocalNodeTest < SearchTest
@@ -32,7 +32,7 @@ class UseLocalNodeTest < SearchTest
       host= container.name
       r=container.search("/search/?query=sddocname:music&nocache&hits=0")
     end
-    matches = wait_for_atleast_log_matches(/Cluster dispatcher.search: group 0 has reduced coverage: Active documents: 0\/0, working nodes: 0\/1 required 1, unresponsive nodes: none/, 2, 120, {:multinode => true})
+    matches = wait_for_atleast_log_matches(/Cluster dispatcher.search: group 0 has reduced coverage: Active documents: 0\/0, working nodes: 0\/1 required 1, unresponsive nodes:/, 2, 120, {:multinode => true})
     assert(matches <= 6, "The test should see 2 to 6 reports for group 0 coverage, saw #{matches}")
   end
 


### PR DESCRIPTION
There was no 'none' in expected message before
https://github.com/vespa-engine/system-test/pull/1502 and code seems
to have a newline just before nodes or 'none' is added anyway.

Actual log message found in test run:

Cluster dispatcher.search: group 0 has reduced coverage: Active documents: 0/0, working nodes: 0/1 required 1, unresponsive nodes: 
search node key = 0 hostname = eea08fbd.systemtest.vespa-vespa-factory.gq2.ows.oath.cloud path = 0 in group 0 statusIsKnown = true working = false activeDocs = 0

