### PR TITLE
Revert "decode summary features also when parsing XML"

### DIFF
--- a/lib/hit.rb
+++ b/lib/hit.rb
@@ -62,11 +62,7 @@ class Hit
       fieldname = e.attribute("name").to_s
       fieldvalue = e.children.join("").to_s
 
-      if fieldname == 'summaryfeatures' and fieldvalue[0] == '{'
-        sf = JSON.parse(fieldvalue)
-        sf.delete('vespa.summaryFeatures.cached')
-        add_field(fieldname, sf)
-      elsif e.elements["item"] != nil
+      if e.elements["item"] != nil
         items = []
         e.each_element("item") do |item|
           items.push(parse_item(item))

--- a/tests/search/attributematchfeatures/attributematchfeatures.rb
+++ b/tests/search/attributematchfeatures/attributematchfeatures.rb
@@ -105,8 +105,8 @@ class AttributeMatchFeatures < IndexedStreamingSearchTest
         pexp["attributeMatch(#{field}).#{name}"] = score
       end
     end
-    puts "#{result.hit[docid].field['summaryfeatures']}"
-    assert_features(pexp, result.hit[docid].field['summaryfeatures'], 1e-4)
+    puts "#{result.hit[docid].field["summaryfeatures"]}"
+    assert_features(pexp, JSON.parse(result.hit[docid].field["summaryfeatures"]), 1e-4)
   end
 
   def teardown

--- a/tests/search/booleansearch/booleansearch.rb
+++ b/tests/search/booleansearch/booleansearch.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 # -*- coding: utf-8 -*-
 require 'indexed_search_test'
@@ -524,7 +523,7 @@ class BooleanSearchTest < SearchTest
       exp_docid = "id:test:test::#{expected_hit[0]}"
       puts "Expects that hit[#{i}].documentid == '#{exp_docid}'"
       assert_field_value(result, "documentid", exp_docid, i)
-      actual_summaryfeatures = result.hit[i].field['summaryfeatures']
+      actual_summaryfeatures = JSON.parse(result.hit[i].field["summaryfeatures"])
       assert_int_features(actual_summaryfeatures,
         {"subqueries(predicate_field).lsb" => expected_hit[1] & 0xFFFFFFFF,
          "subqueries(predicate_field).msb" => (expected_hit[1] >> 32) & 0xFFFFFFFF})
@@ -534,7 +533,7 @@ class BooleanSearchTest < SearchTest
   def assert_summary_features_matches(query, expected_summaryfeatures)
     result = search('/search/?query=&yql=' + query)
     assert_hitcount(result, 1)
-    actual_summaryfeatures = result.hit[0].field['summaryfeatures']
+    actual_summaryfeatures = JSON.parse(result.hit[0].field["summaryfeatures"])
     assert_int_features(actual_summaryfeatures, expected_summaryfeatures)
   end
 

--- a/tests/search/combiningfeatures/combiningfeatures.rb
+++ b/tests/search/combiningfeatures/combiningfeatures.rb
@@ -57,7 +57,7 @@ class CombiningFeatures < IndexedSearchTest
   def assert_feature(expected, query)
     query = "query=" + query + "&parallel&nocache&type=any"
     result = search(query)
-    assert_features(expected, result.hit[0].field['summaryfeatures'], 1e-4)
+    assert_features(expected, JSON.parse(result.hit[0].field["summaryfeatures"]), 1e-4)
   end
 
   def teardown

--- a/tests/search/distancetopath/distancetopath.rb
+++ b/tests/search/distancetopath/distancetopath.rb
@@ -116,7 +116,7 @@ class DistanceToPath < IndexedSearchTest
     results = search("query=sddocname:local&rankproperty.distanceToPath(gps).path=(0,0,10,0,10,5,20,5)&" +
                      "rankproperty.distance=#{distance}&rankproperty.traveled=#{traveled}&ranking=#{ranking}")
     results.hit.each do |document|
