### PR TITLE
Increase min docs slack from 400 to 700 after merge pipelining change

### DIFF
--- a/tests/search/resize/resizebase.rb
+++ b/tests/search/resize/resizebase.rb
@@ -178,7 +178,7 @@ module ResizeApps
     end
 
     def slack_mindocs
-      400
+      700
     end
   end
 


### PR DESCRIPTION
@toregge and/or @baldersheim please review

Can now have many more merges going on at the same time, presumably
also increasing test noise correspondingly.