### PR TITLE
Stop seeding random number generator

### DIFF
--- a/tests/performance/tensor_eval/tensor_eval.rb
+++ b/tests/performance/tensor_eval/tensor_eval.rb
@@ -1,4 +1,4 @@
-# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 require 'performance_test'
 require 'app_generator/search_app'
 require 'performance/fbench'
@@ -59,7 +59,6 @@ class TensorEvalPerfTest < PerformanceTest
 
   def generate_tensor_files
     puts "generate_tensor_files"
-    srand(123456789)
     TensorEvalTensorGenerator.write_tensor_files(dirs.tmpdir)
   end
 

--- a/tests/performance/tensor_eval/utils/query_generator.rb
+++ b/tests/performance/tensor_eval/utils/query_generator.rb
@@ -1,11 +1,12 @@
-# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 class TensorEvalQueryGenerator
 
 def self.gen_rnd_array(num_entries)
+  random_generator = Random.new(123456789)
   result = Array.new
   num_entries.times do
-    result.push(Random.rand(100))
+    result.push(random_generator.rand(100))
   end
   result
 end
@@ -101,7 +102,6 @@ end
 end
 
 if __FILE__ == $0
-  srand(123456789)
   TensorEvalQueryGenerator.write_query_files("")
 end
 

--- a/tests/performance/tensor_eval/utils/tensor_generator.rb
+++ b/tests/performance/tensor_eval/utils/tensor_generator.rb
@@ -1,13 +1,14 @@
-# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 class TensorEvalTensorGenerator
 
   def self.gen_2d_tensor(dim_x, dim_y, dim_size)
+    random_generator = Random.new(123456789)
     result = "{\n"
     result << "  \"cells\": [\n"
     for i in 0...dim_size do
       for j in 0...dim_size do
         result << ",\n" if (i > 0 || j > 0)
-        result << "    { \"address\": { \"#{dim_x}\": \"#{i}\", \"#{dim_y}\": \"#{j}\" }, \"value\": #{Random.rand(100)}.0 }"
+        result << "    { \"address\": { \"#{dim_x}\": \"#{i}\", \"#{dim_y}\": \"#{j}\" }, \"value\": #{random_generator.rand(100)}.0 }"
       end
     end
     result << "\n  ]"
@@ -33,7 +34,6 @@ class TensorEvalTensorGenerator
 end
 
 if __FILE__ == $0
-  srand(123456789)
   TensorEvalTensorGenerator.write_tensor_files(".")
 end
 


### PR DESCRIPTION
Create a new random number generator and seed it instead of seeding
the default one (might contaminate other usage of the default random
number generator).