### PR TITLE
Generate feed up front, then cat

### DIFF
--- a/lib/nodetypes/feeder.rb
+++ b/lib/nodetypes/feeder.rb
@@ -140,7 +140,7 @@ module Feeder
     randomstring = "%04d" % (rand*10000).to_i
     tmpfeed = "#{Environment.instance.vespa_home}/tmp/tmpfeed#{timestamp}-#{randomstring}"
     execute("#{DataGenerator.new.feed_command(template: params[:template], count: params[:count])} > #{tmpfeed}")
-    feedfile(tmpfeed, params.merge({ :localfile => true, :deletefeed => true })
+    feedfile(tmpfeed, params.merge({ :localfile => true, :deletefeed => true }))
   end
 
   # Pipe the output of _command_ into the feeder binary instead of using an


### PR DESCRIPTION
@geirst please review. Let's consider this if it makes tests more stable, and doesn't cost too much time/space.