### PR TITLE
Stop seeding random number generator

### DIFF
--- a/tests/performance/tensor_canvass/tensor_canvass.rb
+++ b/tests/performance/tensor_canvass/tensor_canvass.rb
@@ -1,4 +1,4 @@
-# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 require 'performance_test'
 require 'app_generator/search_app'
 require 'performance/fbench'
@@ -32,7 +32,6 @@ class TensorCanvass < PerformanceTest
   end
 
   def generate_feed_and_queries
-    srand(123456789)
     generate_feed
     generate_queries
   end
@@ -45,6 +44,7 @@ class TensorCanvass < PerformanceTest
   end
 
   def generate_docs
+    @random_generator = Random.new(123456789)
     result = "["
     @num_docs.times do |i|
       result << "," if i > 0
@@ -53,13 +53,13 @@ class TensorCanvass < PerformanceTest
       result << "    \"put\":\"id:test:test::#{i}\",\n"
       result << "    \"fields\":{\n"
       result << "      \"id\":#{i},\n"
-      result << "      \"v1\":#{Random.rand},\n"
-      result << "      \"v2\":#{Random.rand},\n"
-      result << "      \"v3\":#{Random.rand},\n"
-      result << "      \"v4\":#{Random.rand},\n"
-      result << "      \"v5\":#{Random.rand},\n"
-      result << "      \"v6\":#{Random.rand},\n"
-      result << "      \"v7\":#{Random.rand}\n"
+      result << "      \"v1\":#{@random_generator.rand},\n"
+      result << "      \"v2\":#{@random_generator.rand},\n"
+      result << "      \"v3\":#{@random_generator.rand},\n"
+      result << "      \"v4\":#{@random_generator.rand},\n"
+      result << "      \"v5\":#{@random_generator.rand},\n"
+      result << "      \"v6\":#{@random_generator.rand},\n"
+      result << "      \"v7\":#{@random_generator.rand}\n"
       result << "    }\n"
       result << "  }"
     end

--- a/tests/performance/tensor_eval/utils/expression_generator.rb
+++ b/tests/performance/tensor_eval/utils/expression_generator.rb
@@ -1,10 +1,11 @@
-# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 def gen_tensor(dim_x, dim_y, dim_size)
+  @random_generator = Random.new(123456789)
   result = "{"
   for i in 0...dim_size do
     for j in 0...dim_size do
       result << ",\n" if (i > 0 || j > 0)
-      result << "{#{dim_x}:#{i},#{dim_y}:#{j}}:#{Random.rand(100)}"
+      result << "{#{dim_x}:#{i},#{dim_y}:#{j}}:#{@random_generator.rand(100)}"
     end
   end
   result << "}"
@@ -27,7 +28,6 @@ def gen_matrix_expression(file_name, dim_size)
 end
 
 if __FILE__ == $0
-  srand(123456789)
   gen_match_expression("tensor_match_25x25.expression", 25)
   gen_match_expression("tensor_match_50x50.expression", 50)
   gen_match_expression("tensor_match_100x100.expression", 100)

--- a/tests/performance/tensor_matrix_matrix_prod/tensor_matrix_matrix_prod.rb
+++ b/tests/performance/tensor_matrix_matrix_prod/tensor_matrix_matrix_prod.rb
@@ -1,4 +1,4 @@
-# Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 require 'performance_test'
 require 'app_generator/search_app'
 require 'performance/fbench'
@@ -34,7 +34,7 @@ class TensorMatrixMatrixProduct < PerformanceTest
   end
 
   def generate_feed_and_queries
-    srand(123456789)
+    @random_generator = Random.new(123456789)
     generate_feed
     generate_constants
     generate_queries
@@ -56,8 +56,8 @@ class TensorMatrixMatrixProduct < PerformanceTest
       result << "    \"put\":\"id:test:test::#{i}\",\n"
       result << "    \"fields\":{\n"
       result << "      \"id\":#{i},\n"
