### PR TITLE
Revert "Use documentapi instead of gateway"

### DIFF
--- a/patch
+++ b/patch
@@ -1,0 +1,78 @@
+diff --git a/lib/app_generator/container.rb b/lib/app_generator/container.rb
+index 9103af75..950775e6 100644
+--- a/lib/app_generator/container.rb
++++ b/lib/app_generator/container.rb
+@@ -19,6 +19,7 @@ class Container
+   chained_setter :gateway # todo: try to get rid of this, use :documentapi instead
+   chained_setter :documentapi
+   chained_setter :jvmargs
++  chained_setter :jvmoptions
+   chained_setter :jvmgcoptions
+   chained_setter :cpu_socket_affinity
+ 
+@@ -36,7 +37,7 @@ class Container
+     @id = id
+     @baseport = 0
+     @jetty = nil
+-    @jvmargs = nil
++    @jvmoptions = nil
+     @jvmgcoptions = nil
+     @cpu_socket_affinity = nil
+   end
+@@ -60,12 +61,15 @@ class Container
+     helper.tag("container", attrs)
+ 
+     nodeparams = @jvmargs ? { :jvmargs => @jvmargs } : {}
+-    if (@jvmgcoptions != nil) then
+-      nodeparams = nodeparams.merge({:"jvm-gc-options" => @jvmgcoptions})
+-    end
+-    if (@cpu_socket_affinity != nil) then
++    if @cpu_socket_affinity then
+       nodeparams = nodeparams.merge({:"cpu-socket-affinity" => @cpu_socket_affinity})
+     end
++
++    jvm_options = @jvmoptions ? { :options => @jvmoptions } : {}
++    if @jvmgcoptions
++      jvm_options =jvm_options.merge({:"gc-options" => @jvmgcoptions })
++    end
++
+     helper.
+       to_xml(@config).
+       to_xml(@search).
+@@ -77,7 +81,7 @@ class Container
+       to_xml(@handlers).
+       to_xml(@components).
+       to_xml(@http).
+-      tag("nodes", nodeparams).to_xml(node_list).close_tag.
++      tag("nodes", nodeparams).tag("jvm", jvm_options).close_tag.to_xml(node_list).close_tag.
+       to_s
+   end
+ end
+diff --git a/lib/app_generator/test/containertest.rb b/lib/app_generator/test/containertest.rb
+index 7982b315..8e5a4c68 100644
+--- a/lib/app_generator/test/containertest.rb
++++ b/lib/app_generator/test/containertest.rb
+@@ -214,6 +214,23 @@ class ContainerAppGenTest < Test::Unit::TestCase
+     assert_substring_ignore_whitespace(actual, expected_substr)
+   end
+ 
++  def test_jvm_options
++    actual =
++      Container.new.jvmgcoptions('-XX:+UseG1GC -XX:MaxTenuringThreshold=10').
++        jvmoptions('-Dfoo=bar -Dvespa_foo=bar -Xms256m -Xms256m').
++    to_xml("")
++
++    expected_substr =
++    '<container id="default" version="1.0">
++      <nodes>
++        <jvm gc-options="-XX:+UseG1GC -XX:MaxTenuringThreshold=10" options="-Dfoo=bar -Dvespa_foo=bar -Xms256m -Xms256m" />
++        <node hostalias="node1" />
++      </nodes>'
++
++    assert_substring_ignore_whitespace(actual, expected_substr)
++  end
++
++
+   def test_cpu_pinning
+     verify('basic_cpu_pinning.xml', ContainerApp.new.container(Container.new.cpu_socket_affinity(true)))
+   end

--- a/tests/container/http_server/http_server.rb
+++ b/tests/container/http_server/http_server.rb
@@ -20,7 +20,7 @@ class HttpServer < SearchContainerTest
     deploy_app(ContainerApp.new.
                container(Container.new.
                          jvmargs(nil).
-                         documentapi(ContainerDocumentApi.new).
+                         gateway(ContainerDocumentApi.new).
                          search(Searching.new.
                                 chain(Chain.new("default").
                                       add(Searcher.new("test.OutputHttpServerIdentity").

--- a/tests/performance/basic/dispatch/stress_dispatch.rb
+++ b/tests/performance/basic/dispatch/stress_dispatch.rb
@@ -31,7 +31,7 @@ class StressDispatch < PerformanceTest
                                  Searcher.new("com.yahoo.example.CapInFillSearcher")).
                                  inherits("vespa"))).
                     docproc(DocumentProcessing.new).
-                    documentapi(ContainerDocumentApi.new)).
+                    gateway(ContainerDocumentApi.new)).
           indexing("combinedcontainer").
           threads_per_search(1).
           persistence_threads(PersistenceThreads.new(8)).

