### PR TITLE
Make sure ALL_NET_HTTP_ERRORS is defined when catching exceptions.

### DIFF
--- a/lib/factory/factory_http_client.rb
+++ b/lib/factory/factory_http_client.rb
@@ -27,6 +27,12 @@ class FactoryHttpClient
     @auth = FactoryAuthentication.new
   end
 
+  ALL_NET_HTTP_ERRORS = [
+    Timeout::Error,  EOFError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError, Net::HTTPError,
+    Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL, Errno::EPIPE, Errno::EINVAL, Errno::ECONNRESET,
+    Errno::EHOSTUNREACH
+  ]
+
   def request(path, method='GET', body=nil, headers=nil)
     uri = URI(@auth.factory_api + path)
     case method


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
