### PR TITLE
Wait until content nodes have new config before calling wait_until_ready

### DIFF
--- a/tests/search/inconsistent_replicas/visibility_for_deleted_document_in_inconsistent_buckets.rb
+++ b/tests/search/inconsistent_replicas/visibility_for_deleted_document_in_inconsistent_buckets.rb
@@ -35,9 +35,11 @@ class VisibilityForDeletedDocumentsInInconsistentBucketsTest < InconsistentBucke
     dump_bucket_contents
 
     puts_decorated 'Unblocking merges to allow remove-entries to be merged'
-    deploy_app(make_app(three_phase_updates: @params[:enable_3phase],
-                        fast_restart: @params[:fast_restart],
-                        disable_merges: false))
+    gen = get_generation(deploy_app(make_app(three_phase_updates: @params[:enable_3phase],
+                                             fast_restart: @params[:fast_restart],
+                                             disable_merges: false)))
+    # Ensure that config is visible on nodes (and triggering ideal state ops) before running wait_until_ready
+    content_cluster.wait_until_content_nodes_have_config_generation(gen.to_i)
 
     puts_decorated 'Taking node 1 back up'
     mark_content_node_up(1)


### PR DESCRIPTION
One more test that need to wait, see https://github.com/vespa-engine/system-test/pull/1863