--- a/tests/performance/collection_feed/weighted_set_feed.rb
+++ b/tests/performance/collection_feed/weighted_set_feed.rb
@@ -56,7 +56,7 @@ class WeightedSetFeedTest < PerformanceTest
                             jvmargs('-Xms16g -Xmx16g').
                             search(Searching.new).
                             docproc(DocumentProcessing.new).
-                            documentapi(ContainerDocumentApi.new)).
+                            gateway(ContainerDocumentApi.new)).
     generic_service(GenericService.new('devnull', "#{Environment.instance.vespa_home}/bin/vespa-destination --instant --silent 1000000000"))
   end
 

--- a/tests/performance/document_rest_api/document_v1_throughput.rb
+++ b/tests/performance/document_rest_api/document_v1_throughput.rb
@@ -119,7 +119,7 @@ class DocumentV1Throughput < PerformanceTest
             jvmargs('-Xms16g -Xmx16g').
             search(Searching.new).
             docproc(DocumentProcessing.new).
-            documentapi(ContainerDocumentApi.new)).
+            gateway(ContainerDocumentApi.new)).
         admin_metrics(Metrics.new).
         indexing("combinedcontainer").
         sd(selfdir + "text.sd"))

--- a/tests/performance/document_rest_api/visiting.rb
+++ b/tests/performance/document_rest_api/visiting.rb
@@ -28,7 +28,7 @@ class Visiting < PerformanceTest
         Container.new("container").
         jvmargs('-Xms8g -Xmx8g').
         docproc(DocumentProcessing.new).
-        documentapi(ContainerDocumentApi.new)).
+        gateway(ContainerDocumentApi.new)).
       admin_metrics(Metrics.new).
       indexing("container").
       sd(selfdir + "test.sd").

--- a/tests/performance/fast_access_attributes/fast_access_attributes.rb
+++ b/tests/performance/fast_access_attributes/fast_access_attributes.rb
@@ -41,7 +41,7 @@ class FastAccessAttributesPerfTest < PerformanceTest
                     jvmargs('-Xms8g -Xmx8g').
                     search(Searching.new).
                     docproc(DocumentProcessing.new).
-                    documentapi(ContainerDocumentApi.new)).
+                    gateway(ContainerDocumentApi.new)).
           indexing("combinedcontainer").
       num_parts(2).redundancy(2).ready_copies(1).
       visibility_delay(0.002).

--- a/tests/performance/feeding_and_recovery/feeding_and_recovery.rb
+++ b/tests/performance/feeding_and_recovery/feeding_and_recovery.rb
@@ -159,7 +159,7 @@ class FeedingAndRecoveryTest < PerformanceTest
                 jvmargs('-Xms16g -Xmx16g').
                 search(Searching.new).
                 docproc(DocumentProcessing.new).
