### PR TITLE
Clear debuginfod URLs to avoid perf not terminating when killed with …

### DIFF
--- a/docker/Dockerfile.systemtest
+++ b/docker/Dockerfile.systemtest
@@ -17,6 +17,11 @@ FROM $SYSTEMTEST_BASE_IMAGE AS systemtest
 
 ARG SKIP_M2_POPULATE
 
+# Clear all dynamic debuginfo URLs. Current specific issue related to this is
+# that libelfutils wants to download info when interrupting 'perf record'.
+# Depending on network setup for Docker/Podman this might hang forever.
+RUN rm -rf /etc/debuginfod/*
+
 COPY /include/feature-flags.json /opt/vespa/var/vespa/flag.db
 
 RUN mkdir -p /root/.m2


### PR DESCRIPTION
…SIGINT.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
