### PR TITLE
Revert "Update expected test output to match error produced by Jetty 11"

### DIFF
--- a/tests/container/malformed_query_returns_400/malformed_query_returns_400.rb
+++ b/tests/container/malformed_query_returns_400/malformed_query_returns_400.rb
@@ -17,7 +17,7 @@ class MalformedQueryReturns400 < ContainerTest
     response = client.request(Net::HTTP::Get.new('/t est\"'))
 
     assert_equal('400', response.code)
-    assert_equal('Bad Request', response.message)
+    assert_equal('Illegal character SPACE=\' \'', response.message)
   end
 
   def teardown


### PR DESCRIPTION
This reverts commit 6e66a6c10a2dae99ccabeb5cb8d920edbdef3bb6.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
