### PR TITLE
Add agentpath in jvm options attribute as well

### DIFF
--- a/lib/vespa_model.rb
+++ b/lib/vespa_model.rb
@@ -474,6 +474,13 @@ class VespaModel
         origattr = e.attributes['jvmargs']
         newattr += ' ' + origattr if origattr
         e.attributes['jvmargs'] = newattr
+
+        REXML::XPath.each(doc, path + "/jvm") do |e|
+          newattr = @testcase.perfmap_agent_jvmarg
+          origattr = e.attributes['options']
+          newattr += ' ' + origattr if origattr
+          e.attributes['options'] = newattr
+        end
       end
     end
     File.open(vespa_services, 'w') do |out|


### PR DESCRIPTION
I think this should fix the issue seen with GdTest::test_gd where agentpath is not set for the when using `jvmoptions` instead of `jvmargs` in test