### PR TITLE
Removing the perl stuff also removed the openssl dependencies. Use ve…

### DIFF
--- a/docker/include/setup-tls.sh
+++ b/docker/include/setup-tls.sh
@@ -13,6 +13,7 @@ if [[ -n $(find /opt/rh -mindepth 1 -maxdepth 1 -type d -name "rh-ruby*") ]]; th
 fi
 
 # Auto generate cert and key
+export PATH=/opt/vespa-deps/bin:$PATH
 env USER=$THE_USER /opt/vespa-systemtests/lib/node_server.rb --generate-tls-env-and-exit
 
 # Setup the Vespa TLS config


### PR DESCRIPTION
…spa-openssl to generate the certs.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This should fix the build failures for open source on factory.
