### PR TITLE
Ruby is now part of build image.

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -15,24 +15,8 @@ jobs:
       USER_SHELL_BIN: bash
       RUBYLIB: $SD_SOURCE_DIR/lib
     steps:
-      - install-deps: |
-          set -e
-          dnf module enable -y ruby:2.7
-          dnf install -y \
-              gcc-toolset-11-annobin \
-              gcc-toolset-11-annobin-plugin-gcc \
-              gcc-toolset-11-binutils \
-              gcc-toolset-11-gcc-c++ \
-              gcc-toolset-11-libatomic-devel \
-              libxml2-devel \
-              ruby \
-              ruby-devel \
-              rubygems-devel \
-              rubygem-net-telnet \
-
-          source /opt/rh/gcc-toolset-11/enable
-          gem install libxml-ruby gnuplot distribution test-unit builder
       - run-tests: |
+          set -e
           cd ${RUBYLIB}
           ruby test/testrunner.rb
           exit $?


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Requires built image from https://github.com/vespa-engine/docker-image-dev/pull/131
