### PR TITLE
Specify container cluster when calling assert_hitcount

### DIFF
--- a/tests/performance/fast_access_attributes/fast_access_attributes.rb
+++ b/tests/performance/fast_access_attributes/fast_access_attributes.rb
@@ -54,27 +54,27 @@ class FastAccessAttributesPerfTest < PerformanceTest
     start
     feed({:template => put_template, :count => @num_docs})
     wait_for_hits("sddocname:test", @num_docs)
-    assert_hitcount("normal_access:1000", @num_docs)
-    assert_hitcount("fast_access:1000", @num_docs)
+    assert_hits("normal_access:1000", @num_docs)
+    assert_hits("fast_access:1000", @num_docs)
 
     feed_and_profile(update_template("normal_access"), "feeding_normal_access")
     wait_for_hits("normal_access:2000", @num_docs)
-    assert_hitcount("normal_access:1000", 0)
+    assert_hits("normal_access:1000", 0)
     feed_and_profile(update_template("fast_access"), "feeding_fast_access")
     wait_for_hits("fast_access:2000", @num_docs)
-    assert_hitcount("fast_access:1000", 0)
+    assert_hits("fast_access:1000", 0)
 
     feed_and_profile(conditional_update_template("normal_access"), "feeding_conditional_normal_access")
     wait_for_hits("normal_access:3000", @num_docs)
-    assert_hitcount("normal_access:2000", 0)
+    assert_hits("normal_access:2000", 0)
 
     feed_and_profile(conditional_update_template("fast_access"), "feeding_conditional_fast_access")
     wait_for_hits("fast_access:3000", @num_docs)
-    assert_hitcount("fast_access:2000", 0)
+    assert_hits("fast_access:2000", 0)
 
     feed_and_profile(update_template("fast_access"), "feeding_fast_access_direct", {:route => '"search-direct"'})
     wait_for_hits("fast_access:2000", @num_docs)
-    assert_hitcount("fast_access:3000", 0)
+    assert_hits("fast_access:3000", 0)
   end
 
   def feed_and_profile(feed_template, feed_stage, params={})
@@ -87,6 +87,10 @@ class FastAccessAttributesPerfTest < PerformanceTest
 
   def wait_for_hits(query, num_docs)
     wait_for_hitcount(query, num_docs, 60, 0, {:cluster => "combinedcontainer"})
+  end
+
+  def assert_hits(query, num_docs)
+    assert_hitcount(query, num_docs, 0, {:cluster => "combinedcontainer"})
   end
 
   def teardown

--- a/tests/performance/feeding_multiple_doc_types/feeding_multiple_doc_types.rb
+++ b/tests/performance/feeding_multiple_doc_types/feeding_multiple_doc_types.rb
@@ -43,10 +43,10 @@ class FeedingMultipleDocTypesTest < PerformanceTest
   def run_feeding_test(doc_types)
     feed_and_profile(put_template, "feeding_docs", doc_types)
     wait_for_hitcount("sddocname:test", @num_docs, 60, 0, {:cluster => "combinedcontainer"})
-    assert_hitcount("sddocname:test", @num_docs)
+    assert_hitcount("sddocname:test", @num_docs, 0, {:cluster => "combinedcontainer"})
     feed_and_profile(update_template, "feeding_updates", doc_types)
     wait_for_hitcount("number:2000", @num_docs, 60, 0, {:cluster => "combinedcontainer"})
-    assert_hitcount("number:2000", @num_docs)
+    assert_hitcount("number:2000", @num_docs, 0, {:cluster => "combinedcontainer"})
   end
 
   def feed_and_profile(template, feed_stage, doc_types, feed_params_in = {})


### PR DESCRIPTION
Followup to https://github.com/vespa-engine/system-test/pull/2195, need to specify container cluster in a few more places