-                documentapi(ContainerDocumentApi.new)).
+                gateway(ContainerDocumentApi.new)).
       indexing("combinedcontainer").
       config(ConfigOverride.new("vespa.config.content.core.stor-distributormanager").
              add("garbagecollection",

--- a/tests/performance/feeding_and_removing/feeding_and_removing_base.rb
+++ b/tests/performance/feeding_and_removing/feeding_and_removing_base.rb
@@ -27,12 +27,12 @@ class FeedingAndRemovingBase < PerformanceTest
 
   def create_app(visibility_delay = 0, index_threads = 1)
     sd_file = selfdir + "test.sd"
-    app = SearchApp.new.enable_http_documentapi.sd(sd_file).
+    app = SearchApp.new.enable_http_gateway.sd(sd_file).
       container(Container.new("combinedcontainer").
                 jvmargs('-Xms8g -Xmx8g').
                 search(Searching.new).
                 docproc(DocumentProcessing.new).
-                documentapi(ContainerDocumentApi.new)).
+                gateway(ContainerDocumentApi.new)).
       indexing("combinedcontainer").
       redundancy(1).ready_copies(1).threads_per_search(4).
       disable_flush_tuning.

--- a/tests/performance/feeding_multiple_doc_types/feeding_multiple_doc_types.rb
+++ b/tests/performance/feeding_multiple_doc_types/feeding_multiple_doc_types.rb
@@ -72,12 +72,12 @@ class FeedingMultipleDocTypesTest < PerformanceTest
   def create_app(sd_files)
     app = SearchApp.new.
             visibility_delay(0.002).
-            enable_http_documentapi.disable_flush_tuning.
+            enable_http_gateway.disable_flush_tuning.
             container(Container.new("combinedcontainer").
                       jvmargs('-Xms16g -Xmx16g').
                       search(Searching.new).
                       docproc(DocumentProcessing.new).
-                      documentapi(ContainerDocumentApi.new)).
+                      gateway(ContainerDocumentApi.new)).
             indexing("combinedcontainer").
             generic_service(GenericService.new('devnull', "#{Environment.instance.vespa_home}/bin/vespa-destination --instant --silent 1000000000")).
             config(ConfigOverride.new("vespa.config.content.stor-filestor").

--- a/tests/performance/lookup/lookup.rb
+++ b/tests/performance/lookup/lookup.rb
@@ -22,7 +22,7 @@ class LookupPerformance < PerformanceTest
                                       jvmargs("-Xms16g -Xmx16g").
                                       search(Searching.new).
                                       docproc(DocumentProcessing.new).
-                                      documentapi(ContainerDocumentApi.new).
+                                      gateway(ContainerDocumentApi.new).
                                       component(AccessLog.new("disabled"))).
                   indexing("combinedcontainer")
   end

--- a/tests/performance/nearest_neighbor/nearest_neighbor.rb
+++ b/tests/performance/nearest_neighbor/nearest_neighbor.rb
@@ -81,7 +81,7 @@ class NearestNeighborPerformanceTest < PerformanceTest
           container(Container.new("combinedcontainer").
                     search(Searching.new).
                     docproc(DocumentProcessing.new).
-                    documentapi(ContainerDocumentApi.new)).
+                    gateway(ContainerDocumentApi.new)).
           indexing("combinedcontainer").
           threads_per_search(1)
     deploy_app(app)

--- a/tests/performance/parent_child/parent_child_perf.rb
+++ b/tests/performance/parent_child/parent_child_perf.rb
@@ -67,7 +67,7 @@ class ParentChildPerfTest < PerformanceTest
                             jvmargs('-Xms16g -Xmx16g').
                             search(Searching.new).
                             docproc(DocumentProcessing.new).
-                            documentapi(ContainerDocumentApi.new)).
+                            gateway(ContainerDocumentApi.new)).
                   indexing("combinedcontainer")
   end
 

--- a/tests/performance/phrase/phrase_cases.rb
+++ b/tests/performance/phrase/phrase_cases.rb
@@ -40,7 +40,7 @@ class PhraseCasesPerformanceTest < PerformanceTest
           container(Container.new("combinedcontainer").
                     search(Searching.new).
                     docproc(DocumentProcessing.new).
-                    documentapi(ContainerDocumentApi.new)).
+                    gateway(ContainerDocumentApi.new)).
           indexing("combinedcontainer").
           threads_per_search(1)
     deploy_app(app)

--- a/tests/performance/programmatic_feed_client/programmatic_feed_client.rb
+++ b/tests/performance/programmatic_feed_client/programmatic_feed_client.rb
@@ -124,7 +124,7 @@ class ProgrammaticFeedClientTest < PerformanceTest
     container_cluster = Container.new("dpcluster1").
       jvmargs('-Xms16g -Xmx16g').
       search(Searching.new).
-      documentapi(ContainerDocumentApi.new).
+      gateway(ContainerDocumentApi.new).
       component(AccessLog.new("disabled")).
       config(ConfigOverride.new("container.handler.threadpool").add("maxthreads", 4))
     output = deploy_app(SearchApp.new.

--- a/tests/performance/raw_indexing/raw_indexing.rb
+++ b/tests/performance/raw_indexing/raw_indexing.rb
@@ -89,7 +89,7 @@ class FeedingIndexTest < PerformanceTest
                                 jvmargs('-Xms10g -Xmx10g').
                                 search(Searching.new).
                                 docproc(DocumentProcessing.new).
-                                documentapi(ContainerDocumentApi.new)).
+                                gateway(ContainerDocumentApi.new)).
         generic_service(GenericService.new('devnull', "#{Environment.instance.vespa_home}/bin/vespa-destination --instant --silent 1000000000"))
     end
     

