### PR TITLE
Revert "Make sure that all containers are running with perfmap to get Java sy…"

### DIFF
--- a/lib/performance_test.rb
+++ b/lib/performance_test.rb
@@ -273,7 +273,6 @@ class PerformanceTest < TestCase
   end
 
   def setup
-    @vespa.nodeproxies.values.each {|node| override_environment_setting(node, "VESPA_CONTAINER_JVMARGS", perfmap_agent_jvmarg) }
     profiler_start
   end
 


### PR DESCRIPTION
Reverts vespa-engine/system-test#2689
@aressem @hmusum or @arnej27959 
Revert this one to see if that is reason for reduced/unstable perfomance and some core dumps in perf tests