### PR TITLE
- Update expected results based on [docid] sorting which gives global…

### DIFF
--- a/tests/search/sorting/sorting.rb
+++ b/tests/search/sorting/sorting.rb
@@ -89,7 +89,7 @@ class Sorting < IndexedSearchTest
                cluster(SearchCluster.new("search2").sd(selfdir+"strong.sd")))
     start
     feed_and_wait_for_docs("simple", 10000, :file => selfdir+"docs-simple.xml", :clusters => ["search"])
-    feed_and_wait_for_docs("strong", 30, :file => selfdir+"docs-strong.xml", :clusters => ["search2"], :maxpending => 1, :trace => 9 )
+    feed_and_wait_for_docs("strong", 30, :file => selfdir+"docs-strong.xml", :clusters => ["search2"])
     compare_onecluster()
     compare_clustertwo()
     compare_twoclusters()

--- a/tests/search/sorting/strong_docid_a.result.json
+++ b/tests/search/sorting/strong_docid_a.result.json
@@ -15,75 +15,34 @@
         },
         "children": [
             {
-                "id": "id:test:strong::10001",
+                "id": "id:test:strong::10013",
                 "relevance": 0.0,
                 "source": "search2",
                 "fields": {
                     "sddocname": "strong",
-                    "documentid": "id:test:strong::10001",
-                    "name": "doc 10001 hash 47 val1",
-                    "year": 1892,
-                    "category": "products / electronics / photo",
-                    "weight": 4.8,
-                    "myrank": 30.234
+                    "documentid": "id:test:strong::10013",
+                    "name": "doc 10013 hash 59 val13",
+                    "year": 1841,
+                    "lastname": "Wingate",
+                    "category": "products / apparel / shoes",
+                    "lastname_lc": "wingate",
+                    "myrank": 18.234
                 }
             },
             {
-                "id": "id:test:strong::10002",
+                "id": "id:test:strong::10030",
                 "relevance": 0.0,
                 "source": "search2",
                 "fields": {
                     "sddocname": "strong",
-                    "documentid": "id:test:strong::10002",
-                    "name": "doc 10002 hash 48 val2",
-                    "year": 1835,
-                    "category": "products / apparel / clothing / womens / stockings",
-                    "lastname": "Sales",
-                    "weight": 112.2,
-                    "myrank": 19.234,
-                    "lastname_lc": "sales"
-                }
-            },
-            {
-                "id": "id:test:strong::10003",
-                "relevance": 0.0,
-                "source": "search2",
-                "fields": {
-                    "sddocname": "strong",
-                    "documentid": "id:test:strong::10003",
-                    "name": "doc 10003 hash 49 val3",
-                    "year": 1785,
-                    "lastname": "Chartres",
-                    "myrank": 8.234,
-                    "lastname_lc": "chartres"
-                }
-            },
-            {
-                "id": "id:test:strong::10004",
-                "relevance": 0.0,
-                "source": "search2",
-                "fields": {
-                    "sddocname": "strong",
-                    "documentid": "id:test:strong::10004",
-                    "name": "doc 10004 hash 50 val4",
-                    "year": 1886,
-                    "category": "services / phone / 300 minutes",
-                    "weight": 202.05,
-                    "myrank": 27.234
-                }
-            },
-            {
-                "id": "id:test:strong::10005",
-                "relevance": 0.0,
-                "source": "search2",
-                "fields": {
-                    "sddocname": "strong",
-                    "documentid": "id:test:strong::10005",
-                    "name": "doc 10005 hash 51 val5",
-                    "lastname": "Dickens",
-                    "weight": 115.55,
-                    "myrank": 16.234,
-                    "lastname_lc": "dickens"
+                    "documentid": "id:test:strong::10030",
+                    "name": "doc 10030 hash 76 val30",
+                    "year": 1797,
+                    "lastname": "Thacker",
+                    "category": "products / apparel / clothing / womens / shirts",
+                    "lastname_lc": "thacker",
+                    "weight": 246.28,
+                    "myrank": 11.234
                 }
             },
             {
@@ -102,33 +61,83 @@
                 }
             },
             {
-                "id": "id:test:strong::10007",
+                "id": "id:test:strong::10016",
                 "relevance": 0.0,
                 "source": "search2",
                 "fields": {
                     "sddocname": "strong",
-                    "documentid": "id:test:strong::10007",
-                    "name": "doc 10007 hash 53 val7",
-                    "year": 1854,
-                    "category": "services / phone / premium with broadband",
-                    "lastname": "Lipman",
-                    "weight": 165.6,
-                    "myrank": 24.234,
-                    "lastname_lc": "lipman"
+                    "documentid": "id:test:strong::10016",
+                    "name": "doc 10016 hash 62 val16",
+                    "year": 1884,
+                    "lastname": "Cheatum",
+                    "category": "products / apparel / shoes",
+                    "lastname_lc": "cheatum",
+                    "weight": 238.38,
+                    "myrank": 15.234
                 }
             },
             {
-                "id": "id:test:strong::10008",
+                "id": "id:test:strong::10018",
                 "relevance": 0.0,
                 "source": "search2",
                 "fields": {
                     "sddocname": "strong",
-                    "documentid": "id:test:strong::10008",
-                    "name": "doc 10008 hash 54 val8",
-                    "year": 1799,
-                    "category": "products / apparel / clothing / womens / skirts",
-                    "weight": 69.27,
-                    "myrank": 13.234
+                    "documentid": "id:test:strong::10018",
+                    "name": "doc 10018 hash 64 val18",
+                    "year": 1823,
+                    "lastname": "Carder",
+                    "category": "products / electronics / computers",
+                    "lastname_lc": "carder",
+                    "weight": 161.82,
+                    "myrank": 23.234
+                }
+            },
+            {
+                "id": "id:test:strong::10017",
+                "relevance": 0.0,
+                "source": "search2",
+                "fields": {
+                    "sddocname": "strong",
+                    "documentid": "id:test:strong::10017",
+                    "name": "doc 10017 hash 63 val17",
+                    "year": 1814,
+                    "lastname": "Yerman",
+                    "category": "products / apparel / clothing / womens / stockings",
+                    "lastname_lc": "yerman",
+                    "weight": 262.67,
+                    "myrank": 4.234
+                }
+            },
+            {
+                "id": "id:test:strong::10015",
+                "relevance": 0.0,
+                "source": "search2",
+                "fields": {
+                    "sddocname": "strong",
+                    "documentid": "id:test:strong::10015",
+                    "name": "doc 10015 hash 61 val15",
+                    "year": 1807,
+                    "lastname": "Vartanian",
+                    "category": "services / phone / premium with broadband",
+                    "lastname_lc": "vartanian",
+                    "weight": 131.73,
+                    "myrank": 26.234
+                }
+            },
+            {
+                "id": "id:test:strong::10027",
+                "relevance": 0.0,
+                "source": "search2",
+                "fields": {
+                    "sddocname": "strong",
+                    "documentid": "id:test:strong::10027",
+                    "name": "doc 10027 hash 73 val27",
+                    "year": 1821,
+                    "lastname": "Costa",
+                    "category": "products / apparel / clothing / womens / tops",
+                    "lastname_lc": "costa",
+                    "weight": 271.84,
+                    "myrank": 14.234
                 }
             },
             {
@@ -148,19 +157,19 @@
                 }
             },
             {
-                "id": "id:test:strong::10010",
+                "id": "id:test:strong::10029",
                 "relevance": 0.0,
                 "source": "search2",
                 "fields": {
                     "sddocname": "strong",
-                    "documentid": "id:test:strong::10010",
-                    "name": "doc 10010 hash 56 val10",
-                    "year": 1804,
-                    "category": "products / apparel / clothing / womens / pants",
-                    "lastname": "Stark",
-                    "weight": 66.83,
-                    "myrank": 21.234,
-                    "lastname_lc": "stark"
+                    "documentid": "id:test:strong::10029",
+                    "name": "doc 10029 hash 75 val29",
+                    "year": 1812,
+                    "lastname": "Grene",
+                    "category": "products / apparel / clothing / womens / shirts",
+                    "lastname_lc": "grene",
+                    "weight": 223.91,
+                    "myrank": 22.234
                 }
             }
         ]

