### PR TITLE
Stop seeding random number generator

### DIFF
--- a/tests/performance/collection_search/map_of_struct_feed_and_update.rb
+++ b/tests/performance/collection_search/map_of_struct_feed_and_update.rb
@@ -22,7 +22,6 @@ class MapOfStructFeedAndUpdatePerformanceTest < CollectionPerfTestBase
 
   def test_map_of_struct_feeding_and_updates
     set_description('Test feeding, field and element-wise partial updates for map of struct')
-    srand(123456789) # Want deterministic PRNG output TODO explicit Random obj to avoid possible contamination
     [false, true].each do |fast_search|
       run_map_of_struct_test_cases(fast_search: fast_search)
     end
@@ -32,6 +31,7 @@ class MapOfStructFeedAndUpdatePerformanceTest < CollectionPerfTestBase
 
     def initialize(field_value_gen)
       @fv = field_value_gen
+      @rand = Random.new(123456789) # Want deterministic PRNG output
     end
 
     def arbitrary_struct_element_data
@@ -90,7 +90,7 @@ class MapOfStructFeedAndUpdatePerformanceTest < CollectionPerfTestBase
     end
 
     def emit_fields(n)
-      key = "@#{n}-#{rand(@elems_per_doc)}"
+      key = "@#{n}-#{@rand.rand(@elems_per_doc)}"
       "\"struct_map{#{key}}\":{\"assign\":#{arbitrary_struct_element_data.to_json}\}"
     end
 

--- a/tests/performance/collection_search/same_element.rb
+++ b/tests/performance/collection_search/same_element.rb
@@ -27,7 +27,6 @@ class SameElementPerformanceTest < CollectionPerfTestBase
 
   def test_same_element_operator_with_map_of_struct
     set_description('Test use of sameElement() operator for map of struct with varying number of elements per map')
-    srand(123456789) # Want deterministic PRNG output TODO explicit Random obj to avoid possible contamination
     @query_file_name = file_in_tmp('queries.txt')
     puts "Using query file: '#{@query_file_name}'"
     [false, true].each do |fast_search|


### PR DESCRIPTION
Create a new random number generator and seed it instead of seeding
the default one (might contaminate other usage of the default random
number generator).