### PR TITLE
Use the default summary class as the minimal class doesn't exist.

### DIFF
--- a/tests/performance/wand_performance/elasticspapp/schemas/test.sd
+++ b/tests/performance/wand_performance/elasticspapp/schemas/test.sd
@@ -13,6 +13,9 @@ schema test {
         }
     
     }
+
+    document-summary minimal {
+    }
     
     rank-profile default {
         first-phase {


### PR DESCRIPTION
On Vespa 8 it is not allowed to specify a non-existing summary class.
We also ended up using the default summary class before, as a fallback.

@arnej27959 please review