-      result << "      \"float_rand\":#{Random.rand},\n"
-      result << "      \"double_rand\":#{Random.rand}\n"
+      result << "      \"float_rand\":#{@random_generator.rand},\n"
+      result << "      \"double_rand\":#{@random_generator.rand}\n"
       result << "    }\n"
       result << "  }"
     end
@@ -92,7 +92,7 @@ class TensorMatrixMatrixProduct < PerformanceTest
     d0_size.times do |d0|
         d1_size.times do |d1|
           result << ",\n" if (d0 > 0 || d1 > 0)
-          result << "    {\"address\":{\"#{d0_name}\":\"#{d0}\",\"#{d1_name}\":\"#{d1}\"},\"value\":#{Random.rand}}"
+          result << "    {\"address\":{\"#{d0_name}\":\"#{d0}\",\"#{d1_name}\":\"#{d1}\"},\"value\":#{@random_generator.rand}}"
         end
     end
     result << "\n  ]\n"
@@ -109,7 +109,7 @@ class TensorMatrixMatrixProduct < PerformanceTest
     result << "  \"cells\":[\n"
     d0_size.times do |d0|
       result << ",\n" if (d0 > 0)
-      result << "    {\"address\":{\"#{d0_name}\":\"#{d0}\"},\"value\":#{Random.rand}}"
+      result << "    {\"address\":{\"#{d0_name}\":\"#{d0}\"},\"value\":#{@random_generator.rand}}"
     end
     result << "\n  ]\n"
   end

--- a/tests/performance/tensor_replace_max_reduce_prod_join/tensor_replace_max_reduce_prod_join.rb
+++ b/tests/performance/tensor_replace_max_reduce_prod_join/tensor_replace_max_reduce_prod_join.rb
@@ -1,4 +1,4 @@
-# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 require 'performance_test'
 require 'app_generator/search_app'
 require 'performance/fbench'
@@ -36,7 +36,7 @@ class TensorReplaceMaxReduceProdJoinPerfTest < PerformanceTest
   end
 
   def generate_feed_and_queries
-    srand(123456789)
+    @random_generator = Random.new(123456789)
     generate_feed
     generate_queries
   end
@@ -59,7 +59,7 @@ class TensorReplaceMaxReduceProdJoinPerfTest < PerformanceTest
       result << "      \"id\":#{i},\n"
       nums = {}
       while nums.size < 3
-         nums[Random.rand(1000)] = 1.0
+         nums[@random_generator.rand(1000)] = 1.0
       end
       nums = nums.keys
       result << "      \"longarray\":#{nums},\n"
@@ -108,7 +108,7 @@ class TensorReplaceMaxReduceProdJoinPerfTest < PerformanceTest
     wset = {}
     num_entries.times do |i|
       key = unique_keys[i].to_s
-      weight = Random.rand(10000)
+      weight = @random_generator.rand(10000)
       wset[key] = weight
     end
     return wset

--- a/tests/performance/tensorflow/tensorflow.rb
+++ b/tests/performance/tensorflow/tensorflow.rb
@@ -1,4 +1,4 @@
-# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 require 'performance_test'
 require 'app_generator/search_app'
 require 'performance/fbench'
@@ -32,7 +32,6 @@ class TensorFlow < PerformanceTest
   end
 
   def generate_feed_and_queries
-    srand(123456789)
     generate_feed
     generate_queries
   end
@@ -45,6 +44,7 @@ class TensorFlow < PerformanceTest
   end
 
   def generate_docs
+    @random_generator = Random.new(123456789)
     result = "["
     @num_docs.times do |i|
       result << "," if i > 0
@@ -57,7 +57,7 @@ class TensorFlow < PerformanceTest
       result << "        \"cells\":[\n"
       784.times do |j|
         result << "," if j > 0
-        result << "          {\"address\":{\"d0\":\"0\",\"d1\":\"#{j}\"},\"value\":#{Random.rand}}"
+        result << "          {\"address\":{\"d0\":\"0\",\"d1\":\"#{j}\"},\"value\":#{@random_generator.rand}}"
       end
       result << "        ]\n"
       result << "      }\n"


### PR DESCRIPTION
Create a new random number generator and seed it instead of seeding
the default one (might contaminate other usage of the default random
number generator).