### PR TITLE
Disable qrserver access log, doc-api access log and test framework

### DIFF
--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -61,6 +61,7 @@ class TestCase
     @num_hosts = 1
     @dirty_nodeproxies = {}
     @dirty_environment_settings = false
+    @disable_log_query_and_result = nil
     @connection_error = false
     @current_assert_file = nil
     @required_hostnames = nil
@@ -629,6 +630,7 @@ class TestCase
   end
 
   def log_query_and_result(query, result)
+    return if @disable_log_query_and_result
     path = File.join(@dirs.tmpdir, 'query_result.log')
     File.open(path, 'a+') do |f|
       f.write("Query: #{query}\n")

--- a/tests/search/visibility/visibility.rb
+++ b/tests/search/visibility/visibility.rb
@@ -125,6 +125,7 @@ class Visibility < IndexedSearchTest
     @id_prefix = "id:test:#{@doc_type}::"
     @mutex = Mutex.new
     @cv = ConditionVariable.new
+    @disable_log_query_and_result = true
   end
 
   def get_base_sc(parts, r, rc)
@@ -157,11 +158,12 @@ class Visibility < IndexedSearchTest
     SearchApp.new.
             container(Container.new.
                 search(Searching.new).
+                component(AccessLog.new("disabled")).
                 docproc(DocumentProcessing.new).
-                http(Http.new.server(Server.new("node1", 18000)))).
+                gateway(ContainerDocumentApi.new).
+                http(Http.new.server(Server.new("node1", vespa.default_http_gateway_port)))).
             cluster(sc).
-            storage(StorageCluster.new("visibility", 41).distribution_bits(16)).
-            enable_http_gateway
+            storage(StorageCluster.new("visibility", 41).distribution_bits(16))
   end
 
   def get_app(sc)


### PR DESCRIPTION
query_result log for the visibility system tests.

@baldersheim : please review