-      features = document.field['summaryfeatures']
+      features = JSON.parse(document.field["summaryfeatures"])
       puts("- Relevancy " + document.field["relevancy"].to_s + ": " +
            "Document '" + document.field["title"] + "' with distance " +
            features.fetch("distanceToPath(gps).distance").to_s + " after " +
@@ -134,7 +134,7 @@ class DistanceToPath < IndexedSearchTest
     assert_hitcount(query, 1)
     assert_features({ "distanceToPath(gps).distance" => distance,
                       "distanceToPath(gps).traveled" => traveled },
-                    search(query).hit[0].field['summaryfeatures'])
+                    JSON.parse(search(query).hit[0].field["summaryfeatures"]))
   end
 
   def teardown

--- a/tests/search/documentfeatures/documentfeatures.rb
+++ b/tests/search/documentfeatures/documentfeatures.rb
@@ -59,7 +59,7 @@ class DocumentFeatures < IndexedStreamingSearchTest
 
   def assert_attribute(feature, score)
     result = search("query=idx:a&streaming.userid=1")
-    assert_features({feature => score}, result.hit[0].field['summaryfeatures'])
+    assert_features({feature => score}, JSON.parse(result.hit[0].field["summaryfeatures"]))
   end
 
   def teardown

--- a/tests/search/dot_product_search/dot_product_search.rb
+++ b/tests/search/dot_product_search/dot_product_search.rb
@@ -56,7 +56,7 @@ class DotProductSearch < IndexedSearchTest
     result = search(build_query(model))
     assert_equal(expect.size, result.hit.size)
     expect.each_with_index do |expected_sub_scores,i|
-      jsf = result.hit[i].field['summaryfeatures']
+      jsf = JSON.parse(result.hit[i].field["summaryfeatures"])
       sub_scores = extract_subscores(jsf, model.size)
       assert_equal(expected_sub_scores, sub_scores,
                    "subscores differ for hit #{i}: #{expected_sub_scores} != #{sub_scores}")

--- a/tests/search/dotproductfeature/dotproductfeature.rb
+++ b/tests/search/dotproductfeature/dotproductfeature.rb
@@ -53,7 +53,7 @@ class DotProductFeature < IndexedStreamingSearchTest
     end
     puts "run '#{query}'"
     result = search(query)
-    assert_features(expected, result.hit[0].field['summaryfeatures'], 1e-4)
+    assert_features(expected, JSON.parse(result.hit[0].field["summaryfeatures"]), 1e-4)
   end
 
 

--- a/tests/search/equiv/equiv.rb
+++ b/tests/search/equiv/equiv.rb
@@ -74,7 +74,7 @@ class Equiv < IndexedSearchTest
     exp = { "fieldMatch(body).fieldCompleteness" => 1,
             "fieldMatch(body).queryCompleteness" => 1,
             "queryTermCount" => 1 }
-    assert_features(exp, result.hit[0].field['summaryfeatures'])
+    assert_features(exp, JSON.parse(result.hit[0].field["summaryfeatures"]))
 
     puts "==== ==== ==== ==== ==== ==== ==== ==== ==== ===="
     puts "test that EQUIV and multiple alternatives can be combined"
@@ -91,7 +91,7 @@ class Equiv < IndexedSearchTest
     exp = { "fieldMatch(body).fieldCompleteness" => 0.5,
             "fieldMatch(body).queryCompleteness" => 1,
             "queryTermCount" => 1 }
-    assert_features(exp, result.hit[0].field['summaryfeatures'])
+    assert_features(exp, JSON.parse(result.hit[0].field["summaryfeatures"]))
 
     puts "==== ==== ==== ==== ==== ==== ==== ==== ==== ===="
     puts "test for occurrence merging"
@@ -105,7 +105,7 @@ class Equiv < IndexedSearchTest
             "fieldInfo(body).first" => 1,
             "fieldInfo(body).last" => 7,
             "fieldInfo(body).cnt" => 6 }
