### PR TITLE
Make sure to return deploy output from deploy_app_and_assert

### DIFF
--- a/tests/cloudconfig/config_proxy/config_proxy.rb
+++ b/tests/cloudconfig/config_proxy/config_proxy.rb
@@ -115,7 +115,7 @@ class ConfigProxy < CloudConfigTest
     wait_for_reconfig(config_generation)
     # One more time to check that it works with new generation, unchanged config
     config_generation = get_generation(deploy_app_and_assert(:deploy_app_with_routes, @route_count, out_files)).to_i
-    wait_for_reconfig(config_generation, 600)
+    wait_for_reconfig(config_generation)
   end
 
   # Tests that getting an error upstream (e.g. UNKNOWN_DEFINITION) makes the
@@ -185,16 +185,16 @@ class ConfigProxy < CloudConfigTest
 
     config_generation = get_generation(deploy_app_and_assert(:deploy_app_with_routes, @route_count, out_files)).to_i
     if (start_base)
-      wait_for_reconfig(config_generation, 600)
+      wait_for_reconfig(config_generation)
     end
     config_generation = get_generation(deploy_app_and_assert(:deploy_app_with_one_extra_route, @route_count + 1, out_files)).to_i
     if (start_base)
-      wait_for_reconfig(config_generation, 600)
+      wait_for_reconfig(config_generation)
     end
     # One more time to check that it works with new generation, unchanged config
     config_generation = get_generation(deploy_app_and_assert(:deploy_app_with_one_extra_route, @route_count + 1, out_files)).to_i
     if (start_base)
-      wait_for_reconfig(config_generation, 600)
+      wait_for_reconfig(config_generation)
     end
   end
 
@@ -292,6 +292,7 @@ class ConfigProxy < CloudConfigTest
     files.each do |file|
       assert_config(route_count, file, gen)
     end
+    deploy_output
   end
 
 end


### PR DESCRIPTION
Also no need to use default value as seconds argument to wait_for_reconfig

Fix after changes in https://github.com/vespa-engine/system-test/pull/2045