### PR TITLE
Remove tests that explicitly are running with multiple distributor st…

### DIFF
--- a/tests/search/basicsearch/basic_search.rb
+++ b/tests/search/basicsearch/basic_search.rb
@@ -29,21 +29,9 @@ class BasicSearch < IndexedSearchTest
     start_feed_and_check
   end
 
-  def test_basicsearch_with_multiple_distributor_stripes
-    # TODO STRIPE: Remove this test when new distributor stripe mode is default
-    deploy_app(SearchApp.new.
-               cluster_name("basicsearch").
-               sd(SEARCH_DATA+"music.sd").
-               storage(StorageCluster.new("basicsearch").num_distributor_stripes(4)))
-    start_feed_and_check
-  end
-
   def start_feed_and_check
     start
-    feed_and_check
-  end
 
-  def feed_and_check
     feed(:file => SEARCH_DATA+"music.10.json", :timeout => 240)
     wait_for_hitcount("query=sddocname:music", 10)
     assert_hitcount("query=country", 1)

--- a/tests/search/bucketactivation/bucketactivation.rb
+++ b/tests/search/bucketactivation/bucketactivation.rb
@@ -34,20 +34,8 @@ class BucketActivationTest < SearchTest
     set_description("Test basic searching with bucket activation")
     deploy_app(SearchApp.new.sd(SEARCH_DATA+"music.sd").
                search_type("ELASTIC").cluster_name("mycluster").num_parts(4).redundancy(2).
-               storage(StorageCluster.new("mycluster", 4).distribution_bits(16).num_distributor_stripes(0)))
-    run_bucket_activation_test
-  end
+               storage(StorageCluster.new("mycluster", 4).distribution_bits(16)))
 
-  def test_bucket_activation_with_multiple_distributor_stripes
-    # TODO STRIPE: Remove this test when new distributor stripe mode is default
-    set_description("Test basic searching with bucket activation (using 4 distributor stripes)")
-    deploy_app(SearchApp.new.sd(SEARCH_DATA+"music.sd").
-               search_type("ELASTIC").cluster_name("mycluster").num_parts(4).redundancy(2).
-               storage(StorageCluster.new("mycluster", 4).distribution_bits(16).num_distributor_stripes(4)))
-    run_bucket_activation_test
-  end
-
-  def run_bucket_activation_test
     start
     vespa.stop_content_node("mycluster", "3")
     vespa.stop_content_node("mycluster", "2")

--- a/tests/search/bucketreadiness/bucketreadiness_base.rb
+++ b/tests/search/bucketreadiness/bucketreadiness_base.rb
@@ -145,10 +145,10 @@ class BucketReadinessBase < SearchTest
     wait_for_hitcount(get_query(), exp_hitcount)
   end
 
-  def create_app(sd_file, num_distributor_stripes = nil)
+  def create_app(sd_file)
     SearchApp.new.sd(selfdir + sd_file).
       search_type("ELASTIC").cluster_name("mycluster").num_parts(4).redundancy(3).ready_copies(2).
-      storage(StorageCluster.new("mycluster", 4).distribution_bits(8).num_distributor_stripes(num_distributor_stripes))
+      storage(StorageCluster.new("mycluster", 4).distribution_bits(8))
   end
 
   def teardown

--- a/tests/search/bucketreadiness/bucketreadiness_visiting.rb
+++ b/tests/search/bucketreadiness/bucketreadiness_visiting.rb
@@ -33,8 +33,8 @@ class BucketReadiness < BucketReadinessBase
     end
   end
 
