### PR TITLE
Reduce test timeout

### DIFF
--- a/tests/search/basicsearch/basic_search.rb
+++ b/tests/search/basicsearch/basic_search.rb
@@ -10,6 +10,13 @@ class BasicSearch < IndexedSearchTest
     @valgrind_opt = nil
   end
 
+  # Override timeout, since the default is very high (1200 seconds) and if
+  # this test fails due to some service not starting it
+  # will take a very long time before it gives up
+  def timeout_seconds
+    return 300
+  end
+
   def can_share_configservers?(method_name=nil)
     false
   end


### PR DESCRIPTION
Will reduce build time with 15 minutes when something is broken so that this test (which is run after creating docker images) does not complete successfully. Test usually uses less than 60 seconds