### PR TITLE
grep for VESPA in environment

### DIFF
--- a/tests/search/tls_crypto_smoke/tls_crypto_smoke.rb
+++ b/tests/search/tls_crypto_smoke/tls_crypto_smoke.rb
@@ -66,7 +66,7 @@ class TlsCryptoSmokeTest < IndexedSearchTest
     deploy_app(SearchApp.new.sd(SEARCH_DATA + 'music.sd'))
     start
 
-    remote_env = content_node.execute('env', :noecho => true).each_line.map{ |e| env_line_to_key_value(e) }.to_h
+    remote_env = content_node.execute('env | grep VESPA', :noecho => true).each_line.map{ |e| env_line_to_key_value(e) }.to_h
     puts "Test runner environment:"
     remote_env.each { |k,v| puts "  #{k} -> #{v}" }
     puts


### PR DESCRIPTION
* only use variables with VESPA in the name from environment
* avoids problem with shell functions exported to environment

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@bjorncs please review
@geirst FYI
