### PR TITLE
Dump status page to help understand why resume completes immediately

### DIFF
--- a/lib/vespa_model.rb
+++ b/lib/vespa_model.rb
@@ -62,12 +62,12 @@ class VespaModel
     return @storage[cluster].storage[index.to_s]
   end
 
-  def stop_content_node(cluster, index, wait_timeout = 60)
+  def stop_content_node(cluster, index, wait_timeout = 60, states = 'dm')
     content_node(cluster, index).stop
 
     if wait_timeout != 0
       wait_timeout *= 10 if @testcase.valgrind
-      @storage[cluster].wait_for_current_node_state("storage", index.to_i, 'sdm', wait_timeout)
+      @storage[cluster].wait_for_current_node_state("storage", index.to_i, states, wait_timeout)
     end
   end
 

--- a/tests/cloudconfig/orchestrator/orch_cluster.rb
+++ b/tests/cloudconfig/orchestrator/orch_cluster.rb
@@ -241,9 +241,7 @@ class OrchestratorContainerClusterTest < CloudConfigTest
 
     start_content_app
     stop_wait_timeout = 600
-    @vespa.stop_content_node("music", 0, stop_wait_timeout)
-    # give the cluster controller time to see the content node as DOWN
-    sleep(30)
+    @vespa.stop_content_node("music", 0, stop_wait_timeout, 'd')
 
     assert_response_code(orch_suspend(@contentD), 409)
     assert_response_code(orch_suspend(@contentE), 409)
@@ -258,13 +256,26 @@ class OrchestratorContainerClusterTest < CloudConfigTest
     assert_host(@contentD, UP)
     assert_host(@contentE, UP)
     
+    # We dump the content cluster's status page in the cluster controller to
+    # help debugging why 'resume' completes immediately below.
+    # TODO(hakon): Remove these dumps once figured out.
+    dump_status_page
+
     wait_until_up = false
     @vespa.start_content_node("music", 0, 60, wait_until_up)
 
+    dump_status_page
+
     assert_response_code(orch_resume_until_no_conflict(@contentC))
+
+    dump_status_page
 
     assert_host(@contentC, UP)
 
     assert_instance(@all_up)
+  end
+
+  def dump_status_page
+    puts @vespa.clustercontrollers["0"].get_status_page("/clustercontroller-status/v1/music")
   end
 end


### PR DESCRIPTION
Also, test_upgrade_of_downed_node waits until the state is 'down', instead of
one of "sdm" and waiting 30s.

Also, when waiting for the cluster controller to ack a storage node being
stopped, we used to wait until the the node were in one of the states
'stopping', 'maintenance', or 'down'.  However a storage node in 'stopping' is
a transitional state that starts with the node behaving as-if 'up', which the
client probably does not want.  Therefore 'stopping' is removed from this set.