### PR TITLE
Reapply "Disable new performance test that does not complete."

### DIFF
--- a/tests/performance/programmatic_feed_client/programmatic_feed_client.rb
+++ b/tests/performance/programmatic_feed_client/programmatic_feed_client.rb
@@ -80,7 +80,7 @@ class ProgrammaticFeedClientTest < PerformanceTest
     ]
   end
 
-  def test_throughput
+  def fest_throughput
     container_node = deploy_test_app
     build_feed_client
 


### PR DESCRIPTION
Reverts vespa-engine/system-test#1656

Still times out after 1800 seconds