### PR TITLE
Wait longer when starting

### DIFF
--- a/tests/container/component_config/component_config.rb
+++ b/tests/container/component_config/component_config.rb
@@ -40,7 +40,7 @@ class ComponentConfig < SearchContainerTest
     set_expected_logged(/JDisc exiting: Throwable caught/)
     deploy(selfdir + "app_with_missing_config_value", nil, nil, :bundles => [@searcher])
     begin
-      start(20)
+      start(30)
     rescue Exception => e
       # Expected to fail
     end


### PR DESCRIPTION
Log message we are waiting for might not have been logged after
20 seconds, wait 30 seconds.