### PR TITLE
Stop seeding random number generator

### DIFF
--- a/tests/search/addpartition/addpartition.rb
+++ b/tests/search/addpartition/addpartition.rb
@@ -33,7 +33,6 @@ class AddPartition < SearchTest
   def setup
     set_owner("toregge")
     set_description("Test growing cluster by adding partitions")
-    srand(123)
     @doc_type = "addpartition"
     @id_prefix = "id:test:#{@doc_type}::"
   end

--- a/tests/search/down/down.rb
+++ b/tests/search/down/down.rb
@@ -15,7 +15,6 @@ class Down < SearchTest
   def setup
     set_owner("toregge")
     set_description("Verify that documents are searchable after put")
-    srand(123)
     @doc_type = "down"
     @id_prefix = "id:test:#{@doc_type}::"
     @mutex = Mutex.new

--- a/tests/search/feed_block/feed_block_base.rb
+++ b/tests/search/feed_block/feed_block_base.rb
@@ -6,7 +6,6 @@ class FeedBlockBase < IndexedSearchTest
 
   def setup
     set_owner("toregge")
-    srand(123)
     @doc_type = "test"
     @namespace = "test"
     @cluster_name = "test"

--- a/tests/search/visibility/visibility.rb
+++ b/tests/search/visibility/visibility.rb
@@ -120,7 +120,6 @@ class Visibility < IndexedSearchTest
   def setup
     set_owner("toregge")
     set_description("Verify that documents are searchable after put")
-    srand(123)
     @doc_type = "visibility"
     @id_prefix = "id:test:#{@doc_type}::"
     @mutex = Mutex.new


### PR DESCRIPTION
Can't see any use for seeding, it might contaminate other usage of
the default random number generator.