### PR TITLE
Increase slack_maxhits to 250

### DIFF
--- a/tests/search/resize/resizebase.rb
+++ b/tests/search/resize/resizebase.rb
@@ -77,7 +77,7 @@ module ResizeApps
     end
 
     def slack_maxhits
-      200
+      250
     end
 
     def slack_mindocs
@@ -958,7 +958,7 @@ class ResizeContentClusterBase < SearchTest
     @bignumdocs = 100000
     @rapp = nil
     @poll_state = nil
-    @valgrind=false
+    @valgrind = false
     @poll_queries = nil
     @explore_doc_count_vector = nil
   end


### PR DESCRIPTION
Last failure:
Too many hits (5211 > 5200)