-  def create_app_for_visiting(num_distributor_stripes)
-    app = create_app("regular/test.sd", num_distributor_stripes)
+  def create_app_for_visiting
+    app = create_app("regular/test.sd")
     app.config(ConfigOverride.new("vespa.config.content.core.stor-distributormanager").
                add("maxpendingidealstateoperations", 10000000))
     app.config(ConfigOverride.new("vespa.config.content.core.stor-server").
@@ -46,18 +46,7 @@ class BucketReadiness < BucketReadinessBase
 
   def test_visiting_while_nodes_down_and_up
     set_description("Test that we can do visiting while nodes are going down and up")
-    deploy_app(create_app_for_visiting(0))
-    run_visiting_while_nodes_down_and_up_test
-  end
-
-  def test_visiting_while_nodes_down_and_up_using_multiple_distributor_stripes
-    # TODO STRIPE: Remove this test when new distributor stripe mode is default
-    set_description("Test that we can do visiting while nodes are going down and up (using multiple distributor stripes)")
-    deploy_app(create_app_for_visiting(4))
-    run_visiting_while_nodes_down_and_up_test
-  end
-
-  def run_visiting_while_nodes_down_and_up_test
+    deploy_app(create_app_for_visiting)
     start
 
     docs = 10000

--- a/tests/search/httpgateway/documentv1.rb
+++ b/tests/search/httpgateway/documentv1.rb
@@ -31,17 +31,8 @@ class DocumentV1Test < SearchTest
   end
 
   def test_realtimefeed
-    deploy_application(0)
-    run_realtimefeed_test
-  end
+    deploy_application
 
-  def test_realtimefeed_with_multiple_distributor_stripes
-    # TODO STRIPE: Remove this test when new distributor stripe mode is default
-    deploy_application(4)
-    run_realtimefeed_test
-  end
-
-  def run_realtimefeed_test
     # Has color yellow
     feedData = File.read(selfdir+"feedV1.json")
     # Changes to color red
@@ -287,11 +278,11 @@ class DocumentV1Test < SearchTest
     assert(verify_with_retries(http, {"PUT" => 3504, "UPDATE" => 3, "REMOVE" => 2}, {"PUT" => 4, "REMOVE" => 1}))
   end
 
-  def deploy_application(num_distributor_stripes = nil)
+  def deploy_application
     deploy_app(SearchApp.new.container(Container.new("node1").
                                        documentapi(ContainerDocumentApi.new)).
                cluster(SearchCluster.new("content").sd(selfdir+"banana.sd")).
-               storage(StorageCluster.new("content").num_distributor_stripes(num_distributor_stripes)).
+               storage(StorageCluster.new("content")).
                config(ConfigOverride.new("metrics.manager").add("reportPeriodSeconds", 3600)).
                monitoring("vespa", 300))
   end

--- a/tests/search/split_join_readiness/split_join_readiness.rb
+++ b/tests/search/split_join_readiness/split_join_readiness.rb
@@ -4,14 +4,13 @@ require 'json_document_writer'
 
 class SplitJoinReadinessTest < SearchTest
 
-  def create_app(split_count: 2, num_distributor_stripes: 0)
+  def create_app(split_count: 2)
     SearchApp.new.sd(SEARCH_DATA + 'test.sd').
       cluster_name("mycluster").
       num_parts(2).redundancy(2).ready_copies(1).
       storage(StorageCluster.new("mycluster", 2).
               distribution_bits(8).
-              bucket_split_count(split_count).
-              num_distributor_stripes(num_distributor_stripes))
+              bucket_split_count(split_count))
   end
 
   def setup
@@ -114,17 +113,6 @@ class SplitJoinReadinessTest < SearchTest
   def test_split_target_with_changed_ready_state_triggers_bucket_move
     set_description('Test that buckets split with altered ideal state are (de-)indexed as expected')
     deploy_app(create_app(split_count: 2))
-    run_test_split_target_with_changed_ready_state_triggers_bucket_move
-  end
-
-  def test_split_target_with_changed_ready_state_triggers_bucket_move_using_multiple_distributor_stripes
-    # TODO STRIPE: Remove this test when new distributor stripe mode is default
-    set_description('Test that buckets split with altered ideal state are (de-)indexed as expected (using 4 distributor stripe)')
-    deploy_app(create_app(split_count: 2, num_distributor_stripes: 4))
-    run_test_split_target_with_changed_ready_state_triggers_bucket_move
-  end
-
-  def run_test_split_target_with_changed_ready_state_triggers_bucket_move
     start
 
     enable_debug_logging if should_debug_log?

--- a/tests/search/stableactivecount/stableactivecount.rb
+++ b/tests/search/stableactivecount/stableactivecount.rb
@@ -24,14 +24,14 @@ class StableActiveCount < SearchTest
     60*20
   end
 
-  def create_app(num_stripes = 0)
+  def create_app
     SearchApp.new.sd(selfdir+'test.sd').
       search_type("ELASTIC").
       cluster_name("mycluster").
       num_parts(4).redundancy(2).ready_copies(2).
       storage(StorageCluster.new("mycluster", 4).
               distribution_bits(8).
-              bucket_split_count(5).num_distributor_stripes(num_stripes))
+              bucket_split_count(5))
   end
 
   class SearchRunner
