### PR TITLE
Increase load of mat-mat tensor prod perf test (without increasing feed size)

### DIFF
--- a/tests/performance/tensor_matrix_matrix_prod/app/searchdefinitions/test.sd
+++ b/tests/performance/tensor_matrix_matrix_prod/app/searchdefinitions/test.sd
@@ -5,22 +5,12 @@ search test {
         field id type int {
             indexing: summary
         }
-        field vector_512_float type tensor<float>(d0[512]) {
+        field float_rand type float {
             indexing: summary | attribute
         }
-        field matrix_256x512_float type tensor<float>(d0[256],d1[512]) {
+        field double_rand type double {
             indexing: summary | attribute
         }
-        field matrix_512x256_float type tensor<float>(d0[512],d1[256]) {
-            indexing: summary | attribute
-        }
-        field matrix_256x512_double type tensor<double>(d0[256],d1[512]) {
-            indexing: summary | attribute
-        }
-        field matrix_256x1024_float type tensor<float>(d0[256],d1[1024]) {
-            indexing: summary | attribute
-        }
-
     }
 
     document-summary no_summary {
@@ -55,46 +45,46 @@ search test {
     }
 
     rank-profile vector_vector_512_float {
-        first-phase { expression: sum(join(attribute(vector_512_float), constant(vector_512_float), f(a,b)(a * b))) }
+        first-phase { expression: sum(join(attribute(float_rand) * constant(vector_512_float), constant(vector_512_float), f(a,b)(a * b))) }
     }
 
     rank-profile vector_matrix_512_float_inner {
-        first-phase { expression: sum(reduce(join(rename(attribute(vector_512_float), d0, d1), constant(matrix_256x512_float), f(a,b)(a * b)), sum, d1)) }
+        first-phase { expression: sum(reduce(join(rename(attribute(float_rand) * constant(vector_512_float), d0, d1), constant(matrix_256x512_float), f(a,b)(a * b)), sum, d1)) }
     }
 
     rank-profile vector_matrix_512_float_outer {
-        first-phase { expression: sum(reduce(join(attribute(vector_512_float), constant(matrix_512x256_float), f(a,b)(a * b)), sum, d0)) }
+        first-phase { expression: sum(reduce(join(attribute(float_rand) * constant(vector_512_float), constant(matrix_512x256_float), f(a,b)(a * b)), sum, d0)) }
     }
 
     # inner x inner (d0,d2 x d1,d2)
     rank-profile matrix_product_512_float {
-        first-phase { expression: sum(reduce(join(rename(attribute(matrix_256x512_float), d1, d2), rename(constant(matrix_256x512_float), (d0,d1), (d1,d2)), f(a,b)(a * b)), sum, d2)) }
+        first-phase { expression: sum(reduce(join(rename(attribute(float_rand) * constant(matrix_256x512_float), d1, d2), rename(constant(matrix_256x512_float), (d0,d1), (d1,d2)), f(a,b)(a * b)), sum, d2)) }
     }
 
     # inner x outer (d0,d1 x d1,d2)
     rank-profile matrix_product_512_float_inner_outer {
-        first-phase { expression: sum(reduce(join(attribute(matrix_256x512_float), rename(constant(matrix_512x256_float), (d0,d1), (d1,d2)), f(a,b)(a * b)), sum, d1)) }
+        first-phase { expression: sum(reduce(join(attribute(float_rand) * constant(matrix_256x512_float), rename(constant(matrix_512x256_float), (d0,d1), (d1,d2)), f(a,b)(a * b)), sum, d1)) }
     }
 
     # outer x outer (d0,d2 x d0,d1)
     rank-profile matrix_product_512_float_outer_outer {
-        first-phase { expression: sum(reduce(join(rename(attribute(matrix_512x256_float), d1, d2), constant(matrix_512x256_float), f(a,b)(a * b)), sum, d0)) }
+        first-phase { expression: sum(reduce(join(rename(attribute(float_rand) * constant(matrix_512x256_float), d1, d2), constant(matrix_512x256_float), f(a,b)(a * b)), sum, d0)) }
     }
 
     rank-profile matrix_product_1024_float {
-        first-phase { expression: sum(reduce(join(rename(attribute(matrix_256x1024_float), d1, d2), rename(constant(matrix_256x1024_float), (d0,d1), (d1,d2)), f(a,b)(a * b)), sum, d2)) }
+        first-phase { expression: sum(reduce(join(rename(attribute(float_rand) * constant(matrix_256x1024_float), d1, d2), rename(constant(matrix_256x1024_float), (d0,d1), (d1,d2)), f(a,b)(a * b)), sum, d2)) }
     }
 
     rank-profile matrix_product_512_double {
-        first-phase { expression: sum(reduce(join(rename(attribute(matrix_256x512_double), d1, d2), rename(constant(matrix_256x512_double), (d0,d1), (d1,d2)), f(a,b)(a * b)), sum, d2)) }
+        first-phase { expression: sum(reduce(join(rename(attribute(double_rand) * constant(matrix_256x512_double), d1, d2), rename(constant(matrix_256x512_double), (d0,d1), (d1,d2)), f(a,b)(a * b)), sum, d2)) }
     }
 
     rank-profile gemm_512_float {
-        first-phase { expression: sum(join(reduce(join(rename(attribute(matrix_256x512_float), d1, d2), rename(constant(matrix_256x512_float), (d0,d1), (d1,d2)), f(a,b)(a * b)), sum, d2) * 1.1, constant(matrix_256x256_float) * 1.2, f(a,b)(a+b))) }
+        first-phase { expression: sum(join(reduce(join(rename(attribute(float_rand) * constant(matrix_256x512_float), d1, d2), rename(constant(matrix_256x512_float), (d0,d1), (d1,d2)), f(a,b)(a * b)), sum, d2) * 1.1, constant(matrix_256x256_float) * 1.2, f(a,b)(a+b))) }
     }
 
     rank-profile gemm_512_float_inline_join {
-        first-phase { expression: sum(join(reduce(join(rename(attribute(matrix_256x512_float), d1, d2), rename(constant(matrix_256x512_float), (d0,d1), (d1,d2)), f(a,b)(a * b)), sum, d2), constant(matrix_256x256_float), f(a,b)(1.1*a + 1.2*b))) }
+        first-phase { expression: sum(join(reduce(join(rename(attribute(float_rand) * constant(matrix_256x512_float), d1, d2), rename(constant(matrix_256x512_float), (d0,d1), (d1,d2)), f(a,b)(a * b)), sum, d2), constant(matrix_256x256_float), f(a,b)(1.1*a + 1.2*b))) }
     }
 
 }

--- a/tests/performance/tensor_matrix_matrix_prod/tensor_matrix_matrix_prod.rb
+++ b/tests/performance/tensor_matrix_matrix_prod/tensor_matrix_matrix_prod.rb
@@ -24,7 +24,7 @@ class TensorMatrixMatrixProduct < PerformanceTest
     @docs_file_name = dirs.tmpdir + "/docs.json"
     @queries_file_name = dirs.tmpdir + "/queries.txt"
     @constants_dir = dirs.tmpdir + "/search/"
-    @num_docs = 100
+    @num_docs = 1000
 
     generate_feed_and_queries
     deploy_and_feed
@@ -54,21 +54,8 @@ class TensorMatrixMatrixProduct < PerformanceTest
       result << "    \"put\":\"id:test:test::#{i}\",\n"
       result << "    \"fields\":{\n"
       result << "      \"id\":#{i},\n"
-      result << "      \"vector_512_float\":{\n"
-      result << generate_cells_1d("d0", 512)
-      result << "      },\n"
-      result << "      \"matrix_256x512_float\":{\n"
-      result << generate_cells_2d("d0", 256, "d1", 512)
-      result << "      },\n"
-      result << "      \"matrix_512x256_float\":{\n"
-      result << generate_cells_2d("d0", 512, "d1", 256)
-      result << "      },\n"
-      result << "      \"matrix_256x512_double\":{\n"
-      result << generate_cells_2d("d0", 256, "d1", 512)
-      result << "      },\n"
-      result << "      \"matrix_256x1024_float\":{\n"
-      result << generate_cells_2d("d0", 256, "d1", 1024)
-      result << "      }\n"
+      result << "      \"float_rand\":#{Random.rand}\n"
+      result << "      \"double_rand\":#{Random.rand}\n"
       result << "    }\n"
       result << "  }"
     end


### PR DESCRIPTION
@baldersheim Please review. Previous attempt (https://github.com/vespa-engine/system-test/pull/1956) overloaded factory with too many large documents. Generating 100 documents with these large tensors takes minutes on factory. Now, the document size is much more manageable.