### PR TITLE
We get longer snippets when not splitting interlinear annotations.

### DIFF
--- a/tests/search/bugs/5707026/bug5707026.rb
+++ b/tests/search/bugs/5707026/bug5707026.rb
@@ -38,8 +38,8 @@ class Bug5707026 < IndexedSearchTest
 
     query = "cafe+menu"
     wait_for_hitcount(query, 2)
-    exp_body_0 = "<sep/><hi>Café</hi> Surf's <hi>Café</hi> Print <hi>Menu</hi> Email a <sep/> Print <hi>Menu</hi> Print <sep/>"
-    exp_body_1 = "<sep/>week s Tuesday Dinner <hi>Menu</hi>! This pilot program is currently scheduled<sep/> or comments? Reach us at <hi>cafe</hi>@yahoo-inc.com ."
+    exp_body_0 = "<sep/><hi>Café</hi> Surf's <hi>Café</hi> Print <hi>Menu</hi> Email a Friend<sep/> Print <hi>Menu</hi> Print Details<sep/>"
+    exp_body_1 = "<sep/>week s Tuesday Dinner <hi>Menu</hi>! This pilot program is currently scheduled<sep/>Questions or comments? Reach us at <hi>cafe</hi>@yahoo-inc.com ."
     assert_field_value(query, "body", exp_body_0, 0)
     assert_field_value(query, "body", exp_body_1, 1)
   end

--- a/tests/search/dynteaser/time.long.result
+++ b/tests/search/dynteaser/time.long.result
@@ -8,6 +8,6 @@
     <field name="content">Kaw-Liga;Johnny Red;Ringo;The Hanging Tree;Despaerados Waiting For A Train;Lizzie And The Rainman;Mama Sang A Song;Honey;Marie Laveau;Ode To Billie Joe;Ten Thousand Drums;Hot Rod Lincoln;One Piece At A Time;Pancho And Lefty;Coat Of Many Colors</field>
     <field name="dyncontent"><sep /> Rod Lincoln;One Piece At A <hi>Time</hi>;Pancho And Lefty;Coat Of Many <sep /></field>
     <field name="content2"><sep /> Rod Lincoln;One Piece At A <hi>Time</hi>;Pancho And Lefty;Coat Of Many <sep /></field>
-    <field name="content3"><sep /> Drums;Hot Rod Lincoln;One Piece At A <hi>Time</hi>;Pancho And Lefty;Coat Of Many Colors. Additional<sep /></field>
+    <field name="content3"><sep />Thousand Drums;Hot Rod Lincoln;One Piece At A <hi>Time</hi>;Pancho And Lefty;Coat Of Many Colors. Additional<sep /></field>
   </hit>
 </result>

--- a/tests/search/dynteaser/time.result
+++ b/tests/search/dynteaser/time.result
@@ -6,8 +6,8 @@
     <field name="uri">en-0</field>
     <field name="url">en-0</field>
     <field name="content">Kaw-Liga;Johnny Red;Ringo;The Hanging Tree;Despaerados Waiting For A Train;Lizzie And The Rainman;Mama Sang A Song;Honey;Marie Laveau;Ode To Billie Joe;Ten Thousand Drums;Hot Rod Lincoln;One Piece At A Time;Pancho And Lefty;Coat Of Many Colors</field>
-    <field name="dyncontent"><sep /> Rod Lincoln;One Piece At A <hi>Time</hi>;Pancho And Lefty;Coat Of Many <sep /></field>
-    <field name="content2"><sep /> Rod Lincoln;One Piece At A <hi>Time</hi>;Pancho And Lefty;Coat Of Many <sep /></field>
-    <field name="content3"><sep /> Rod Lincoln;One Piece At A <hi>Time</hi>;Pancho And Lefty;Coat Of Many <sep /></field>
+    <field name="dyncontent"><sep />Hot Rod Lincoln;One Piece At A <hi>Time</hi>;Pancho And Lefty;Coat Of Many Colors<sep /></field>
+    <field name="content2"><sep />Hot Rod Lincoln;One Piece At A <hi>Time</hi>;Pancho And Lefty;Coat Of Many Colors<sep /></field>
+    <field name="content3"><sep />Hot Rod Lincoln;One Piece At A <hi>Time</hi>;Pancho And Lefty;Coat Of Many Colors<sep /></field>
   </hit>
 </result>


### PR DESCRIPTION
@geirst : please review
