### PR TITLE
Require config generation in wait_for_reconfig

### DIFF
--- a/lib/container_test.rb
+++ b/lib/container_test.rb
@@ -22,6 +22,7 @@ class ContainerTest < TestCase
     output = container_deploy(app, params)
     @container = (vespa.container.values.first || vespa.qrserver.values.first)
     wait_for_application(@container, output)
+    output
   end
 
   # First deployment

--- a/lib/test_base.rb
+++ b/lib/test_base.rb
@@ -1359,21 +1359,21 @@ module TestBase
     }
   end
 
-  # Note: When you have several config servers they are not necessarily in sync,
-  # so this might end up checking that all services have the old generation instead
-  # of the new one
-  def wait_for_reconfig(retries=600, echo=false)
+  def wait_for_reconfig(expected_generation, retries=600, echo=false)
     while retries > 0
       r = vespa_config_status(echo)
       exitcode = r[0].to_i
+      output = r[1]
       if exitcode != 0
         retries -= 1
-        sleep 0.1
       else
-        break
+        if output =~ /has the latest generation #{expected_generation}/
+          break
+        end
       end
+      sleep 0.1
     end
-    assert_equal(0, exitcode, "Services never reconfigured to latest application package, output from vespa-config-status: #{r[1]}")
+    assert_equal(0, exitcode, "Services never reconfigured to latest application package, output from vespa-config-status: #{output}")
   end
 
   def vespa_config_status(echo=false)

--- a/tests/cloudconfig/config_proxy/config_proxy.rb
+++ b/tests/cloudconfig/config_proxy/config_proxy.rb
@@ -1,3 +1,4 @@
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 require 'cloudconfig_test'
 require 'search_test'
 require 'search_test'
@@ -110,11 +111,11 @@ class ConfigProxy < CloudConfigTest
     assert_config(@route_count + 1, out_file_1)
     assert_config(@route_count + 1, out_file_2)
 
-    deploy_app_and_assert(:deploy_app_with_routes, @route_count, out_files)
-    wait_for_reconfig(600)
+    config_generation = get_generation(deploy_app_and_assert(:deploy_app_with_routes, @route_count, out_files)).to_i
+    wait_for_reconfig(config_generation)
     # One more time to check that it works with new generation, unchanged config
-    deploy_app_and_assert(:deploy_app_with_routes, @route_count, out_files)
-    wait_for_reconfig(600)
+    config_generation = get_generation(deploy_app_and_assert(:deploy_app_with_routes, @route_count, out_files)).to_i
+    wait_for_reconfig(config_generation, 600)
   end
 
   # Tests that getting an error upstream (e.g. UNKNOWN_DEFINITION) makes the
@@ -182,18 +183,18 @@ class ConfigProxy < CloudConfigTest
     assert_config(@route_count, out_file_1, gen)
     assert_config(@route_count, out_file_2, gen)
 
-    deploy_app_and_assert(:deploy_app_with_routes, @route_count, out_files)
+    config_generation = get_generation(deploy_app_and_assert(:deploy_app_with_routes, @route_count, out_files)).to_i
     if (start_base)
-      wait_for_reconfig(600)
+      wait_for_reconfig(config_generation, 600)
     end
-    deploy_app_and_assert(:deploy_app_with_one_extra_route, @route_count + 1, out_files)
+    config_generation = get_generation(deploy_app_and_assert(:deploy_app_with_one_extra_route, @route_count + 1, out_files)).to_i
     if (start_base)
-      wait_for_reconfig(600)
+      wait_for_reconfig(config_generation, 600)
     end
     # One more time to check that it works with new generation, unchanged config
-    deploy_app_and_assert(:deploy_app_with_one_extra_route, @route_count + 1, out_files)
+    config_generation = get_generation(deploy_app_and_assert(:deploy_app_with_one_extra_route, @route_count + 1, out_files)).to_i
     if (start_base)
-      wait_for_reconfig(600)
+      wait_for_reconfig(config_generation, 600)
     end
   end
 

--- a/tests/cloudconfig/multiple_configservers/multiple_configservers.rb
+++ b/tests/cloudconfig/multiple_configservers/multiple_configservers.rb
@@ -70,7 +70,7 @@ class MultipleConfigservers < CloudConfigTest
     #assert_prepared_response_key(@node3, @session_id - 1, "activate")
 
     wait_for_config_generation_on_all_configservers(@session_id)