-    assert_features(exp, result.hit[0].field["summaryfeatures"])
+    assert_features(exp, JSON.parse(result.hit[0].field["summaryfeatures"]))
 
     puts "==== ==== ==== ==== ==== ==== ==== ==== ==== ===="
     puts "test for occurrence merging (now with duplicates)"
@@ -120,7 +120,7 @@ class Equiv < IndexedSearchTest
             "fieldInfo(body).first" => 1,
             "fieldInfo(body).last" => 7,
             "fieldInfo(body).cnt" => 6 }
-    assert_features(exp, result.hit[0].field['summaryfeatures'])
+    assert_features(exp, JSON.parse(result.hit[0].field["summaryfeatures"]))
 
     puts "==== ==== ==== ==== ==== ==== ==== ==== ==== ===="
     puts "test for document frequency merging"

--- a/tests/search/expressions_as_arguments/expressions_as_arguments.rb
+++ b/tests/search/expressions_as_arguments/expressions_as_arguments.rb
@@ -18,7 +18,7 @@ class ExpressionsAsArguments < IndexedSearchTest
     start
     feed_and_wait_for_docs("test", 1, :file => selfdir + "feed.json")
     result = search("query=sddocname:test&ranking=test")
-    summary = result.hit[0].field['summaryfeatures']
+    summary = JSON.parse(result.hit[0].field["summaryfeatures"])
 
     puts summary
 

--- a/tests/search/fieldmatchfeatures/fieldmatchfeatures_base.rb
+++ b/tests/search/fieldmatchfeatures/fieldmatchfeatures_base.rb
@@ -144,7 +144,7 @@ module FieldMatchFeaturesBase
     result.hit.each do |hit|
       if hit.field[@id_field] == "id:fieldmatch:fieldmatch:n=1:#{docid}"
         # same epsilon as searchlib unit tests
-        assert_features(expected, hit.field['summaryfeatures'], 1e-4)
+        assert_features(expected, JSON.parse(hit.field["summaryfeatures"]), 1e-4)
         found = true
         break
       end
@@ -162,7 +162,7 @@ module FieldMatchFeaturesBase
     exp = {"fieldMatch(a_literal).matches" => matches}
     result = search_with_timeout(5, query)
     result.sort_results_by("documentid")
-    assert_features(exp, result.hit[docid].field['summaryfeatures'])
+    assert_features(exp, JSON.parse(result.hit[docid].field["summaryfeatures"]))
   end
 
   def assert_fmfilter(score, query_completeness, weight, matches, query)
@@ -171,7 +171,7 @@ module FieldMatchFeaturesBase
            "fieldMatch(a).weight" => weight, "fieldMatch(a).matches" => matches, \
            "fieldMatch(a).degradedMatches" => matches, "fieldMatch(a).proximity" => 0, \
            "fieldMatch(a).orderness" => 0, "fieldMatch(a).longestSequence" => 0}
-    assert_features(exp, search_with_timeout(5, query).hit[0].field['summaryfeatures'], 1e-3)
+    assert_features(exp, JSON.parse(search_with_timeout(5, query).hit[0].field["summaryfeatures"]), 1e-3)
   end
 
   def run_field_term_match
@@ -214,7 +214,7 @@ module FieldMatchFeaturesBase
     exp = {"fieldMatch(#{field}).matches" => matches, \
            "fieldMatch(#{field}).fieldCompleteness" => fieldCompleteness, \
            "fieldTermMatch(#{field},0).occurrences" => occurrences}
-    assert_features(exp, result.hit[docid].field['summaryfeatures'], 1e-3)
+    assert_features(exp, JSON.parse(result.hit[docid].field["summaryfeatures"]), 1e-3)
   end
 
   def run_phrase_test()
@@ -250,13 +250,13 @@ module FieldMatchFeaturesBase
     assert_phrase_streaming(2, "query=%22a+b%22+%22x+d%22", "f2")
     assert_phrase_streaming(4, "query=a+b+x+d",         "f2")
 
