### PR TITLE
Test config definition with version

### DIFF
--- a/tests/container/component_config/src2/src/main/resources/configdefinitions/extra-hit.def
+++ b/tests/container/component_config/src2/src/main/resources/configdefinitions/extra-hit.def
@@ -1,4 +1,5 @@
 package=com.yahoo.vespatest
+version=4 # TODO: Version not used, remove in Vespa 9
 
 enumVal enum {Mind, Body, World}
 times int default=1


### PR DESCRIPTION
Still supported (but version is ignored) in Vespa 8, will be removed in Vespa 9