### PR TITLE
Wait longer

### DIFF
--- a/tests/search/auto_oos/auto_oos.rb
+++ b/tests/search/auto_oos/auto_oos.rb
@@ -63,7 +63,7 @@ class AutomaticOutOfServiceTest < SearchTest
     assert_nothing_raised() { 
       got = "nothing good"
       trynum = 0
-      while ((trynum < 60) && (got != expected_response_code)) do
+      while ((trynum < 120) && (got != expected_response_code)) do
         trynum += 1
         sleep 1
         response = https_client.get(s_name, s_port, path)

--- a/tests/search/checkautorestart/checkautorestart.rb
+++ b/tests/search/checkautorestart/checkautorestart.rb
@@ -27,7 +27,7 @@ class CheckAutoRestart < SearchTest
   end
 
   def check_new_pids(app)
-    limit = 30
+    limit = 60
     start = Time.now.to_i
     pids = Hash.new
     while (Time.now.to_i - start < limit)

--- a/tests/search/schemachanges/schemachanges_need_refeed_reconfig.rb
+++ b/tests/search/schemachanges/schemachanges_need_refeed_reconfig.rb
@@ -122,10 +122,10 @@ class SchemaChangesNeedRefeedReconfigTest < IndexedSearchTest
   # Wait for convergence of all services in the application — specifically document processors 
   def wait_for_convergence(generation)
     start_time = Time.now
-    until get_json(http_request(URI(application_url + "serviceconverge"), {}))["converged"] or Time.now - start_time > 60 # seconds
+    until get_json(http_request(URI(application_url + "serviceconverge"), {}))["converged"] or Time.now - start_time > 120 # seconds
       sleep 1
     end
-    assert(Time.now - start_time < 60, "Services should converge on new generation within the minute")
+    assert(Time.now - start_time < 120, "Services should converge on new generation within the minute")
     assert(generation == get_json(http_request(URI(application_url + "serviceconverge"), {}))["wantedGeneration"],
            "Should converge on generation #{generation}")
     puts "Services converged on new config generation after #{Time.now - start_time} seconds"


### PR DESCRIPTION
Adjust so running with less resources (as we do for opensource runs) works better

