### PR TITLE
Use explicit 0 distributor stripes as baseline for tests running with…

### DIFF
--- a/tests/search/bucketactivation/bucketactivation.rb
+++ b/tests/search/bucketactivation/bucketactivation.rb
@@ -34,7 +34,7 @@ class BucketActivationTest < SearchTest
     set_description("Test basic searching with bucket activation")
     deploy_app(SearchApp.new.sd(SEARCH_DATA+"music.sd").
                search_type("ELASTIC").cluster_name("mycluster").num_parts(4).redundancy(2).
-               storage(StorageCluster.new("mycluster", 4).distribution_bits(16)))
+               storage(StorageCluster.new("mycluster", 4).distribution_bits(16).num_distributor_stripes(0)))
     run_bucket_activation_test
   end
 

--- a/tests/search/stableactivecount/stableactivecount.rb
+++ b/tests/search/stableactivecount/stableactivecount.rb
@@ -24,7 +24,7 @@ class StableActiveCount < SearchTest
     60*20
   end
 
-  def create_app(num_stripes = nil)
+  def create_app(num_stripes = 0)
     SearchApp.new.sd(selfdir+'test.sd').
       search_type("ELASTIC").
       cluster_name("mycluster").

--- a/tests/vds/merging.rb
+++ b/tests/vds/merging.rb
@@ -16,7 +16,7 @@ class MergingTest < PersistentProviderTest
   end
 
   def test_merging
-    deploy_app(default_app.num_nodes(2).redundancy(2))
+    deploy_app(default_app.num_nodes(2).redundancy(2).num_distributor_stripes(0))
     run_merging_test
   end
 


### PR DESCRIPTION
… both legacy and new mode.

@toregge please review
@vekterli FYI