### PR TITLE
Ignore extra warning line about hostname mismatches.

### DIFF
--- a/tests/cloudconfig/tools/vespa-deploy.rb
+++ b/tests/cloudconfig/tools/vespa-deploy.rb
@@ -229,7 +229,7 @@ EOS
 
   def create_expected_prepare_output()
     expected = <<EOS;
-Preparing session #{@session_id} using #{@session_path}/#{@session_id}/prepared.*
+Preparing session #{@session_id} using #{@session_path}/#{@session_id}/prepared\\n?.*
 Session #{@session_id} for tenant '#{@tenant}' prepared.
 EOS
     Regexp.new(expected)


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Not sure if it is possible to avoid outputting the warning observed here at all:
https://factory.vespa.oath.cloud/testrun/55617958/test/VespaDeploy::test_deploy_output