-    assert_features({"fieldMatch(f1)" => 1}, search_with_timeout(5, "query=f1:%22a+b+c+d%22"+"&streaming.userid=1").hit[0].field['summaryfeatures'])
-    assert_features({"fieldMatch(f1)" => 1}, search_with_timeout(5, "query=f1:a+b+c+d"+"&streaming.userid=1").hit[0].field['summaryfeatures'])
+    assert_features({"fieldMatch(f1)" => 1}, JSON.parse(search_with_timeout(5, "query=f1:%22a+b+c+d%22"+"&streaming.userid=1").hit[0].field["summaryfeatures"]))
+    assert_features({"fieldMatch(f1)" => 1}, JSON.parse(search_with_timeout(5, "query=f1:a+b+c+d"+"&streaming.userid=1").hit[0].field["summaryfeatures"]))
   end
 
   def assert_phrase_streaming(matches, query, field)
     result = search_with_timeout(5, query + "&streaming.userid=1")
-    assert_features({"fieldMatch(#{field}).matches" => matches}, result.hit[0].field['summaryfeatures'])
+    assert_features({"fieldMatch(#{field}).matches" => matches}, JSON.parse(result.hit[0].field["summaryfeatures"]))
   end
 
   def teardown

--- a/tests/search/foreachfeature/foreachfeature.rb
+++ b/tests/search/foreachfeature/foreachfeature.rb
@@ -60,7 +60,7 @@ class ForeachFeature < IndexedStreamingSearchTest
   def assert_foreach(expected, ranking, docid)
     query = "query=a!300+b!200+c&streaming.userid=1&ranking=" + ranking
     result = search_with_timeout(60, query)
-    assert_features(expected, result.hit[docid].field['summaryfeatures'], 1e-4)
+    assert_features(expected, JSON.parse(result.hit[docid].field["summaryfeatures"]), 1e-4)
   end
 
 

--- a/tests/search/globalfeatures/globalfeatures.rb
+++ b/tests/search/globalfeatures/globalfeatures.rb
@@ -34,7 +34,7 @@ class GlobalFeatures < IndexedStreamingSearchTest
     query = "query=a&nocache&rankproperty.vespa.now=#{now}&streaming.userid=1"
     search(query)
     exp = {"now" => out}
-    assert_features(exp, search(query).hit[0].field['summaryfeatures'])
+    assert_features(exp, JSON.parse(search(query).hit[0].field["summaryfeatures"]))
   end
 
   def assert_actual_now(epsilon)
@@ -43,7 +43,7 @@ class GlobalFeatures < IndexedStreamingSearchTest
     timebefore = Time.now.to_i
     now = Time.now.to_i
     exp = {"now" => now}
-    got = search(query).hit[0].field['summaryfeatures']
+    got = JSON.parse(search(query).hit[0].field["summaryfeatures"])
     timeafter = Time.now.to_i
     assert_features(exp, got, epsilon + timeafter - timebefore)
   end
@@ -82,7 +82,7 @@ class GlobalFeatures < IndexedStreamingSearchTest
     else
       exp = {"age(a)" => Time.now.to_i - age}
     end
-    got = search(query).hit[0].field['summaryfeatures']
+    got = JSON.parse(search(query).hit[0].field["summaryfeatures"])
     timeafter = Time.now.to_i
     assert_features(exp, got, epsilon + timeafter - timebefore)
   end
@@ -90,7 +90,7 @@ class GlobalFeatures < IndexedStreamingSearchTest
   def assert_freshness(freshness, age)
     query = "query=a:86400&nocache&streaming.userid=1&rankproperty.vespa.now=#{86400 + age}"
     exp = {"freshness(a)" => freshness}
-    assert_features(exp, search(query).hit[0].field['summaryfeatures'], 1e-4)
+    assert_features(exp, JSON.parse(search(query).hit[0].field["summaryfeatures"]), 1e-4)
   end
 
 