@@ -135,16 +135,6 @@ class StableActiveCount < SearchTest
                     'merged across to other nodes.')
 
     deploy_app(create_app)
-    run_stable_active_count_test
-  end
-
-  def test_hitcount_stable_during_splitting_within_node_with_multiple_distributor_stripes
-    # TODO STRIPE: Remove this test when new distributor stripe mode is default
-    deploy_app(create_app(4))
-    run_stable_active_count_test
-  end
-
-  def run_stable_active_count_test
     start
 
     puts "Generating feed 1"

--- a/tests/vds/distributordown.rb
+++ b/tests/vds/distributordown.rb
@@ -55,11 +55,10 @@ class DistributorDown < MultiProviderStorageTest
            "docs to be reported by distributor #{index}")
   end
 
-  def create_app(num_distributor_stripes)
+  def create_app
     StorageApp.new.enable_http_gateway.storage_cluster(
               StorageCluster.new("storage").
               redundancy(2).
-              num_distributor_stripes(num_distributor_stripes).
               group(NodeGroup.new(0, "mycluster").
                   distribution("1|*").
                   group(
@@ -74,18 +73,7 @@ class DistributorDown < MultiProviderStorageTest
 
   def test_all_distributors_in_one_group_down
     set_owner("vekterli")
-    deploy_app(create_app(0))
-    run_all_distributors_in_one_group_down_test
-  end
-
-  def test_all_distributors_in_one_group_down_using_multiple_distributor_stripes
-    # TODO STRIPE: Remove this test when new distributor stripe mode is default
-    set_owner("geirst")
-    deploy_app(create_app(4))
-    run_all_distributors_in_one_group_down_test
-  end
-
-  def run_all_distributors_in_one_group_down_test
+    deploy_app(create_app)
     start
 
     puts "Feed through both distributors. Validate buckets on both."

--- a/tests/vds/merging.rb
+++ b/tests/vds/merging.rb
@@ -16,17 +16,7 @@ class MergingTest < PersistentProviderTest
   end
 
   def test_merging
-    deploy_app(default_app.num_nodes(2).redundancy(2).num_distributor_stripes(0))
-    run_merging_test
-  end
-
-  def test_merging_with_multiple_distributor_stripes
-    # TODO STRIPE: Remove this test when new distributor stripe mode is default
-    deploy_app(default_app.num_nodes(2).redundancy(2).num_distributor_stripes(4))
-    run_merging_test
-  end
-
-  def run_merging_test
+    deploy_app(default_app.num_nodes(2).redundancy(2))
     start
     # Take down one node
     vespa.stop_content_node("storage", "1")

--- a/tests/vds/metrics.rb
+++ b/tests/vds/metrics.rb
@@ -9,12 +9,11 @@ class VdsMetrics < VdsTest
     set_owner("vekterli")
   end
 
-  def create_app(num_distributor_stripes)
+  def create_app
     default_app.admin_metrics(Metrics.new.
                               consumer(Consumer.new("log").
                                        metric(Metric.new("vds.datastored.disk0.docs", "foo")).
-                                       metric(Metric.new("vds.datastored.disk1.bytes", "bar")))).
-                num_distributor_stripes(num_distributor_stripes)
+                                       metric(Metric.new("vds.datastored.disk1.bytes", "bar"))))
   end
 
   def assert_event_log(count, metric, value = nil)
@@ -75,17 +74,7 @@ class VdsMetrics < VdsTest
 
   # Test that doc counts and sizes are available via state v1 metrics API
   def test_state_v1_metrics_doc_counts
-    deploy_app(create_app(0))
-    run_state_v1_metrics_doc_counts_test
-  end
-
-  def test_state_v1_metrics_doc_counts_using_multiple_distributor_stripes
-    # TODO STRIPE: Remove this test when new distributor stripe mode is default
-    deploy_app(create_app(4))
-    run_state_v1_metrics_doc_counts_test
-  end
-
-  def run_state_v1_metrics_doc_counts_test
+    deploy_app(create_app)
     start
     # At first startup, document counts should be zero
     assert_doc_metrics(0)


### PR DESCRIPTION
…ripes.

The new distributor stripe code path is default in 7.468.9 (https://github.com/vespa-engine/vespa/pull/19162).

@vekterli please review