### PR TITLE
Use 'model.type=all' to get back AND semantics MERGEOK

### DIFF
--- a/tests/performance/dotproduct/dot_product.rb
+++ b/tests/performance/dotproduct/dot_product.rb
@@ -29,7 +29,7 @@ class DotProduct < PerformanceTest
 
 
   def test_DotProduct
-    deploy_app(SearchApp.new.threads_per_search(1).sd(@sdfile))
+    deploy_app(SearchApp.new.threads_per_search(1).sd(@sdfile).search_dir(selfdir + "search"))
     start
 
     feed({:template => doc_template, :count => 100000})

--- a/tests/performance/dotproduct/search/query-profiles/default.xml
+++ b/tests/performance/dotproduct/search/query-profiles/default.xml
@@ -1,4 +1,3 @@
 <query-profile id="default">
-    <field name="timeout">60.0</field>
     <field name="model.type">all</field>
 </query-profile>

--- a/tests/performance/grouping/search/query-profiles/default.xml
+++ b/tests/performance/grouping/search/query-profiles/default.xml
@@ -2,4 +2,5 @@
   <field name="grouping.globalMaxGroups">-1</field>
   <field name="grouping.defaultMaxGroups">-1</field>
   <field name="grouping.defaultMaxHits">-1</field>
+  <field name="model.type">all</field>
 </query-profile>

--- a/tests/performance/parent_child/parent_child_perf.rb
+++ b/tests/performance/parent_child/parent_child_perf.rb
@@ -63,6 +63,7 @@ class ParentChildPerfTest < PerformanceTest
                   sd(selfdir + "campaign.sd", { :global => true }).
                   sd(selfdir + "ad.sd").
                   threads_per_search(1).
