### PR TITLE
Remove 'operation="append"' for config overrides.

### DIFF
--- a/lib/app_generator/config_overrides.rb
+++ b/lib/app_generator/config_overrides.rb
@@ -39,11 +39,6 @@ class ArrayConfig
   def initialize(name)
     @name = name
     @map = {}
-    @mode = 'item'
-  end
-  def append
-    @mode = 'append'
-    return self
   end
   def add(key, value)
     if !key.kind_of? Integer
@@ -55,20 +50,12 @@ class ArrayConfig
   end
 
   def to_xml(indent)
-    if @mode == 'item'
-      XmlHelper.new(indent).
-        tag(@name).
-        list_do(@map.keys) { |helper, key|
-          helper.tag("item").
-            to_xml(@map[key]).close_tag }.to_s
-    else
-      XmlHelper.new(indent).
-        list_do(@map.keys) { |helper, key|
-          helper.tag(@name, :operation => "append").
-            to_xml(@map[key]).close_tag }.to_s
-    end
+    XmlHelper.new(indent).
+      tag(@name).
+      list_do(@map.keys) { |helper, key|
+        helper.tag("item").
+          to_xml(@map[key]).close_tag }.to_s
   end
-
 end
 
 class MapConfig

--- a/lib/app_generator/test/storageapp_configoverride.xml
+++ b/lib/app_generator/test/storageapp_configoverride.xml
@@ -5,9 +5,13 @@
   </admin>
 
   <config name="metricsmanager">
-    <consumers operation="append">
-      <name>myconsumer</name>
-      <tags operation="append">logdefault</tags>
+    <consumers>
+      <item>
+        <name>myconsumer</name>
+        <tags>
+          <item>logdefault</item>
+        </tags>
+      </item>
     </consumers>
   </config>
 

--- a/lib/app_generator/test/storageapp_configoverride2.xml
+++ b/lib/app_generator/test/storageapp_configoverride2.xml
@@ -6,9 +6,11 @@
 
   <config name="metricsmanager">
     <snapshot>
-      <periods operation="append">10</periods>
-      <periods operation="append">60</periods>
-      <periods operation="append">300</periods>
+      <periods>
+        <item>10</item>
+        <item>60</item>
+        <item>300</item>
+      </periods>
     </snapshot>
   </config>
 

--- a/lib/app_generator/test/storagetest.rb
+++ b/lib/app_generator/test/storagetest.rb
@@ -22,14 +22,14 @@ class StorageAppGenTest < Test::Unit::TestCase
   def create_advanced_configoverride
     StorageApp.new.enable_http_gateway.default_cluster.sd("sd").provider("PROTON").
             config(ConfigOverride.new("metricsmanager").
-                add(ArrayConfig.new("consumers").append.
+                add(ArrayConfig.new("consumers").
                     add(0, ConfigValue.new("name", "myconsumer")).
-                    add(0, ArrayConfig.new("tags").append.
+                    add(0, ArrayConfig.new("tags").
                         add(0, "logdefault"))))
   end
 
   def create_advanced_configoverride2
-    snapshots = ArrayConfig.new("periods").append
+    snapshots = ArrayConfig.new("periods")
     snapshots.add(0, 10)
     snapshots.add(1, 60)
     snapshots.add(2, 300)

--- a/lib/app_generator/test/test.rb
+++ b/lib/app_generator/test/test.rb
@@ -647,12 +647,6 @@ class SearchAppGenTest < Test::Unit::TestCase
       <item>value1_1</item>
     </name>'
     assert_substring_ignore_whitespace(actual, expected_substr)
-
-    actual = config.append.to_xml(" ")
-    expected_substr = '
-      <name operation="append">value0_1value0_2</name>
-      <name operation="append">value1_1</name>'
-    assert_substring_ignore_whitespace(actual, expected_substr)
   end
 
   def test_map_config


### PR DESCRIPTION
- Deprecated for removal in Vespa 8

It was only used in the app generator and tests, not in any actual system tests.
