### PR TITLE
Enable memory traps on system tests

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -5,7 +5,8 @@
             "rules" : [
                 {
                     "value" : [
-                        "VESPA_BITVECTOR_RANGE_CHECK=true"
+                        "VESPA_BITVECTOR_RANGE_CHECK=true",
+                        "VESPA_USE_MPROTECT_TRAP=yes"
                     ]
                 }
             ]


### PR DESCRIPTION
@baldersheim please review. I'll unify the mprotect environment variable to use "true" later... 🙂