--- a/tests/performance/reindexing/reindexing_and_feeding.rb
+++ b/tests/performance/reindexing/reindexing_and_feeding.rb
@@ -26,7 +26,7 @@ class ReindexingAndFeedingTest < PerformanceTest
 		jvmargs('-Xms16g -Xmx16g').
 		search(Searching.new).
 		docproc(DocumentProcessing.new).
-		documentapi(ContainerDocumentApi.new)).
+		gateway(ContainerDocumentApi.new)).
     admin_metrics(Metrics.new).
     indexing("combinedcontainer").
     sd(selfdir + "doc.sd")

--- a/tests/performance/state_transition/gets_during_state_transitions.rb
+++ b/tests/performance/state_transition/gets_during_state_transitions.rb
@@ -38,7 +38,7 @@ class GetsDuringStateTransitionsTest < PerformanceTest
     container(Container.new("combinedcontainer").
                             search(Searching.new).
                             docproc(DocumentProcessing.new).
-                            documentapi(ContainerDocumentApi.new)).
+                            gateway(ContainerDocumentApi.new)).
     config(ConfigOverride.new('vespa.config.content.core.stor-distributormanager').
                           add('simulated_db_pruning_latency_msec', 2000).
                           add('simulated_db_merging_latency_msec', 3000).

--- a/tests/search/booleansearch/booleansearch.rb
+++ b/tests/search/booleansearch/booleansearch.rb
@@ -28,7 +28,7 @@ class BooleanSearchTest < SearchTest
         container(Container.new("combinedcontainer").
             search(Searching.new).
             docproc(DocumentProcessing.new).
-            documentapi(ContainerDocumentApi.new)))
+            gateway(ContainerDocumentApi.new)))
     start
   end
 

--- a/tests/search/concretedocs/concretedocs.rb
+++ b/tests/search/concretedocs/concretedocs.rb
@@ -17,7 +17,7 @@ class ConcreteDocs < SearchTest
                sd(selfdir + 'concretedocs2/disease.sd').
                container(Container.new('default').
                          search(Searching.new).
-                         documentapi(ContainerDocumentApi.new.documentapi(true)).
+                         documentapi(ContainerDocumentApi.new.gateway(true)).
                          concretedoc(ConcreteDoc.new('vehicle')).
                          concretedoc(ConcreteDoc.new('ship')).
                          concretedoc(ConcreteDoc.new('disease').

--- a/tests/search/fbench/run_fbench.rb
+++ b/tests/search/fbench/run_fbench.rb
@@ -96,11 +96,11 @@ class Fbench2 < IndexedSearchTest
     c_cluster_a = Container.new('c-a').
                     search(Searching.new).
                     http(Http.new.server(Server.new('foo-server', 6180))).
-                    documentapi(ContainerDocumentApi.new)
+                    gateway(ContainerDocumentApi.new)
     c_cluster_b = Container.new('c-b').
                     search(Searching.new).
                     http(Http.new.server(Server.new('bar-server', 6190))).
-                    documentapi(ContainerDocumentApi.new)
+                    gateway(ContainerDocumentApi.new)
     deploy_app(SearchApp.new.
                  sd("#{selfdir}/banana.sd").
                  container(c_cluster_a).

--- a/tests/search/feed_block/feed_block_base.rb
+++ b/tests/search/feed_block/feed_block_base.rb
@@ -39,8 +39,8 @@ class FeedBlockBase < IndexedSearchTest
                 search(Searching.new).
                 component(AccessLog.new("disabled")).
                 docproc(DocumentProcessing.new).
-                documentapi(ContainerDocumentApi.new).
-                http(Http.new.server(Server.new("node1", vespa.default_http_documentapi_port)))).
+                gateway(ContainerDocumentApi.new).
+                http(Http.new.server(Server.new("node1", vespa.default_http_gateway_port)))).
       sd(selfdir + "test.sd").num_parts(@num_parts).redundancy(@num_parts).ready_copies(1)
   end
 

--- a/tests/search/feed_block/feed_block_disk_two_nodes_base.rb
+++ b/tests/search/feed_block/feed_block_disk_two_nodes_base.rb
@@ -79,8 +79,8 @@ class FeedBlockDiskTwoNodesBase < FeedBlockBase
                 search(Searching.new).
                 component(AccessLog.new("disabled")).
                 docproc(DocumentProcessing.new).
-                documentapi(ContainerDocumentApi.new).
-                http(Http.new.server(Server.new("node1", vespa.default_http_documentapi_port)))).
+                gateway(ContainerDocumentApi.new).
+                http(Http.new.server(Server.new("node1", vespa.default_http_gateway_port)))).
       storage(StorageCluster.new(@cluster_name, 41)).
       config(get_tls_configoverride).
       config(get_flush_configoverride).

