### PR TITLE
Wait until content nodes have new config before calling wait_until_ready

### DIFF
--- a/tests/search/bucketactivation/inhibit_minority_bucket_state_activation.rb
+++ b/tests/search/bucketactivation/inhibit_minority_bucket_state_activation.rb
@@ -60,7 +60,9 @@ class InhibitMinorityBucketStateActivationTest < SearchTest
     assert_group_hitcount(1, 'bar', 0)
 
     # Once merges complete and replicas are in sync, all replicas should be active.
-    deploy_app(make_app(disable_merges: false))
+    gen = get_generation(deploy_app(make_app(disable_merges: false)))
+    # Ensure that config is visible on nodes (and triggering ideal state ops) before running wait_until_ready
+    vespa.storage['storage'].wait_until_content_nodes_have_config_generation(gen.to_i)
     wait_until_ready
     vespa.adminserver.execute('vespa-stat --document id:test:test::doc-0')
     assert_group_hitcount(0, 'bar', 20)

--- a/tests/search/inconsistent_replicas/disjoint_source_only_documents.rb
+++ b/tests/search/inconsistent_replicas/disjoint_source_only_documents.rb
@@ -53,7 +53,9 @@ class DisjointSourceOnlyDocuments < SearchTest
     set_content_node_state(1, 'r')
     set_content_node_state(2, 'r')
 
-    deploy_app(make_app(disable_merges: false))
+    gen = get_generation(deploy_app(make_app(disable_merges: false)))
+    # Ensure that config is visible on nodes (and triggering ideal state ops) before running wait_until_ready
+    cluster.wait_until_content_nodes_have_config_generation(gen.to_i)
     cluster.wait_until_ready(200)
 
     puts "Checking that cluster contains #{n_docs} docs..."


### PR DESCRIPTION
These tests became unstable when doing some config protocol changes (that probably changed how fast config was updated for nodes). 

Taken from tests/vds/join_sparse_buckets/join_sparse_buckets.rb, which probably had the same issue at some time