### PR TITLE
don't ask for struct datatype by name

### DIFF
--- a/tests/docproc/annotations/Annotator.java
+++ b/tests/docproc/annotations/Annotator.java
@@ -48,29 +48,29 @@ public class Annotator extends DocumentProcessor {
 			root.add(dateSpan);
 			root.add(placeSpan);
 
-			Struct personValue = new Struct(manager.getDataType("annotation.person"));
+			Struct personValue = new Struct(personType.getDataType());
 			personValue.setFieldValue("name", "george washington");
 			Annotation person = new Annotation(personType, personValue);
 			tree.annotate(personSpan, person);
 
-			Struct artistValue = new Struct(manager.getDataType("annotation.artist"));
+			Struct artistValue = new Struct(artistType.getDataType());
 			artistValue.setFieldValue("name", "elvis presley");
 			artistValue.setFieldValue("instrument", new IntegerFieldValue(20));
 			Annotation artist = new Annotation(artistType, artistValue);
 			tree.annotate(artistSpan, artist);
 
-			Struct dateValue = new Struct(manager.getDataType("annotation.date"));
+			Struct dateValue = new Struct(dateType.getDataType());
 			dateValue.setFieldValue("exacttime", 123456789L);
 			Annotation date = new Annotation(dateType, dateValue);
 			tree.annotate(dateSpan, date);
 
-			Struct placeValue = new Struct(manager.getDataType("annotation.place"));
+			Struct placeValue = new Struct(placeType.getDataType());
 			placeValue.setFieldValue("lat", 1467L);
 			placeValue.setFieldValue("lon", 789L);
 			Annotation place = new Annotation(placeType, placeValue);
 			tree.annotate(placeSpan, place);
 
-			Struct eventValue = new Struct(manager.getDataType("annotation.event"));
+			Struct eventValue = new Struct(eventType.getDataType());
 			eventValue.setFieldValue("description", "Big concert");
 			eventValue.setFieldValue("person", new AnnotationReference((AnnotationReferenceDataType) manager.getDataType("annotationreference<person>"), person));
 			eventValue.setFieldValue("date", new AnnotationReference((AnnotationReferenceDataType) manager.getDataType("annotationreference<date>"), date));


### PR DESCRIPTION
* we already have the AnnotationType and therefore know which
  datatype it wants directly, no need to ask for it by name

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@bratseth or @baldersheim review
NOTE: this is exactly the sort of change that customers might need to do.
