### PR TITLE
Test empty fields in response for reference fields and tensor fields.

### DIFF
--- a/tests/search/empty_fields_in_response/child.sd
+++ b/tests/search/empty_fields_in_response/child.sd
@@ -1,0 +1,11 @@
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+schema child {
+  document child {
+
+    # Reference field
+    field reference_attribute type reference<parent> {
+      indexing: attribute | summary
+    }
+  }
+}

--- a/tests/search/empty_fields_in_response/child_docs.json
+++ b/tests/search/empty_fields_in_response/child_docs.json
@@ -1,0 +1,25 @@
+[
+    {
+        "put":"id:test:child::normal",
+        "fields": {
+            "reference_attribute": "id:test:parent::normal"
+        }
+    },
+    {
+        "put":"id:test:child::not_set",
+        "fields": {
+        }
+    },
+    {
+        "put":"id:test:child::set_empty",
+        "fields": {
+            "reference_attribute": ""
+        }
+    },
+    {
+        "put":"id:test:child::set_null",
+        "fields": {
+            "reference_attribute": null
+        }
+    }
+]

--- a/tests/search/empty_fields_in_response/docs.json
+++ b/tests/search/empty_fields_in_response/docs.json
@@ -19,7 +19,19 @@
             "weightedset_attribute": { "a":1 },
             "weightedset_non_attribute": { "a":1 },
             "map_attribute": { "b":2 },
-            "map_non_attribute": { "b":2 }
+            "map_non_attribute": { "b":2 },
+            "tensor_attribute":  {
+                "cells": [
+                    { "address": { "x": "a", "y": "b" }, "value": 2.0 },
+                    { "address": { "x": "c", "y": "d" }, "value": 3.0 }
+                ]
+            },
+            "tensor_non_attribute":  {
+                "cells": [
+                    { "address": { "x": "a", "y": "b" }, "value": 12.0 },
+                    { "address": { "x": "c", "y": "d" }, "value": 13.0 }
+                ]
+            }
         }
     },
     {
@@ -66,7 +78,9 @@
             "weightedset_attribute": null,
             "weightedset_non_attribute": null,
             "map_attribute": null,
-            "map_non_attribute": null
+            "map_non_attribute": null,
+            "tensor_attribute": null,
+            "tensor_non_attribute": null
         }
     }
 ]

--- a/tests/search/empty_fields_in_response/parent.sd
+++ b/tests/search/empty_fields_in_response/parent.sd
@@ -1,0 +1,7 @@
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+schema parent {
+  document parent {
+
+  }
+}

--- a/tests/search/empty_fields_in_response/test.sd
+++ b/tests/search/empty_fields_in_response/test.sd
@@ -78,5 +78,13 @@ schema test {
       indexing: summary
     }
 
+    # Tensor field
+    field tensor_attribute type tensor(x{},y{}) {
+      indexing: attribute | summary
+    }
+    field tensor_non_attribute type tensor(x{},y{}) {
+      indexing: summary
+    }
+
   }
 }


### PR DESCRIPTION
@geirst : please review

This PR depends on PR vespa-engine/vespa#23416.
