### PR TITLE
Revert "Disable workaround for performance tests on Darwin."

### DIFF
--- a/lib/node_server.rb
+++ b/lib/node_server.rb
@@ -1053,7 +1053,7 @@ def main(callback_endpoint)
 end
 
 if __FILE__ == $0
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6.0') && ! RUBY_PLATFORM =~ /darwin/
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6.0')
     # Ruby version >= 2.6.0 disables transparent hugepages for the process. This has negative effects
     # for forked processes and leads to a high number of interrupts (at least for the vespa-feed-perf client).
     # We fix this here by enabling the THP here before doing anything else.


### PR DESCRIPTION
Reverts vespa-engine/system-test#2064
@toregge PR
Revert to see if this is the cause for performance regression