### PR TITLE
Write VESPA_TLS_CONFIG_FILE to conf/vespa/default-env.txt

### DIFF
--- a/lib/default_env_file.rb
+++ b/lib/default_env_file.rb
@@ -5,6 +5,8 @@ require 'thread'
 
 class DefaultEnvFile
 
+  attr_reader :file_name
+
   def initialize(vespa_home)
     @file_name = "#{vespa_home}/conf/vespa/default-env.txt"
     @file_name_orig = "#{@file_name}.orig"

--- a/lib/tls_env.rb
+++ b/lib/tls_env.rb
@@ -6,6 +6,7 @@ require 'json'
 class TlsEnv
 
   CONFIG_FILE_ENV_VAR = 'VESPA_TLS_CONFIG_FILE'
+  DISABLE_TLS_ENV_VAR = 'VESPA_FACTORY_SYSTEMTESTS_DISABLE_TLS'
 
   attr_reader :ssl_ctx, :ca_certificates_file, :certificate_file, :private_key_file
 
@@ -47,7 +48,7 @@ class TlsEnv
 
   private
   def generate_tls_config_if_missing
-    unless ENV[CONFIG_FILE_ENV_VAR] or ENV['VESPA_FACTORY_SYSTEMTESTS_DISABLE_TLS']
+    unless ENV[CONFIG_FILE_ENV_VAR] or ENV[DISABLE_TLS_ENV_VAR]
       ssl_config = SslConfig.new(cert_path: :default)
       ssl_config.auto_create_keys_if_required
       tls_config_file = ssl_config.cert_file('tls-config.json')
@@ -73,9 +74,11 @@ class TlsEnv
   private
   def write_tls_config_path_to_default_env_if_present
     tls_config_file = ENV[CONFIG_FILE_ENV_VAR]
-    unless tls_config_file.nil? or not File.exist?(tls_config_file)
-      default_env_file = DefaultEnvFile.new(Environment.instance.vespa_home)
+    default_env_file = DefaultEnvFile.new(Environment.instance.vespa_home)
+    if tls_config_file and File.exist?(tls_config_file) and not ENV[DISABLE_TLS_ENV_VAR]
       default_env_file.set(CONFIG_FILE_ENV_VAR, tls_config_file)
+    else
+      default_env_file.set(CONFIG_FILE_ENV_VAR, nil)
     end
   end
 

--- a/lib/tls_env.rb
+++ b/lib/tls_env.rb
@@ -75,10 +75,12 @@ class TlsEnv
   def write_tls_config_path_to_default_env_if_present
     tls_config_file = ENV[CONFIG_FILE_ENV_VAR]
     default_env_file = DefaultEnvFile.new(Environment.instance.vespa_home)
-    if tls_config_file and File.exist?(tls_config_file) and not ENV[DISABLE_TLS_ENV_VAR]
-      default_env_file.set(CONFIG_FILE_ENV_VAR, tls_config_file)
-    else
-      default_env_file.set(CONFIG_FILE_ENV_VAR, nil)
+    if File.exists?(default_env_file.file_name)
+      if tls_config_file and File.exist?(tls_config_file) and not ENV[DISABLE_TLS_ENV_VAR]
+        default_env_file.set(CONFIG_FILE_ENV_VAR, tls_config_file)
+      else
+        default_env_file.set(CONFIG_FILE_ENV_VAR, nil)
+      end
     end
   end
 

--- a/lib/tls_env.rb
+++ b/lib/tls_env.rb
@@ -5,6 +5,8 @@ require 'json'
 
 class TlsEnv
 
+  CONFIG_FILE_ENV_VAR = 'VESPA_TLS_CONFIG_FILE'
+
   attr_reader :ssl_ctx, :ca_certificates_file, :certificate_file, :private_key_file
 
   def initialize
@@ -13,6 +15,7 @@ class TlsEnv
     @debug_print = false
 
     generate_tls_config_if_missing
+    write_tls_config_path_to_default_env_if_present
     get_openssl_ctx_from_env_or_nil
   end
 
@@ -44,7 +47,7 @@ class TlsEnv
 
   private
   def generate_tls_config_if_missing
-    unless ENV['VESPA_TLS_CONFIG_FILE'] or ENV['VESPA_FACTORY_SYSTEMTESTS_DISABLE_TLS']
+    unless ENV[CONFIG_FILE_ENV_VAR] or ENV['VESPA_FACTORY_SYSTEMTESTS_DISABLE_TLS']
       ssl_config = SslConfig.new(cert_path: :default)
       ssl_config.auto_create_keys_if_required
       tls_config_file = ssl_config.cert_file('tls-config.json')
@@ -63,13 +66,22 @@ class TlsEnv
       end
       FileUtils.chown(ssl_config.user, nil, tls_config_file)
       puts "Environment variable VESPA_TLS_CONFIG_FILE is not assigned, setting it to #{tls_config_file}."
-      ENV['VESPA_TLS_CONFIG_FILE'] = tls_config_file
+      ENV[CONFIG_FILE_ENV_VAR] = tls_config_file
+    end
+  end
+
+  private
+  def write_tls_config_path_to_default_env_if_present
+    tls_config_file = ENV[CONFIG_FILE_ENV_VAR]
+    unless tls_config_file.nil? or not File.exist?(tls_config_file)
+      default_env_file = DefaultEnvFile.new(Environment.instance.vespa_home)
+      default_env_file.set(CONFIG_FILE_ENV_VAR, tls_config_file)
     end
   end
 
   private
   def get_openssl_ctx_from_env_or_nil
-    cfg_file = ENV['VESPA_TLS_CONFIG_FILE']
+    cfg_file = ENV[CONFIG_FILE_ENV_VAR]
     mode = ENV['VESPA_TLS_INSECURE_MIXED_MODE']
     if not cfg_file or mode == 'plaintext_client_mixed_server'
       puts 'Warning: Vespa TLS is not configured, continuing with insecure connections.'


### PR DESCRIPTION
Storing the value of VESPA_TLS_CONFIG_FILE to default-env.txt makes it
easier to run Vespa CLI utilities manually. Specifying the environment
variable manually will no longer be necessary.

FYI @geirst 
