### PR TITLE
Fallback to a score of 100 if duration is missing, unknown etc.

### DIFF
--- a/lib/factory/backend_client.rb
+++ b/lib/factory/backend_client.rb
@@ -22,6 +22,7 @@ class SimpleSystestSorter
   def calculate_scores(durations, test_objects)
     test_objects.map do |test_object, method_name|
       score = durations["#{test_object.class.to_s}::#{method_name}"].to_f
+      score = 100 if score < 0.1 # Use 100 as fallback when new test, unknown duration due to previous run aborted etc.
       score = score + test_object.num_hosts * 2000 if test_object.num_hosts > 1
       score = score + 1e10 if test_object.required_hostnames
       puts "Test: #{test_object.class.to_s}::#{method_name} got a score of: #{score}"


### PR DESCRIPTION
When test runs are aborted, duration will be 0 for running or remaining
tests. Long-running tests will then get a score of 0, which makes the
next test run take even longer, as those tests will be started last.