### PR TITLE
No more CentOS 7 rh-ruby27 support MERGEOK

### DIFF
--- a/bin/run-tests-on-swarm.sh
+++ b/bin/run-tests-on-swarm.sh
@@ -353,7 +353,7 @@ docker run --rm \
            --hostname $TESTRUNNER.$NETWORK \
            --network $NETWORK \
            --entrypoint bash $DOCKERIMAGE -lc \
-           "source /opt/rh/rh-ruby27/enable && ruby \${VESPA_SYSTEM_TEST_HOME-/opt/vespa-systemtests}/lib/testrunner.rb $TESTRUNNER_OPTS"
+           "ruby \${VESPA_SYSTEM_TEST_HOME-/opt/vespa-systemtests}/lib/testrunner.rb $TESTRUNNER_OPTS"
 
 if ! $KEEPRUNNING; then
   docker_cleanup


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Required to get system/performance tests going for open source.
