### PR TITLE
Alter query to give exact result

### DIFF
--- a/tests/search/grouping_adv/default-max2.xml
+++ b/tests/search/grouping_adv/default-max2.xml
@@ -99,6 +99,19 @@
             <field name="boool">false</field>
             <field name="documentid">id:test:test:n=1234:03</field>
           </hit>
+          <hit relevancy="3580.099884632731" source="search">
+            <field name="relevancy">3580.099884632731</field>
+            <field name="sddocname">test</field>
+            <field name="n">2</field>
+            <field name="a">a1</field>
+            <field name="b">b1</field>
+            <field name="c">c2</field>
+            <field name="from">1234517161</field>
+            <field name="to">1234527162000000000</field>
+            <field name="body">test</field>
+            <field name="boool">false</field>
+            <field name="documentid">id:test:test:n=72331337:02</field>
+          </hit>
           <hit relevancy="1234.517162" source="search">
             <field name="relevancy">1234.517162</field>
             <field name="sddocname">test</field>
@@ -111,6 +124,19 @@
             <field name="body">test</field>
             <field name="boool">true</field>
             <field name="documentid">id:test:test:n=1234:01</field>
+          </hit>
+          <hit relevancy="-3580.099884632731" source="search">
+            <field name="relevancy">-3580.099884632731</field>
+            <field name="sddocname">test</field>
+            <field name="n">-2</field>
+            <field name="a">a1</field>
+            <field name="b">b1</field>
+            <field name="c">c2</field>
+            <field name="from">1234517161</field>
+            <field name="to">1234527162000000000</field>
+            <field name="body">test</field>
+            <field name="boool">true</field>
+            <field name="documentid">id:test:test:n=72331337:28</field>
           </hit>
         </hitlist>
       </group>

--- a/tests/search/grouping_adv/grouping_base.rb
+++ b/tests/search/grouping_adv/grouping_base.rb
@@ -224,10 +224,10 @@ module GroupingBase
     # TODO handle bool in grouping, and also do so for streaming search.
     check_query("all(group(boool) each(output(count())))", "#{selfdir}/boool.xml")
 
-    check_query_default_max("all(group(a)each(each(output(summary()))))", "#{selfdir}/default-max1.xml", -1, 1)
-    check_query_default_max("all(group(a)each(each(output(summary()))))", "#{selfdir}/default-max2.xml", 1, -1)
-    check_query_default_max("all(group(a)each(each(output(summary()))))", "#{selfdir}/default-max3.xml", 1, 1)
-    check_query_default_max("all(group(a)max(2)each(max(2)each(output(summary()))))", "#{selfdir}/default-max4.xml", 1, 1)
+    check_query_default_max("all(group(a)precision(10)each(each(output(summary()))))", "#{selfdir}/default-max1.xml", -1, 1)
+    check_query_default_max("all(group(a)precision(10)each(each(output(summary()))))", "#{selfdir}/default-max2.xml", 1, -1)
+    check_query_default_max("all(group(a)precision(10)each(each(output(summary()))))", "#{selfdir}/default-max3.xml", 1, 1)
+    check_query_default_max("all(group(a)max(2)precision(10)each(max(2)precision(10)each(output(summary()))))", "#{selfdir}/default-max4.xml", 1, 1)
   end
 
   # Tests that are known to fail


### PR DESCRIPTION
Ensure same result set for both indexed and streaming search

@baldersheim Do you know a larger `precision` value is required here? The result for `all(group(a)max(1)each(each(output(summary()))))` is missing two docsums unless precision is overridden with a high enough value (e.g `precision(10)`). This is only the case for indexed - streaming search returns all docsums without the need for higher precision. Trace indicates that query is executed in two passes.