### PR TITLE
Unset bool field is not printed for streaming search when

### DIFF
--- a/tests/search/empty_fields_in_response/empty_fields_in_response.rb
+++ b/tests/search/empty_fields_in_response/empty_fields_in_response.rb
@@ -75,9 +75,6 @@ class EmptyFieldsInResponseTest < IndexedStreamingSearchTest
   def not_set_search_values
     if is_streaming
       {
-        # Bool has no empty value. Always present in docsum blob.
-        "bool_attribute" => false,
-        "bool_non_attribute" => false
       }
     else
       {
@@ -96,15 +93,7 @@ class EmptyFieldsInResponseTest < IndexedStreamingSearchTest
   end
 
   def not_set_get_values
-    if is_streaming
-      {
-      }
-    else
-      {
-        # Bool has no empty value. Always present in attribute.
-        "bool_attribute" => false
-      }
-    end
+    not_set_search_values
   end
 
   def set_null_get_values


### PR DESCRIPTION
bool values are not stored in docsum blob.

This should be merged at same time as vespa-engine/vespa#23447

@geirst : please review
