### PR TITLE
Revert "Increase warmup time from 10 to 30 seconds"

### DIFF
--- a/tests/performance/programmatic_feed_client/programmatic_feed_client.rb
+++ b/tests/performance/programmatic_feed_client/programmatic_feed_client.rb
@@ -85,7 +85,7 @@ class ProgrammaticFeedClientTest < PerformanceTest
       "java #{perfmap_agent_jvmarg} -cp #{java_client_src_root}/target/java-feed-client-1.0.jar " +
         "-Dvespa.test.feed.route=#{DUMMY_ROUTE} " +
         "-Dvespa.test.feed.documents=#{DOCUMENTS} " +
-        "-Dvespa.test.feed.warmup.seconds=#{30} " +
+        "-Dvespa.test.feed.warmup.seconds=#{10} " +
         "-Dvespa.test.feed.benchmark.seconds=#{30} " +
         "-Dvespa.test.feed.document-text='#{generate_text(size)}' " +
         "-Dvespa.test.feed.connections=#{connections} " +


### PR DESCRIPTION
Reverts vespa-engine/system-test#2259

Tests gave 0 throughput with some of the clients after the change.