@@ -171,7 +171,7 @@ class GlobalFeatures < IndexedStreamingSearchTest
     result.sort_results_by(@id_field)
     retval = []
     result.hit.each do |hit|
-      retval.push(hit.field['summaryfeatures'])
+      retval.push(JSON.parse(hit.field["summaryfeatures"]))
     end
     return retval
   end

--- a/tests/search/globalfeatures/globalfeatures_distance_closeness.rb
+++ b/tests/search/globalfeatures/globalfeatures_distance_closeness.rb
@@ -36,13 +36,13 @@ class GlobalFeaturesIndexed < IndexedStreamingSearchTest
   def assert_distance(distance, x, y)
     query = "query=sddocname:distance&pos.xy=#{x}%3B#{y}&streaming.selection=true"
     exp = {"distance(xy)" => distance}
-    assert_features(exp, search(query).hit[0].field['summaryfeatures'], 1e-4)
+    assert_features(exp, JSON.parse(search(query).hit[0].field["summaryfeatures"]), 1e-4)
   end
 
   def assert_closeness(closeness, distance)
     query = "query=sddocname:distance&pos.xy=#{distance + 5}%3B-5&streaming.selection=true"
     exp = {"closeness(xy)" => closeness}
-    assert_features(exp, search(query).hit[0].field['summaryfeatures'], 1e-4)
+    assert_features(exp, JSON.parse(search(query).hit[0].field["summaryfeatures"]), 1e-4)
   end
 
 

--- a/tests/search/matchesfeature/matchesfeature.rb
+++ b/tests/search/matchesfeature/matchesfeature.rb
@@ -53,7 +53,7 @@ class MatchesFeature < IndexedStreamingSearchTest
   def assert_matches(expected, query)
     query = query + "&streaming.userid=1"
     result = search(query)
-    assert_features(expected, result.hit[0].field['summaryfeatures'], 1e-4)
+    assert_features(expected, JSON.parse(result.hit[0].field["summaryfeatures"]), 1e-4)
   end
 
   def teardown

--- a/tests/search/multipleweightedsets/multiweight.rb
+++ b/tests/search/multipleweightedsets/multiweight.rb
@@ -14,7 +14,7 @@ class MultipleWeightedSets < IndexedSearchTest
   end
 
   def assert_summaryfeatures(expected, result)
-    assert_features(expected, result.hit[0].field['summaryfeatures'])
+    assert_features(expected, JSON.parse(result.hit[0].field["summaryfeatures"]))
   end
 
   def test_multipleweightedsets

--- a/tests/search/nativerankfeature/nativerankfeature.rb
+++ b/tests/search/nativerankfeature/nativerankfeature.rb
@@ -184,7 +184,7 @@ class NativeRankFeature < IndexedStreamingSearchTest
     query = query + "&streaming.userid=1&ranking=" + ranking
     puts "assert_expnr: #{query}"
     result = search(query)
-    assert_features(expected, result.hit[0].field['summaryfeatures'], 1e-4)
+    assert_features(expected, JSON.parse(result.hit[0].field["summaryfeatures"]), 1e-4)
   end
 
 

--- a/tests/search/nearest_neighbor/nearest_neighbor.rb
+++ b/tests/search/nearest_neighbor/nearest_neighbor.rb
@@ -249,7 +249,7 @@ class NearestNeighborTest < IndexedSearchTest
     doc_type = qp[:doc_type] || 'test'
     assert_field_value(result, "documentid", get_docid(exp_docid, doc_type), i)
     assert_relevancy(result, exp_score, i)
-    assert_features(exp_features, result.hit[i].field['summaryfeatures'])
+    assert_features(exp_features, JSON.parse(result.hit[i].field["summaryfeatures"]))
   end
 
   def get_query(qprops)

--- a/tests/search/no_query_in_summary_fetch/no_query_in_summary_fetch.rb
+++ b/tests/search/no_query_in_summary_fetch/no_query_in_summary_fetch.rb
@@ -13,19 +13,15 @@ class NoQueryInSummaryFetch < IndexedSearchTest
     start
     feed_and_wait_for_docs("test", 1, :file => selfdir + "data.xml")
 