-    wait_for_reconfig(600, true)
+    wait_for_reconfig(@session_id, 600, true)
     feed_and_wait_for_docs("banana", 5, :file => selfdir + "bananafeed-extended.xml")
   end
 

--- a/tests/container/configinspect/inspect.rb
+++ b/tests/container/configinspect/inspect.rb
@@ -1,4 +1,4 @@
-# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 require 'search_container_test'
 require 'app_generator/search_app'
 
@@ -14,8 +14,8 @@ class ConfigInspect < SearchContainerTest
   def test_config_status_util
     r = vespa_config_status
     assert_equal(0, r[0].to_i, "System ended up with wrong config generation on start:\n#{r[1]}")
-    deploy_app(SearchApp.new().sd(selfdir+'simple.sd').visibility_delay(60))
-    wait_for_reconfig(600, true)
+    config_generation = get_generation(deploy_app(SearchApp.new().sd(selfdir+'simple.sd').visibility_delay(60))).to_i
+    wait_for_reconfig(config_generation, 600, true)
   end
 
   def teardown

--- a/tests/container/servlet/servlet_reconfig/servlet_reconfig.rb
+++ b/tests/container/servlet/servlet_reconfig/servlet_reconfig.rb
@@ -62,10 +62,9 @@ class ServletReconfig < ContainerTest
   end
 
   def deploy_and_wait_for_reconfig(application)
-    deploy(application, :bundles => [@resource])
-    wait_for_reconfig
+    config_generation = get_generation(deploy(application, :bundles => [@resource])).to_i
+    wait_for_reconfig(config_generation)
   end
-
 
   def application_with_cloud_config(path, cloudConfigMessage)
     create_application(path, cloudConfigMessage, nil)

--- a/tests/search/addnewfield/addnewfield.rb
+++ b/tests/search/addnewfield/addnewfield.rb
@@ -1,4 +1,4 @@
-# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 require 'indexed_streaming_search_test'
 
@@ -28,7 +28,7 @@ class Addnewfield < IndexedStreamingSearchTest
     # deploy config with extra document field
     deploy_output = deploy_app(SearchApp.new.sd(rename_and_use_sd_file(selfdir+"wnf-music.sd", "music.sd")))
     wait_for_application(vespa.container.values.first, deploy_output)
-    wait_for_reconfig(600, true)
+    wait_for_reconfig(get_generation(deploy_output).to_i, 600, true)
 
     ### Pragmatic sleep to wait for config propagation as streaming search does ad-hoc config subscription.
     ### The proper solution is to wire this in to set of configs monitored in proton.

--- a/tests/search/bugs/6612278/bug_6612278.rb
+++ b/tests/search/bugs/6612278/bug_6612278.rb
@@ -47,8 +47,8 @@ class Bug6612278Test < SearchTest
     wait_until_ready
 
     feed(:file => "#{selfdir}/feed2.xml")
-    deploy_app(generate_app(4, 2))
-    wait_for_reconfig # To ensure new distribution config has kicked.
+    config_generation = get_generation(deploy_app(generate_app(4, 2))).to_i
+    wait_for_reconfig(config_generation) # To ensure new distribution config has kicked.
 
     set_node_up('storage', 1)
     set_node_up('storage', 0)

--- a/tests/search/error_reporting/error_reporting.rb
+++ b/tests/search/error_reporting/error_reporting.rb
@@ -39,7 +39,7 @@ class ErrorReportingTest < IndexedSearchTest
                                            .new("vespa.config.search.core.proton")
                                            .add("forward_issues", "false")))
     wait_for_application(vespa.container.values.first, deploy_output)
-    wait_for_reconfig(600, true)
+    wait_for_reconfig(get_generation(deploy_output).to_i, 600, true)
 
     result = search(q)
     json = JSON.parse(result.xmldata)

--- a/tests/search/schemachanges/schemachanges_base.rb
+++ b/tests/search/schemachanges/schemachanges_base.rb
@@ -1,4 +1,4 @@
-# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 module SchemaChangesBase
 
@@ -13,8 +13,9 @@ module SchemaChangesBase
 
   def postdeploy_wait(deploy_output)
     wait_for_application(vespa.container.values.first, deploy_output)