--- a/tests/search/sorting/strong_docid_d.result.json
+++ b/tests/search/sorting/strong_docid_d.result.json
@@ -15,35 +15,47 @@
         },
         "children": [
             {
-                "id": "id:test:strong::10030",
+                "id": "id:test:strong::10026",
                 "relevance": 0.0,
                 "source": "search2",
                 "fields": {
                     "sddocname": "strong",
-                    "documentid": "id:test:strong::10030",
-                    "name": "doc 10030 hash 76 val30",
-                    "year": 1797,
-                    "lastname": "Thacker",
-                    "category": "products / apparel / clothing / womens / shirts",
-                    "lastname_lc": "thacker",
-                    "weight": 246.28,
-                    "myrank": 11.234
+                    "documentid": "id:test:strong::10026",
+                    "name": "doc 10026 hash 72 val26",
+                    "year": 1887,
+                    "category": "products / apparel / clothing / womens / pants",
+                    "weight": 124.89,
+                    "myrank": 25.234
                 }
             },
             {
-                "id": "id:test:strong::10029",
+                "id": "id:test:strong::10021",
                 "relevance": 0.0,
                 "source": "search2",
                 "fields": {
                     "sddocname": "strong",
-                    "documentid": "id:test:strong::10029",
-                    "name": "doc 10029 hash 75 val29",
-                    "year": 1812,
-                    "lastname": "Grene",
-                    "category": "products / apparel / clothing / womens / shirts",
-                    "lastname_lc": "grene",
-                    "weight": 223.91,
-                    "myrank": 22.234
+                    "documentid": "id:test:strong::10021",
+                    "name": "doc 10021 hash 67 val21",
+                    "year": 1877,
+                    "lastname": "Smith",
+                    "category": "products / apparel / clothing / womens / stockings",
+                    "lastname_lc": "smith",
+                    "weight": 233.66,
+                    "myrank": 20.234
+                }
+            },
+            {
+                "id": "id:test:strong::10003",
+                "relevance": 0.0,
+                "source": "search2",
+                "fields": {
+                    "sddocname": "strong",
+                    "documentid": "id:test:strong::10003",
+                    "name": "doc 10003 hash 49 val3",
+                    "year": 1785,
+                    "lastname": "Chartres",
+                    "myrank": 8.234,
+                    "lastname_lc": "chartres"
                 }
             },
             {
@@ -60,49 +72,44 @@
                 }
             },
             {
-                "id": "id:test:strong::10027",
+                "id": "id:test:strong::10001",
                 "relevance": 0.0,
                 "source": "search2",
                 "fields": {
                     "sddocname": "strong",
-                    "documentid": "id:test:strong::10027",
-                    "name": "doc 10027 hash 73 val27",
-                    "year": 1821,
-                    "lastname": "Costa",
-                    "category": "products / apparel / clothing / womens / tops",
-                    "lastname_lc": "costa",
-                    "weight": 271.84,
-                    "myrank": 14.234
+                    "documentid": "id:test:strong::10001",
+                    "name": "doc 10001 hash 47 val1",
+                    "year": 1892,
+                    "category": "products / electronics / photo",
+                    "weight": 4.8,
+                    "myrank": 30.234
                 }
             },
             {
-                "id": "id:test:strong::10026",
+                "id": "id:test:strong::10004",
                 "relevance": 0.0,
                 "source": "search2",
                 "fields": {
                     "sddocname": "strong",
-                    "documentid": "id:test:strong::10026",
-                    "name": "doc 10026 hash 72 val26",
-                    "year": 1887,
-                    "category": "products / apparel / clothing / womens / pants",
-                    "weight": 124.89,
-                    "myrank": 25.234
+                    "documentid": "id:test:strong::10004",
+                    "name": "doc 10004 hash 50 val4",
+                    "year": 1886,
+                    "category": "services / phone / 300 minutes",
+                    "weight": 202.05,
+                    "myrank": 27.234
                 }
             },
             {
-                "id": "id:test:strong::10025",
-                "relevance": 0.0,
+                "id": "id:test:strong::10012",
+                "relevance": 29.233999252319336,
                 "source": "search2",
                 "fields": {
                     "sddocname": "strong",
-                    "documentid": "id:test:strong::10025",
-                    "name": "doc 10025 hash 71 val25",
-                    "year": 1818,
-                    "lastname": "Kitson",
-                    "category": "services / mortgage / prime",
-                    "lastname_lc": "kitson",
-                    "weight": 76.3,
-                    "myrank": 6.234
+                    "documentid": "id:test:strong::10012",
+                    "name": "doc 10012 hash 58 val12",
+                    "year": 1828,
+                    "category": "services / phone / premium with broadband",
+                    "myrank": 29.234
                 }
             },
             {
@@ -122,50 +129,33 @@
                 }
             },
             {
-                "id": "id:test:strong::10023",
-                "relevance": 0.0,
+                "id": "id:test:strong::10020",
+                "relevance": 1.2339999675750732,
                 "source": "search2",
                 "fields": {
                     "sddocname": "strong",
-                    "documentid": "id:test:strong::10023",
-                    "name": "doc 10023 hash 69 val23",
-                    "year": 1858,
-                    "lastname": "Mosby",
-                    "category": "products / apparel / clothing / womens / shorts",
-                    "lastname_lc": "mosby",
-                    "weight": 271.74,
-                    "myrank": 28.234
+                    "documentid": "id:test:strong::10020",
+                    "name": "doc 10020 hash 66 val20",
+                    "year": 1806,
+                    "category": "products / electronics / photo",
+                    "myrank": 1.234,
+                    "weight": 92.77
                 }
             },
             {
-                "id": "id:test:strong::10022",
-                "relevance": 0.0,
+                "id": "id:test:strong::10011",
+                "relevance": 10.234000205993652,
                 "source": "search2",
                 "fields": {
                     "sddocname": "strong",
-                    "documentid": "id:test:strong::10022",
-                    "name": "doc 10022 hash 68 val22",
-                    "year": 1849,
-                    "lastname": "Comstock",
-                    "category": "products / electronics / computers",
-                    "lastname_lc": "comstock",
-                    "myrank": 9.234
-                }
-            },
-            {
-                "id": "id:test:strong::10021",
-                "relevance": 0.0,
-                "source": "search2",
-                "fields": {
-                    "sddocname": "strong",
-                    "documentid": "id:test:strong::10021",
-                    "name": "doc 10021 hash 67 val21",
-                    "year": 1877,
-                    "lastname": "Smith",
-                    "category": "products / apparel / clothing / womens / stockings",
-                    "lastname_lc": "smith",
-                    "weight": 233.66,
-                    "myrank": 20.234
+                    "documentid": "id:test:strong::10011",
+                    "name": "doc 10011 hash 57 val11",
+                    "year": 1825,
+                    "category": "products / apparel / clothing / womens / skirts",
+                    "lastname": "Gaddy",
+                    "weight": 186.91,
+                    "myrank": 10.234,
+                    "lastname_lc": "gaddy"
                 }
             }
         ]


### PR DESCRIPTION
… ordering.

- No longer any need to feed in sequence to guartee order in test.

@geirst or @hmusum PR
Goes with https://github.com/vespa-engine/vespa/pull/24463