-    save_result("query=title:foo&tracelevel=3&ranking.profile=test1&ranking.queryCache=false&timeout=9.9", "foo.xml")
-
     # Need as cache is off and required by rank profile test1
     result = search_base("query=title:foo&tracelevel=3&ranking.profile=test1&ranking.queryCache=false&timeout=9.9")
-    puts "hit 0: #{result.hit[0]}"
-    puts "hit 0 sf: #{result.hit[0].field['summaryfeatures']}"
     assert(result.xmldata.match("Resending query during document summary fetching"), "Resending query data when the feature cache is turned off")
-    assert_equal({'fieldMatch(title)' => 1.0}, result.hit[0].field['summaryfeatures'])
+    assert_equal('{"fieldMatch(title)":1.0,"vespa.summaryFeatures.cached":0.0}', result.hit[0].comparable_fields["summaryfeatures"])
 
     # Not needed as explicit cached
     result = search_base("query=title:foo&tracelevel=3&ranking.profile=test1&ranking.queryCache=true&timeout=9.9")
     assert(result.xmldata.match("Not resending query during document summary fetching"), "Not resending query data when the feature cache is turned off")
-    assert_equal({'fieldMatch(title)' => 1.0}, result.hit[0].field['summaryfeatures'])
+    assert_equal('{"fieldMatch(title)":1.0,"vespa.summaryFeatures.cached":0.0}', result.hit[0].comparable_fields["summaryfeatures"])
 
     # Not needed by query
     result = search_base("query=title:foo&tracelevel=3&timeout=9.9")

--- a/tests/search/partialupdate/partialupdate.rb
+++ b/tests/search/partialupdate/partialupdate.rb
@@ -429,7 +429,7 @@ class PartialUpdate < IndexedSearchTest
     pexp = {}
     pexp["fieldInfo(#{field}).cnt"] = score
     puts "#{result.hit[docid].field["summaryfeatures"]}"
-    assert_features(pexp, result.hit[docid].field['summaryfeatures'], 1e-4)
+    assert_features(pexp, JSON.parse(result.hit[docid].field["summaryfeatures"]), 1e-4)
   end
 
   def assert_attrfieldcount(field, query, score, docid=0)
@@ -439,7 +439,7 @@ class PartialUpdate < IndexedSearchTest
     pexp = {}
     pexp["attributeMatch(#{field}).matches"] = score
     puts "#{result.hit[docid].field["summaryfeatures"]}"
-    assert_features(pexp, result.hit[docid].field['summaryfeatures'], 1e-4)
+    assert_features(pexp, JSON.parse(result.hit[docid].field["summaryfeatures"]), 1e-4)
   end
 
   def assert_attrfieldcount_kludge(field, query, score, docid=0)
@@ -449,7 +449,7 @@ class PartialUpdate < IndexedSearchTest
     pexp = {}
     pexp["attribute(#{field}).count"] = score
     puts "#{result.hit[docid].field["summaryfeatures"]}"
-    assert_features(pexp, result.hit[docid].field['summaryfeatures'], 1e-4)
+    assert_features(pexp, JSON.parse(result.hit[docid].field["summaryfeatures"]), 1e-4)
   end
 
   def transfer_fbench_queries(query_dir)

--- a/tests/search/queryfeatures/queryfeatures.rb
+++ b/tests/search/queryfeatures/queryfeatures.rb
@@ -32,7 +32,7 @@ class QueryFeatures < IndexedStreamingSearchTest
     query = "query=a&streaming.userid=1" + rankproperties
     result = search(query)
     sf = result.hit[0].field["summaryfeatures"]
-    assert_features(expected, sf)
+    assert_features(expected, JSON.parse(sf))
   end
 
 