-    wait_for_config_generation_proxy(get_generation(deploy_output))
-    wait_for_reconfig(600)
+    config_generation = get_generation(deploy_output).to_i
+    wait_for_config_generation_proxy(config_generation)
+    wait_for_reconfig(config_generation, 600)
   end
 
   def redeploy(sdfile, validation_override = nil)

--- a/tests/vds/garbagecollection.rb
+++ b/tests/vds/garbagecollection.rb
@@ -62,8 +62,8 @@ class GarbageCollection < MultiProviderStorageTest
     # Before doing a final crosscheck validation of bucket state, ensure
     # that GC has been disabled so that the bucket state parsing code
     # does not get confused by intermittent GC operations being scheduled.
-    deploy_gc_app(false)
-    wait_for_reconfig
+    config_generation = get_generation(deploy_gc_app(false)).to_i
+    wait_for_reconfig(config_generation)
     crosscheck_bucket_consistency
   end
 

--- a/tests/vds/multiplesearchdefinitions/multiplesearchdefinitions.rb
+++ b/tests/vds/multiplesearchdefinitions/multiplesearchdefinitions.rb
@@ -35,9 +35,9 @@ class MultipleSearchDefs < VdsMultiModelTest
     assert(/id:storage_test:music:n=1234:music1/, output)
 
     puts "1 **************************************************************"
-    deploy_app(default_app("music2").validation_override("content-type-removal"))
-
-    wait_for_reconfig(600, true)
+    deploy_output = deploy_app(default_app("music2").validation_override("content-type-removal"))
+    config_generation = get_generation(deploy_output).to_i
+    wait_for_reconfig(config_generation, 600, true)
 
     # music2 application is deployed => should fail to feed music documents but succeed in feeding music2 documents
     output = feedfile(selfdir+"music.xml", :exceptiononfailure => false)
@@ -55,9 +55,10 @@ class MultipleSearchDefs < VdsMultiModelTest
     assert_no_match(/Document type music not found/, output)
 
     puts "2 **************************************************************"
-    deploy_app(default_app.validation_override("content-type-removal"))
 
-    wait_for_reconfig(600, true)
+    deploy_output = deploy_app(default_app.validation_override("content-type-removal"))
+    config_generation = get_generation(deploy_output).to_i
+    wait_for_reconfig(config_generation, 600, true)
 
     # music application is deployed => should fail to feed music2 documents but succeed in feeding music documents
     output = feedfile(selfdir+"music.xml", :retries => 3)
@@ -77,9 +78,9 @@ class MultipleSearchDefs < VdsMultiModelTest
     puts "3 **************************************************************"
 
     # Now deploy application with both document types => put/get should work for both
-    deploy_app(default_app.sd(VDS + "/schemas/music2.sd").validation_override("content-type-removal"))
-
-    wait_for_reconfig(600, true)
+    deploy_output = deploy_app(default_app.sd(VDS + "/schemas/music2.sd").validation_override("content-type-removal"))
+    config_generation = get_generation(deploy_output).to_i
+    wait_for_reconfig(config_generation, 600, true)
 
     # Test vespaget
     output = vespaget("id:storage_test:music:n=1234:music1")

--- a/tests/vds/operation_priority_blocking/operation_priority_blocking.rb
+++ b/tests/vds/operation_priority_blocking/operation_priority_blocking.rb
@@ -1,4 +1,4 @@
-# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 require 'vds_test'
 
 class OperationPriorityBlocking < VdsTest
@@ -70,13 +70,13 @@ class OperationPriorityBlocking < VdsTest
     puts "Deploying app with priority threshold of '#{priority_name}'"
     puts "----"
     output = deploy_app(app_with_priority_threshold(priority_int_value_of(priority_name)))
-    gen = get_generation(output).to_i
+    config_generation = get_generation(output).to_i
 
     # deploy_app does not wait until config has been propagated, so we have to
     # do this explicitly here to avoid test race conditions between deployment
     # and feeding.
-    wait_for_reconfig
-    vespa.storage['storage'].wait_until_content_nodes_have_config_generation(gen)
+    wait_for_reconfig(config_generation)
+    vespa.storage['storage'].wait_until_content_nodes_have_config_generation(config_generation)
   end
 
   def test_feed_ops_with_low_priority_can_be_blocked


### PR DESCRIPTION
When you have several config servers they are not necessarily in sync,
so without checking against expected config generation we might end up
checking that all services have the old generation instead of the new one.