### PR TITLE
Use query-profile to override default max group

### DIFF
--- a/tests/search/grouping_adv/grouping_streaming.rb
+++ b/tests/search/grouping_adv/grouping_streaming.rb
@@ -19,7 +19,7 @@ class GroupingStreaming < StreamingSearchTest
   end
 
   def test_advgrouping_vds
-    deploy_app(singlenode_streaming_2storage(selfdir + 'test.sd'))
+    deploy_app(singlenode_streaming_2storage(selfdir + 'test.sd').search_dir(selfdir + 'search'))
     start
     feed_docs
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