@@ -52,7 +52,7 @@ class QueryFeatures < IndexedStreamingSearchTest
 
   def assert_query_term_count(exp, query)
     query = "query=" + query + "&streaming.userid=1"
-    assert_features({"queryTermCount" => exp}, search(query).hit[0].field['summaryfeatures'])
+    assert_features({"queryTermCount" => exp}, JSON.parse(search(query).hit[0].field["summaryfeatures"]))
   end
 
 
@@ -146,7 +146,7 @@ class QueryFeatures < IndexedStreamingSearchTest
     sf = result.hit[0].field["summaryfeatures"]
     fn = "term(#{termidx})"
     assert_features({fn + ".significance" => significance, fn + ".weight" => weight, \
-                     fn + ".connectedness" => connectedness}, sf)
+                     fn + ".connectedness" => connectedness}, JSON.parse(sf))
   end
 
   def teardown

--- a/tests/search/rankdegradation/rankdegradation.rb
+++ b/tests/search/rankdegradation/rankdegradation.rb
@@ -30,7 +30,7 @@ class RankDegradation < IndexedStreamingSearchTest
   def run_nan_test
     r = search("query=f1:10&streaming.selection=true&ranking=nan")
     assert_equal("-Infinity", r.hit[0].field["relevancy"])
-    sf = r.hit[0].field['summaryfeatures']
+    sf = JSON.parse(r.hit[0].field["summaryfeatures"])
     puts "summaryfeatures: #{sf.to_a.join(":")}"
     assert_equal(nil, sf.fetch("firstPhase"))
   end

--- a/tests/search/rankfilter/rankfilter.rb
+++ b/tests/search/rankfilter/rankfilter.rb
@@ -57,7 +57,7 @@ class RankFilter < IndexedSearchTest
     query = "query=" + query + "&nocache"
     result = search(query)
     exp = {"fieldTermMatch(#{field},0).firstPosition" => fpos}
-    assert_features(exp, result.hit[0].field['summaryfeatures'], 1e-4)
+    assert_features(exp, JSON.parse(result.hit[0].field["summaryfeatures"]), 1e-4)
   end
 
   def teardown

--- a/tests/search/rankingmacros/rankingmacros.rb
+++ b/tests/search/rankingmacros/rankingmacros.rb
@@ -25,12 +25,12 @@ class RankingMacros < IndexedSearchTest
                      "rankingExpression(myfeature)" => 546,
                      "rankingExpression(anotherfeature)" => 5460,
                      "rankingExpression(yetanotherfeature)" => 54600},
-                     result.hit[0].field['summaryfeatures'], 1e-4)
+                     JSON.parse(result.hit[0].field["summaryfeatures"]), 1e-4)
     assert_equal(score, 4*(1+1));
 
     result = search("query=title:foo&ranking=constantsAndMacro");
     assert_features({"firstPhase" => 159},
-                     result.hit[0].field['summaryfeatures'], 1e-4)
+                     JSON.parse(result.hit[0].field["summaryfeatures"]), 1e-4)
   end
 
   def teardown

--- a/tests/search/rankprofiles/rankprofiles.rb
+++ b/tests/search/rankprofiles/rankprofiles.rb
@@ -50,7 +50,7 @@ class RankProfiles < IndexedSearchTest
   end
 
   def assert_expression(exp, query, docid)
-    assert_features(exp, search(query).hit[docid].field['summaryfeatures'], 1e-04)
+    assert_features(exp, JSON.parse(search(query).hit[docid].field["summaryfeatures"]), 1e-04)
   end
 
   def teardown

--- a/tests/search/recall/recall.rb
+++ b/tests/search/recall/recall.rb
@@ -29,7 +29,7 @@ class Recall < IndexedSearchTest
     result = search(query)
     assert_equal(1, result.hit.size);
     exp = {"fieldMatch(title).matches" => matches, "queryTermCount" => term_count}
-    assert_features(exp, result.hit[0].field['summaryfeatures'])
+    assert_features(exp, JSON.parse(result.hit[0].field["summaryfeatures"]))
   end
 
   def get_relevancy(query)

