### PR TITLE
Reduce slack for max hits. Worst outliers are now ignored (due to them

### DIFF
--- a/tests/search/resize/resizebase.rb
+++ b/tests/search/resize/resizebase.rb
@@ -19,7 +19,7 @@ module ResizeApps
       @num_hosts = num_hosts
       @sps = sps
       @slack_minhits = 200
-      @slack_maxdocs_per_group = 1500
+      @slack_maxdocs_per_group = 800
       assert(num_hosts == 1 || num_hosts == 2 || num_hosts >= nodes)
     end
 
@@ -77,7 +77,7 @@ module ResizeApps
     end
 
     def slack_maxhits
-      1500
+      150
     end
 
     def slack_mindocs
@@ -174,7 +174,7 @@ module ResizeApps
     end
 
     def slack_maxhits
-      1500
+      500
     end
 
     def slack_mindocs
@@ -304,7 +304,7 @@ module ResizeApps
     end
 
     def slack_maxhits
-      1500
+      500
     end
 
     def slack_mindocs


### PR DESCRIPTION
being caused by slow poll results).

Reduce slack for max docs for same reason.

@geirst : please review