--- a/tests/search/httpclient_docproc/httpclient_docproc.rb
+++ b/tests/search/httpclient_docproc/httpclient_docproc.rb
@@ -23,7 +23,7 @@ class HttpClientDocProcTest < SearchTest
     add_bundle(DOCPROC + "/SpawningMusicDocProc.java")
     container_cluster = Container.new("dpcluster1").
                             search(Searching.new).
-                            documentapi(ContainerDocumentApi.new).
+                            gateway(ContainerDocumentApi.new).
                             docproc(DocumentProcessing.new.chain(Chain.new("default").add(
                                     DocumentProcessor.new("com.yahoo.vespatest.SpawningMusicDocProc"))))
     output = deploy_app(SearchApp.new.

--- a/tests/search/httpclient_docproc/massive_http_client_feeding.rb
+++ b/tests/search/httpclient_docproc/massive_http_client_feeding.rb
@@ -60,7 +60,7 @@ class MassiveHttpClientFeedingTest < SearchTest
       component(AccessLog.new("disabled")).
       jvmargs("-Xms4096m -Xmx4096m").
       search(Searching.new).
-      documentapi(ContainerDocumentApi.new).
+      gateway(ContainerDocumentApi.new).
       config(ConfigOverride.new("container.handler.threadpool").add("maxthreads", 4)).
       http(Http.new.
         server(

--- a/tests/search/metricsproxy/metricsproxy.rb
+++ b/tests/search/metricsproxy/metricsproxy.rb
@@ -12,7 +12,7 @@ class MetricsProxy < IndexedSearchTest
     SearchApp.new.
       sd(SEARCH_DATA+'music.sd').
       container(Container.new.
-                  documentapi(ContainerDocumentApi.new).
+                  gateway(ContainerDocumentApi.new).
                   search(Searching.new))
   end
 

--- a/tests/search/reindexing/reindexing.rb
+++ b/tests/search/reindexing/reindexing.rb
@@ -20,7 +20,7 @@ class ReindexingTest < IndexedSearchTest
         container(Container.new('combinedcontainer').
             search(Searching.new).
             docproc(DocumentProcessing.new).
-            documentapi(ContainerDocumentApi.new))
+            gateway(ContainerDocumentApi.new))
     deploy_app(app)
     start
     container_node = @vespa.container["combinedcontainer/0"]

--- a/tests/search/routingdocapitag/routingdocapitag.rb
+++ b/tests/search/routingdocapitag/routingdocapitag.rb
@@ -16,7 +16,7 @@ class RoutingDocApiTagTest < IndexedSearchTest
             .doc_type("book"))\
         .container(Container.new\
             .search(Searching.new)\
-            .documentapi(ContainerDocumentApi.new))
+            .gateway(ContainerDocumentApi.new))
     deploy_app(app)
     # TODO: Remove hack that is need to use correct port
     @get_params = { :route => "storage/cluster.storage", :port => Environment.instance.vespa_web_service_port }

--- a/tests/search/schemachanges/schemachanges_elasticonly.rb
+++ b/tests/search/schemachanges/schemachanges_elasticonly.rb
@@ -24,15 +24,15 @@ class SchemaChangesElastic < IndexedSearchTest
     @test_dir = selfdir + "docdb/"
     deploy_output = deploy_app(SearchApp.new.
                                sd(@test_dir + "testa.sd").
-                               documentapi("node1").
-                               enable_http_documentapi)
+                               gateway("node1").
+                               enable_http_gateway)
     start
     postdeploy_wait(deploy_output)
     feed_and_wait_for_docs("testa", 1, :file => @test_dir + "feed.0.xml")
 
     puts "add 'testb' documentdb"
     deploy_output = deploy_app(SearchApp.new.
-                               enable_http_documentapi.
+                               enable_http_gateway.
                                sd(@test_dir + "testa.sd").sd(@test_dir + "testb.sd"))
     wait_for_content_cluster_config_generation(deploy_output)
     postdeploy_wait(deploy_output)

