### PR TITLE
Reduce spam-level logging in unstable test

### DIFF
--- a/tests/search/split_join_readiness/split_join_readiness.rb
+++ b/tests/search/split_join_readiness/split_join_readiness.rb
@@ -61,8 +61,8 @@ class SplitJoinReadinessTest < SearchTest
     logctl_all('distributor', 'distributor.operation.idealstate.setactive', 'debug=on,spam=on')
     logctl_all('distributor', 'distributor.operation.idealstate.split', 'debug=on,spam=on')
     logctl_all('distributor', 'distributor.operation.idealstate.join', 'debug=on,spam=on')
-    logctl_all('searchnode', 'proton.server.bucketmovejob', 'debug=on,spam=on')
-    logctl_all('searchnode', 'proton.server.buckethandler', 'debug=on,spam=on')
+    logctl_all('searchnode', 'proton.server.bucketmovejob', 'debug=on,spam=off')
+    logctl_all('searchnode', 'proton.server.buckethandler', 'debug=on,spam=off')
     logctl_all('searchnode', 'persistence.filestor.modifiedbucketchecker', 'debug=on,spam=on')
   end
 


### PR DESCRIPTION
@geirst please review

Too much logging makes test stable, which paradoxically is the exact
opposite of what we want to achieve...!
