### PR TITLE
Start removing support for 'gateway'

### DIFF
--- a/lib/app_generator/app.rb
+++ b/lib/app_generator/app.rb
@@ -100,7 +100,6 @@ class App
   chained_forward :clients,
                   :gateways_jvmargs => :gateways_jvmargs,
                   :feeder_options => :feeder_options,
-                  :gateway => :gateway,
                   :load_type => :load_type
   chained_forward :generic_services, :generic_service => :service
 

--- a/lib/app_generator/clients.rb
+++ b/lib/app_generator/clients.rb
@@ -55,10 +55,6 @@ class Clients
     return [Gateway.new("node1")]
   end
 
-  def gateway(hostalias, jvmargs = nil, baseport="")
-    @gateways.push(Gateway.new(hostalias, jvmargs, baseport))
-  end
-
   def create_gateways(indent)
     if (@accept_no_clients && @gateways.empty?)
       return ""

--- a/lib/app_generator/container.rb
+++ b/lib/app_generator/container.rb
@@ -16,7 +16,6 @@ class Container
   chained_setter :docproc
   chained_setter :processing
   chained_setter :http
-  chained_setter :gateway # todo: try to get rid of this, use :documentapi instead
   chained_setter :documentapi
   chained_setter :jvmargs
   chained_setter :jvmoptions
@@ -76,7 +75,6 @@ class Container
       to_xml(@docproc).
       to_xml(@concretedocs).
       to_xml(@processing).
-      to_xml(@gateway).
       to_xml(@documentapi).
       to_xml(@handlers).
       to_xml(@components).

--- a/lib/app_generator/test/test.rb
+++ b/lib/app_generator/test/test.rb
@@ -253,23 +253,6 @@ class SearchAppGenTest < Test::Unit::TestCase
     assert_substring_ignore_whitespace(actual, expected_substr)
   end
 
-  def test_multiple_gateways
-    actual = SearchApp.new.gateway("node1").gateway("node2").
-             services_xml
-    expected_substr = '
-      <container id="doc-api" version="1.0">
-        <document-api />
-        <http>
-            <server id="default" port="19020" />
-        </http>
-        <nodes>
-          <node hostalias="node1" />
-          <node hostalias="node2" />
-        </nodes>
-      </container>'
-    assert_substring_ignore_whitespace(actual, expected_substr)
-  end
-
   def test_multiple_slobroks
     actual = SearchApp.new.slobrok("node1").slobrok("node2").
              services_xml
@@ -557,12 +540,6 @@ class SearchAppGenTest < Test::Unit::TestCase
             <server id="default" port="19020" />
         </http>
         <nodes jvmargs="-Option">'
-    assert_substring_ignore_whitespace(actual, expected_substr)
-  end
-
-  def test_gateway_jvmargs
-    actual = SearchApp.new.gateway("foo", '-Option').services_xml
-    expected_substr = '<node hostalias="foo" jvmargs="-Option" />'
     assert_substring_ignore_whitespace(actual, expected_substr)
   end
 


### PR DESCRIPTION
Remove support for creating gateway with hostname and/or jvmargs,
only used in test code.