--- a/tests/search/visibility/visibility.rb
+++ b/tests/search/visibility/visibility.rb
@@ -159,8 +159,8 @@ class Visibility < IndexedSearchTest
                 search(Searching.new).
                 component(AccessLog.new("disabled")).
                 docproc(DocumentProcessing.new).
-                documentapi(ContainerDocumentApi.new).
-                http(Http.new.server(Server.new("node1", vespa.default_http_documentapi_port)))).
+                gateway(ContainerDocumentApi.new).
+                http(Http.new.server(Server.new("node1", vespa.default_http_gateway_port)))).
             cluster(sc).
             storage(StorageCluster.new("visibility", 41).distribution_bits(16))
   end

--- a/tests/vds/vds_basic_feeding.rb
+++ b/tests/vds/vds_basic_feeding.rb
@@ -1,4 +1,4 @@
-# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 require 'multi_provider_storage_test'
 
 class VdsBasicFeeding < MultiProviderStorageTest
@@ -57,22 +57,30 @@ class VdsBasicFeeding < MultiProviderStorageTest
       add_field("year",  1997).
       add_field("tracks", [ "Track 1", "Track 2", "Track 3" ])
 
+#    puts "doc1 XML: " + doc1.to_xml
+
     # Get the documents we just stored using vespa-feeder
     doc2 = vespa.document_api_v1.get("id:music:music::http://music.yahoo.com/bobdylan/BestOf")
 
+#    puts "doc2 XML: " + doc2.to_xml
+
     assert_equal(doc1, doc2)
 
-    # Put document with array attribute using document API
+    # Put document with array attribute using SOAP gateway
     doc3 = Document.new("music", "id:storage_test:music:n=1234:soap").
       add_field("url", "http://music.yahoo.com/soap").
       add_field("title", "SoapTitle").
       add_field("artist", "Vespa").
       add_field("tracks", [ "123", "456", "789" ])
 
+#    puts "doc3 XML: " + doc3.to_xml
+
     vespa.document_api_v1.put(doc3)
 
-    # Get the documents we just stored using document API
+    # Get the documents we just stored using SOAP gateway
     doc4 = vespa.document_api_v1.get("id:storage_test:music:n=1234:soap")
+
+#    puts "doc4 XML: " + doc4.to_xml
 
     assert_equal(doc3, doc4)
   end
@@ -93,22 +101,30 @@ class VdsBasicFeeding < MultiProviderStorageTest
       add_field("year",  1997).
       add_field("popularity", { 0 => 10, 1 => 11, 2 => 12 })
 
+#    puts "doc1 XML: " + doc1.to_xml
+
     # Get the documents we just stored using vespa-feeder
     doc2 = vespa.document_api_v1.get("id:music:music::http://music.yahoo.com/bobdylan/BestOf")
 
+#    puts "doc2 XML: " + doc2.to_xml
+
     assert_equal(doc1, doc2)
 
-    # Put document with weightedset attribute using document API
+    # Put document with weightedset attribute using SOAP gateway
     doc3 = Document.new("music", "id:storage_test:music:n=1234:soap").
       add_field("url", "http://music.yahoo.com/soap").
       add_field("title", "SoapTitle").
       add_field("artist", "Vespa").
       add_field("popularity", { 3 =>20, 4 => 31, 5 => 42 })
 
+#    puts "doc3 XML: " + doc3.to_xml
+
     vespa.document_api_v1.put(doc3)
 
-    # Get the documents we just stored using document API
+    # Get the documents we just stored using SOAP gateway
     doc4 = vespa.document_api_v1.get("id:storage_test:music:n=1234:soap")
+
+#    puts "doc4 XML: " + doc4.to_xml
 
     assert_equal(doc3, doc4)
   end


### PR DESCRIPTION
Reverts vespa-engine/system-test#2127

Didn't work, mixed up some things when doing search and replace