--- a/tests/search/summaryfeatures/summaryfeatures.rb
+++ b/tests/search/summaryfeatures/summaryfeatures.rb
@@ -13,6 +13,15 @@ class SummaryFeatures < IndexedSearchTest
     deploy_app(SearchApp.new.sd(selfdir + "sd2/test.sd"))
     start
     feed(:file => selfdir + "doc.xml")
+
+    assert_summaryfeatures
+  end
+
+  def test_summaryfeatures_emul
+    deploy_app(SearchApp.new.sd(selfdir + "sd2/test.sd"))
+    start
+    feed(:file => selfdir + "doc.xml")
+
     assert_summaryfeatures
   end
 
@@ -83,7 +92,7 @@ class SummaryFeatures < IndexedSearchTest
     # verify that summaryfeatures are presented as true floatingpoint values with '.0' after seemingly integer numbers.
     result = search("query=body:test&hits=1&nocache")
     assert_equal(1, result.hit.size)
-    assert_equal({"attribute(attr)" => 200.0, "value(1)" => 1.0, "value(2)" => 2.0}, result.hit[0].field["summaryfeatures"])
+    assert_equal('{"attribute(attr)":200.0,"value(1)":1.0,"value(2)":2.0,"vespa.summaryFeatures.cached":0.0}', result.hit[0].field["summaryfeatures"])
 
     # verify that summaryfeatures are produced with grouping and hits=0 and the various cache combinations
     base_q = "query=body:test&select=all(group(attr)each(each(output(summary()))))&hits=0"
@@ -104,7 +113,7 @@ class SummaryFeatures < IndexedSearchTest
   def assert_sf_hit(result, hit, attr_value)
     sf = result.hit[hit].field["summaryfeatures"]
     puts "summaryfeatures for hit #{hit}: '#{sf}'"
-    json = sf
+    json = JSON.parse(sf)
     assert_equal(attr_value, result.hit[hit].field["attr"].to_i)
     assert_features({"value(1)" => 1.0}, json)
     assert_features({"value(2)" => 2.0}, json)

--- a/tests/search/weighting_ranklog/weighting_summaryfeatures.rb
+++ b/tests/search/weighting_ranklog/weighting_summaryfeatures.rb
@@ -22,7 +22,7 @@ class Weighting_Ranklog < IndexedSearchTest
     }
     result = search("query=black+desc:black");
     assert_equal(1, result.hitcount)
-    assert_features(expected, result.hit[0].field['summaryfeatures'])
+    assert_features(expected, JSON.parse(result.hit[0].field["summaryfeatures"]))
 
     puts "Query: heavy weighting"
     expected = {
@@ -31,7 +31,7 @@ class Weighting_Ranklog < IndexedSearchTest
     }
     result = search("query=black\!10000+desc:black");
     assert_equal(1, result.hitcount)
-    assert_features(expected, result.hit[0].field['summaryfeatures'])
+    assert_features(expected, JSON.parse(result.hit[0].field["summaryfeatures"]))
 
   end
 


### PR DESCRIPTION
Reverts vespa-engine/system-test#2177

Many system tests started failing with similar to:

ERROR IN 'DocumentFeaturesIndexed::test_field_length__ELASTIC()': TypeError: no implicit conversion of Hash into String

     at /opt/rh/rh-ruby27/root/usr/share/ruby/json/common.rb:156:in `initialize'
     at /opt/rh/rh-ruby27/root/usr/share/ruby/json/common.rb:156:in `new'
     at /opt/rh/rh-ruby27/root/usr/share/ruby/json/common.rb:156:in `parse'
     at /opt/vespa-systemtests/tests/search/documentfeatures/documentfeatures_indexed.rb:45:in `assert_field_length'
     at /opt/vespa-systemtests/tests/search/documentfeatures/documentfeatures_indexed.rb:19:in `test_field_length'