+                  search_dir(selfdir + "search").
                   container(Container.new("combinedcontainer").
                             jvmoptions('-Xms16g -Xmx16g').
                             search(Searching.new).

--- a/tests/performance/parent_child/search/query-profiles/default.xml
+++ b/tests/performance/parent_child/search/query-profiles/default.xml
@@ -1,4 +1,3 @@
 <query-profile id="default">
-    <field name="timeout">60.0</field>
     <field name="model.type">all</field>
 </query-profile>

--- a/tests/performance/partitioning/partitioning.rb
+++ b/tests/performance/partitioning/partitioning.rb
@@ -32,6 +32,7 @@ class SearchPartitioningBase < PerformanceTest
 
   def thread_scaling_test
     deploy_app(SearchApp.new.
+               search_dir(selfdir + "search").
                cluster(SearchCluster.new.
                        sd(selfdir + "test.sd").
                        threads_per_search(16).

--- a/tests/performance/partitioning/search/query-profiles/default.xml
+++ b/tests/performance/partitioning/search/query-profiles/default.xml
@@ -1,4 +1,3 @@
 <query-profile id="default">
-    <field name="timeout">60.0</field>
     <field name="model.type">all</field>
 </query-profile>

--- a/tests/performance/phrase/phrase_cases.rb
+++ b/tests/performance/phrase/phrase_cases.rb
@@ -37,6 +37,7 @@ class PhraseCasesPerformanceTest < PerformanceTest
 
     app = SearchApp.new.monitoring("vespa", 60).
           sd(selfdir+"foobar.sd").
+          search_dir(selfdir + "search").
           container(Container.new("combinedcontainer").
                     search(Searching.new).
                     docproc(DocumentProcessing.new).

--- a/tests/performance/phrase/search/query-profiles/default.xml
+++ b/tests/performance/phrase/search/query-profiles/default.xml
@@ -1,4 +1,3 @@
 <query-profile id="default">
-    <field name="timeout">60.0</field>
     <field name="model.type">all</field>
 </query-profile>

--- a/tests/performance/raw_indexing/raw_indexing.rb
+++ b/tests/performance/raw_indexing/raw_indexing.rb
@@ -86,6 +86,7 @@ class FeedingIndexTest < PerformanceTest
         # We only care about single node performance for this test.
         SearchApp.new.sd(selfdir + 'doc.sd').
         num_parts(1).redundancy(1).ready_copies(1).
+        search_dir(selfdir + "search").
         container(Container.new("combinedcontainer").
                                 jvmoptions('-Xms10g -Xmx10g').
                                 search(Searching.new).

--- a/tests/performance/raw_indexing/search/query-profiles/default.xml
+++ b/tests/performance/raw_indexing/search/query-profiles/default.xml
@@ -1,4 +1,3 @@
 <query-profile id="default">
-    <field name="timeout">60.0</field>
     <field name="model.type">all</field>
 </query-profile>

--- a/tests/performance/tensor_eval/search/query-profiles/default.xml
+++ b/tests/performance/tensor_eval/search/query-profiles/default.xml
@@ -1,4 +1,3 @@
 <query-profile id="default">
-    <field name="timeout">60.0</field>
     <field name="model.type">all</field>
 </query-profile>

--- a/tests/performance/tensor_eval/tensor_eval.rb
+++ b/tests/performance/tensor_eval/tensor_eval.rb
@@ -36,6 +36,7 @@ class TensorEvalPerfTest < PerformanceTest
 
   def create_app
     SearchApp.new.sd(selfdir + "test.sd").
+      search_dir(selfdir + "search").
       search_chain(SearchChain.new.add(Searcher.new("com.yahoo.test.TensorInQueryBuilderSearcher"))).
       rank_expression_file(dirs.tmpdir + "sparse_tensor_25x25.json").
       rank_expression_file(dirs.tmpdir + "sparse_tensor_50x50.json").

--- a/tests/performance/tensor_eval/tensor_sparse_dot_product.rb
+++ b/tests/performance/tensor_eval/tensor_sparse_dot_product.rb
@@ -10,6 +10,7 @@ class TensorSparseDotProductTest < TensorEvalPerfTest
 
   def create_app
     SearchApp.new.sd(selfdir + "sparsedot.sd").
+      search_dir(selfdir + "search").
       threads_per_search(1).
       container(Container.new.
                   search(Searching.new.

--- a/tests/performance/tensor_eval/tensor_unstable_dot_product.rb
+++ b/tests/performance/tensor_eval/tensor_unstable_dot_product.rb
@@ -10,7 +10,7 @@ class TensorUnstableDotProductPerfTest < TensorEvalPerfTest
 
   def test_tensor_unstable_dot_product
     set_description('Test tensor dot product with unstable cell types')
-    deploy_app(SearchApp.new.sd(selfdir + 'unstable.sd'))
+    deploy_app(SearchApp.new.sd(selfdir + 'unstable.sd').search_dir(selfdir + "search"))
     start
     @container = (vespa.qrserver['0'] or vespa.container.values.first)
     unstable_feed

--- a/tests/performance/tensor_replace_max_reduce_prod_join/search/query-profiles/default.xml
+++ b/tests/performance/tensor_replace_max_reduce_prod_join/search/query-profiles/default.xml
@@ -1,4 +1,3 @@
 <query-profile id="default">
-    <field name="timeout">60.0</field>
     <field name="model.type">all</field>
 </query-profile>

--- a/tests/performance/tensor_replace_max_reduce_prod_join/tensor_replace_max_reduce_prod_join.rb
+++ b/tests/performance/tensor_replace_max_reduce_prod_join/tensor_replace_max_reduce_prod_join.rb
@@ -115,7 +115,7 @@ class TensorReplaceMaxReduceProdJoinPerfTest < PerformanceTest
   end
 
   def deploy_and_feed
-    deploy_app(SearchApp.new.sd(selfdir + "test.sd"))
+    deploy_app(SearchApp.new.sd(selfdir + "test.sd").search_dir(selfdir + "search"))
     start
     feed_and_wait_for_docs("test", @num_docs, :file => @docs_file_name)
     @container = (vespa.qrserver["0"] or vespa.container.values.first)

--- a/tests/performance/wand_performance/elasticspapp/search/query-profiles/default.xml
+++ b/tests/performance/wand_performance/elasticspapp/search/query-profiles/default.xml
@@ -3,4 +3,5 @@
 <field name="maxHits">2000</field>
 <field name="maxOffsets">2000</field>
 <field name="presentation.summary">minimal</field>
+<field name="model.type">all</field>
 </query-profile>


### PR DESCRIPTION
In Vespa 8 the default simple query language is changed from 'all' to 'weakAnd'.

@bratseth please review
@arnej27959 FYI