### PR TITLE
Define rank profile 'year' in schema 'common'

### DIFF
--- a/tests/search/multipledoctypes/common.sd
+++ b/tests/search/multipledoctypes/common.sd
@@ -14,4 +14,7 @@ schema common {
   fieldset default {
     fields: title
   }
+  rank-profile year inherits default {
+    first-phase { expression: attribute(year) }
+  }  
 }


### PR DESCRIPTION
When searching multiple document types and specifying a
rank profile it must be defined for all schemas.