### PR TITLE
Revert "Write VESPA_TLS_CONFIG_FILE to conf/vespa/default-env.txt"

### DIFF
--- a/lib/default_env_file.rb
+++ b/lib/default_env_file.rb
@@ -5,8 +5,6 @@ require 'thread'
 
 class DefaultEnvFile
 
-  attr_reader :file_name
-
   def initialize(vespa_home)
     @file_name = "#{vespa_home}/conf/vespa/default-env.txt"
     @file_name_orig = "#{@file_name}.orig"


### PR DESCRIPTION
Reverts vespa-engine/system-test#1855

Test run failed with:

 14:03:09 [2021-08-25 14:03:09 +0000] ERROR: Testrun failed, marking as aborted:
14:03:09 Permission denied @ rb_sysopen - /opt/vespa/conf/vespa/default-env.txt.new: 