### PR TITLE
Set lz4 and gzip as accepted compression types

### DIFF
--- a/docker/Dockerfile.systemtest
+++ b/docker/Dockerfile.systemtest
@@ -34,6 +34,7 @@ ENV RUBYLIB=/opt/vespa-systemtests/lib:/opt/vespa-systemtests/tests
 RUN /opt/vespa-systemtests/docker/include/setup-tls.sh root
 
 ENV VESPA_TLS_CONFIG_FILE=/opt/vespa/conf/vespa/tls/tls_config.json
+ENV VESPA_FILE_DISTRIBUTION_ACCEPTED_COMPRESSION_TYPES=gzip,lz4
 
 RUN if [[ "$SKIP_M2_POPULATE" != "true" ]]; then /opt/vespa-systemtests/docker/include/populate-m2-repo.sh root; fi
 


### PR DESCRIPTION
Try a run with this, server will use lz4 instead of gzip with this for file distribution

@aressem or @baldersheim. Please review only, will merge when factory is more stable.

I'll make a revert after this is merged in case this does not work out as expected.