### PR TITLE
Suspend until success

### DIFF
--- a/tests/cloudconfig/orchestrator/orch_cluster.rb
+++ b/tests/cloudconfig/orchestrator/orch_cluster.rb
@@ -246,7 +246,9 @@ class OrchestratorContainerClusterTest < CloudConfigTest
     assert_response_code(orch_suspend(@contentD), 409)
     assert_response_code(orch_suspend(@contentE), 409)
 
-    assert_response_code(orch_suspend(@contentC))
+    # The first suspend may not complete without timeouts (observed with slow
+    # system test nodes), therefore retry until success.
+    assert_response_code(orch_suspend_until_no_conflict(@contentC))
 
     c_allowed_down = @all_up.clone
     c_allowed_down[@contentC] = DOWN

--- a/tests/cloudconfig/orchestrator/orch_cluster.rb
+++ b/tests/cloudconfig/orchestrator/orch_cluster.rb
@@ -248,6 +248,7 @@ class OrchestratorContainerClusterTest < CloudConfigTest
 
     # The first suspend may not complete without timeouts (observed with slow
     # system test nodes), therefore retry until success.
+    dump_status_page
     assert_response_code(orch_suspend_until_no_conflict(@contentC))
 
     c_allowed_down = @all_up.clone


### PR DESCRIPTION
When actually asking the CC for suspension (https://github.com/vespa-engine/vespa/pull/17854), the suspend of the node with the downed storage node failed due to 409
```
{
  "hostname" : "aa720a43.systemtest.vespa-vespa-factory.gq2.ows.oath.cloud",
  "reason" : {
    "constraint" : "controller-set-node-state",
    "message" : "suspend failed: Changing the state of aa720a43.systemtest.vespa-vespa-factory.gq2.ows.oath.cloud would violate controller-set-node-state: Failure from cluster controllers [c02476e5.systemtest.vespa-vespa-factory.gq2.ows.oath.cloud] when setting node 0 in cluster music to state MAINTENANCE: Task exceeded its version wait deadline: the following nodes have not converged to at least version 6: distributor.0, distributor.1, distributor.2, storage.0, storage.1, storage.2"
  }
}
```

The typical deadline is just short of 10s I believe, and I guess this is too short on the system test nodes!?

This may also happen in real production environment, and in case the host admin will retry.  So the test is changed to retry until success or 10m timeout.