### PR TITLE
Rename searcher and use more randomness

### DIFF
--- a/lib/doc_reader.rb
+++ b/lib/doc_reader.rb
@@ -1,4 +1,4 @@
-# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 require 'digest/md5'
 require 'environment'
 
@@ -50,9 +50,10 @@ class DocReader
       source_name = "."
       source_dir = source
     end
-    randomstring = "%04d" % (rand*10000).to_i
-    `tar czf  #{Environment.instance.vespa_home}/tmp/#{tar_name}.#{randomstring}.tar.gz --directory #{source_dir} #{source_name}`
-    return "#{Environment.instance.vespa_home}/tmp/#{tar_name}.#{randomstring}.tar.gz"
+    randomstring = "%06d" % (rand(1000000)).to_i
+    archive = "#{Environment.instance.vespa_home}/tmp/#{tar_name}.#{randomstring}.tar.gz"
+    `tar czf #{archive} --directory #{source_dir} #{source_name}`
+    archive
   end
 
   def delete(filename)

--- a/tests/search/attributeprefetch/AttributePrefetchTestSearcher.java
+++ b/tests/search/attributeprefetch/AttributePrefetchTestSearcher.java
@@ -7,7 +7,7 @@ import com.yahoo.search.Searcher;
 import com.yahoo.search.result.Hit;
 import com.yahoo.search.searchchain.Execution;
 
-public class TestSearcher extends Searcher {
+public class AttributePrefetchTestSearcher extends Searcher {
 
     public Result search(Query query, Execution execution) {
         Result result = execution.search(query);

--- a/tests/search/attributeprefetch/TestSearcher.java
+++ b/tests/search/attributeprefetch/TestSearcher.java
@@ -1,4 +1,4 @@
-// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespatest.attributeprefetch;
 
 import com.yahoo.search.Query;
@@ -14,66 +14,60 @@ public class TestSearcher extends Searcher {
         if (query.properties().get("notestsearcher") != null) {
             return result;
         }
-		String error = null;
-		Hit hit = null;
-		boolean wasCached = false;
+        String error = null;
+        Hit hit = null;
+        boolean wasCached = false;
 
-		if (result.getHitCount() == 1) {
-			hit = result.hits().get(0);
-			wasCached = hit.isCached();
-		} else {
-			error = "Hit count was " + result.getHitCount()
-					+ ", expected 1";
-		}
-		if (error == null && !wasCached) {
-			String str = (String) hit.getField("stringfield");
-			if (str != null) {
-				error = "'stringfield' should not be set before "
-						+ "filling in attributes";
-			}
-		}
-		if (error == null && !wasCached) {
-			String body = (String) hit.getField("body");
-			if (body != null) {
-				error = "'body' should not be set before "
-						+ "filling in docsums";
-			}
-		}
-		execution.fillAttributes(result);
-		if (error == null && !wasCached) {
-			String body = (String) hit.getField("body");
-			if (body != null) {
-				error = "'body' should not be set before "
-						+ "filling in docsums";
-			}
-		}
-		if (error == null) {
-			String str = (String) hit.getField("stringfield");
-			if (str == null) {
-				error = "'stringfield' should be set after "
-						+ "filling in attributes";
-			} else if (!str.equals("stringvalue")) {
-				error = "'stringfield' == " + str + " != \"stringvalue\"";
-			}
-		}
-		execution.fill(result);
-		if (error == null) {
-			String body = (String) hit.getField("body");
-			if (body == null) {
-				error = "'body' should be set after "
-						+ "filling in docsums";
-			} else if (!body.equals("x")) {
-				error = "'body' == " + body + " != \"x\"";
-			}
-		}
-		Hit fb = new Hit("feedback");
-		if (error == null) {
-			fb.setField("feedback", "TEST SEARCHER: OK");
-		} else {
-			fb.setField("feedback", "TEST SEARCHER: ERROR: " + error);
-		}
-		result.hits().add(fb);
-		return result;
-	}
+        if (result.getHitCount() == 1) {
+            hit = result.hits().get(0);
+            wasCached = hit.isCached();
+        } else {
+            error = "Hit count was " + result.getHitCount() + ", expected 1";
+        }
+        if (error == null && !wasCached) {
+            String str = (String) hit.getField("stringfield");
+            if (str != null) {
+                error = "'stringfield' should not be set before filling in attributes";
+            }
+        }
+        if (error == null && !wasCached) {
+            String body = (String) hit.getField("body");
+            if (body != null) {
+                error = "'body' should not be set before filling in docsums";
+            }
+        }
+        execution.fillAttributes(result);
+        if (error == null && !wasCached) {
+            String body = (String) hit.getField("body");
+            if (body != null) {
+                error = "'body' should not be set before filling in docsums";
+            }
+        }
+        if (error == null) {
+            String str = (String) hit.getField("stringfield");
+            if (str == null) {
+                error = "'stringfield' should be set after filling in attributes";
+            } else if (!str.equals("stringvalue")) {
+                error = "'stringfield' == " + str + " != \"stringvalue\"";
+            }
+        }
+        execution.fill(result);
+        if (error == null) {
+            String body = (String) hit.getField("body");
+            if (body == null) {
+                error = "'body' should be set after filling in docsums";
+            } else if (!body.equals("x")) {
+                error = "'body' == " + body + " != \"x\"";
+            }
+        }
+        Hit fb = new Hit("feedback");
+        if (error == null) {
+            fb.setField("feedback", "TEST SEARCHER: OK");
+        } else {
+            fb.setField("feedback", "TEST SEARCHER: ERROR: " + error);
+        }
+        result.hits().add(fb);
+        return result;
+    }
 
 }

--- a/tests/search/attributeprefetch/attributeprefetch.rb
+++ b/tests/search/attributeprefetch/attributeprefetch.rb
@@ -6,9 +6,9 @@ class AttributePrefetch < IndexedSearchTest
 
   def setup
     set_owner("havardpe")
-    add_bundle(selfdir+"TestSearcher.java")
+    add_bundle(selfdir+"AttributePrefetchTestSearcher.java")
     search_chain = Chain.new("default", "vespa").
-        add(Searcher.new("com.yahoo.vespatest.attributeprefetch.TestSearcher", "transformedQuery", "blendedResult"))
+        add(Searcher.new("com.yahoo.vespatest.attributeprefetch.AttributePrefetchTestSearcher", "transformedQuery", "blendedResult"))
     deploy_app(SearchApp.new.sd(selfdir+"attr.sd").container(
                    Container.new.search(
                        Searching.new.chain(search_chain))))


### PR DESCRIPTION
Looks like we might end up using same file name for tar file for two different tests, even though we try to use a file name with a random component. One of the test fails when tar file is deleted by the other test run if they are running simultaneously. Extend random string with two characters and use a uniqe file name for searcher.