### PR TITLE
Support query params for wait_for_hitcount

### DIFF
--- a/lib/test_base.rb
+++ b/lib/test_base.rb
@@ -244,7 +244,7 @@ module TestBase
     query = url_escape_q(query)
 
     if params[:cluster]
-      container = vespa.qrs[params[:cluster]].qrserver[qrserver_id.to_s]
+      container = vespa.container[params[:cluster] + "/" + qrserver_id.to_s] or vespa.qrs[params[:cluster]].qrserver[qrserver_id.to_s]
     else
       container = (vespa.qrserver[qrserver_id.to_s] or vespa.container.values.first)
     end
@@ -900,17 +900,17 @@ module TestBase
   end
 
   # Feeds the file specified in params and waits for expected number of document.
-  def feed_and_wait_for_docs(doc_type, wanted_hitcount, params={}, path="")
+  def feed_and_wait_for_docs(doc_type, wanted_hitcount, feed_params={}, path="", query_params={})
     query = "#{path}query=sddocname:#{doc_type}&nocache&hits=0&streaming.selection=true"
-    return feed_and_wait_for_hitcount(query, wanted_hitcount, params)
+    return feed_and_wait_for_hitcount(query, wanted_hitcount, feed_params, query_params)
   end
 
   # Feeds the file specified in params and waits for expected number of hits for the given query.
-  def feed_and_wait_for_hitcount(query, wanted_hitcount, params={})
-    timeout = params[:timeout]
+  def feed_and_wait_for_hitcount(query, wanted_hitcount, feed_params={}, query_params={})
+    timeout = feed_params[:timeout]
     timeout = 120 if timeout == nil
-    feederoutput = feed(params)
-    wait_for_hitcount(query, wanted_hitcount, timeout)
+    feederoutput = feed(feed_params)
+    wait_for_hitcount(query, wanted_hitcount, timeout, 0, query_params)
     return feederoutput
   end
 
@@ -1110,7 +1110,7 @@ module TestBase
   end
 
   # Waits until _query_ has a total hit count equal to _wanted_hitcount_
-  def wait_for_hitcount(query, wanted_hitcount, timeout_in=60, qrserver_id=0)
+  def wait_for_hitcount(query, wanted_hitcount, timeout_in=60, qrserver_id=0, params={})
 
     hitcount = -1
     timeout = timeout_in
@@ -1126,7 +1126,7 @@ module TestBase
     while Time.now.to_i < start + timeout
       begin
         trynum += 1
-        hitcount = search_with_timeout(timeout_in, query, qrserver_id).hitcount
+        hitcount = search_with_timeout(timeout_in, query, qrserver_id, {}, false, params).hitcount
         if wanted_hitcount == hitcount
           puts "Success on try #{trynum}: Got #{wanted_hitcount} hits"
           return true

--- a/tests/performance/fast_access_attributes/fast_access_attributes.rb
+++ b/tests/performance/fast_access_attributes/fast_access_attributes.rb
@@ -53,27 +53,27 @@ class FastAccessAttributesPerfTest < PerformanceTest
     #vespa.adminserver.logctl("searchnode2:search.filechunk", "debug=on")
     start
     feed({:template => put_template, :count => @num_docs})
-    wait_for_hitcount("sddocname:test", @num_docs)
+    wait_for_hits("sddocname:test", @num_docs)
     assert_hitcount("normal_access:1000", @num_docs)
     assert_hitcount("fast_access:1000", @num_docs)
 
     feed_and_profile(update_template("normal_access"), "feeding_normal_access")
-    wait_for_hitcount("normal_access:2000", @num_docs)
+    wait_for_hits("normal_access:2000", @num_docs)
     assert_hitcount("normal_access:1000", 0)
     feed_and_profile(update_template("fast_access"), "feeding_fast_access")
-    wait_for_hitcount("fast_access:2000", @num_docs)
+    wait_for_hits("fast_access:2000", @num_docs)
     assert_hitcount("fast_access:1000", 0)
 
     feed_and_profile(conditional_update_template("normal_access"), "feeding_conditional_normal_access")
