### PR TITLE
Test app with several partitions and document API

### DIFF
--- a/lib/app_generator/test/complex_elastic.xml
+++ b/lib/app_generator/test/complex_elastic.xml
@@ -57,4 +57,14 @@
     </engine>
   </content>
 
+  <container id="doc-api" version="1.0">
+    <document-api />
+    <http>
+      <server id="default" port="19020" />
+    </http>
+    <nodes jvmargs="-Xms64m -Xmx256m">
+      <node hostalias="node1" />
+    </nodes>
+  </container>
+
 </services>

--- a/lib/app_generator/test/test.rb
+++ b/lib/app_generator/test/test.rb
@@ -20,6 +20,7 @@ class SearchAppGenTest < Test::Unit::TestCase
   def create_complex
     SearchApp.new.sd("sd1").sd("sd2").sd("sd3").
       cluster_name("storage").num_parts(4).redundancy(3).
+      enable_document_api.
       config(ConfigOverride.new("stor-distribution").
              add("ready_copies", 2))
   end


### PR DESCRIPTION
Add test covering the case where we want to use smaller heap for
doc api container when having multiple partitions
