### PR TITLE
Revert "Increase load of tensor matrix matrix prod perf test"

### DIFF
--- a/tests/performance/tensor_matrix_matrix_prod/tensor_matrix_matrix_prod.rb
+++ b/tests/performance/tensor_matrix_matrix_prod/tensor_matrix_matrix_prod.rb
@@ -24,7 +24,7 @@ class TensorMatrixMatrixProduct < PerformanceTest
     @docs_file_name = dirs.tmpdir + "/docs.json"
     @queries_file_name = dirs.tmpdir + "/queries.txt"
     @constants_dir = dirs.tmpdir + "/search/"
-    @num_docs = 1000
+    @num_docs = 100
 
     generate_feed_and_queries
     deploy_and_feed


### PR DESCRIPTION
Reverts vespa-engine/system-test#1956

Does not seem to finish within ~5000 seconds. Trying to revert to see if this is causing the factory issue.