-    wait_for_hitcount("normal_access:3000", @num_docs)
+    wait_for_hits("normal_access:3000", @num_docs)
     assert_hitcount("normal_access:2000", 0)
 
     feed_and_profile(conditional_update_template("fast_access"), "feeding_conditional_fast_access")
-    wait_for_hitcount("fast_access:3000", @num_docs)
+    wait_for_hits("fast_access:3000", @num_docs)
     assert_hitcount("fast_access:2000", 0)
 
     feed_and_profile(update_template("fast_access"), "feeding_fast_access_direct", {:route => '"search-direct"'})
-    wait_for_hitcount("fast_access:2000", @num_docs)
+    wait_for_hits("fast_access:2000", @num_docs)
     assert_hitcount("fast_access:3000", 0)
   end
 
@@ -83,6 +83,10 @@ class FastAccessAttributesPerfTest < PerformanceTest
     profiler_start
     run_template_feeder(fillers: [parameter_filler("feed_stage", feed_stage)], params: params)
     profiler_report(feed_stage)
+  end
+
+  def wait_for_hits(query, num_docs)
+    wait_for_hitcount(query, num_docs, 60, 0, {:cluster => "combinedcontainer"})
   end
 
   def teardown

--- a/tests/performance/feeding_and_removing/feeding_and_removing_base.rb
+++ b/tests/performance/feeding_and_removing/feeding_and_removing_base.rb
@@ -71,7 +71,7 @@ class FeedingAndRemovingBase < PerformanceTest
     run_template_feeder(fillers: fillers, params: feed_params)
     profiler_report(feed_stage + "_" + visibility_delay.to_s + "_" + index_threads.to_s)
     write_metrics(feed_stage, visibility_delay, index_threads)
-    wait_for_hitcount("sddocname:test", doc_count)
+    wait_for_hitcount("sddocname:test", doc_count, 60, 0, {:cluster => "combinedcontainer"})
   end
 
   def write_metrics(feed_stage, visibility_delay, index_threads)

--- a/tests/performance/feeding_multiple_doc_types/feeding_multiple_doc_types.rb
+++ b/tests/performance/feeding_multiple_doc_types/feeding_multiple_doc_types.rb
@@ -42,10 +42,10 @@ class FeedingMultipleDocTypesTest < PerformanceTest
 
   def run_feeding_test(doc_types)
     feed_and_profile(put_template, "feeding_docs", doc_types)
-    wait_for_hitcount("sddocname:test", @num_docs)
+    wait_for_hitcount("sddocname:test", @num_docs, 60, 0, {:cluster => "combinedcontainer"})
     assert_hitcount("sddocname:test", @num_docs)
     feed_and_profile(update_template, "feeding_updates", doc_types)
-    wait_for_hitcount("number:2000", @num_docs)
+    wait_for_hitcount("number:2000", @num_docs, 60, 0, {:cluster => "combinedcontainer"})
     assert_hitcount("number:2000", @num_docs)
   end
 

--- a/tests/search/searchchains_cluster_connections/searchchains_cluster_connections.rb
+++ b/tests/search/searchchains_cluster_connections/searchchains_cluster_connections.rb
@@ -1,4 +1,4 @@
-# Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 require 'indexed_search_test'
 require 'app_generator/http'
 
@@ -36,9 +36,9 @@ class SearchchainsClusterConnections < IndexedSearchTest
 
   def start_and_feed
     start
-    feed_and_wait_for_docs("music", 10, :file => SEARCH_DATA+"music.10.xml")
-    feed_and_wait_for_docs("books", 5, :file => selfdir + "books.1.xml", :clusters => [ "books"])
-  end
+    feed_and_wait_for_docs("music", 10, {:file => SEARCH_DATA+"music.10.xml"}, "", {:cluster => "container1"})
+    feed_and_wait_for_docs("books", 5, {:file => selfdir + "books.1.xml", :clusters => [ "books"]}, "", {:cluster => "container2"})
+   end
 
   def check_hits_from_each_cluster
     assert_hits("music", "Classic Female Blues", 1, "container1") # hit with first qrserver/container (music provider)


### PR DESCRIPTION
Needed when there are more than 1 container cluster, works by accident today, when search container cluster is first one generated with app generator.