### PR TITLE
Restrict sameElement queries to the document type where the field exi…

### DIFF
--- a/tests/search/struct_and_map_types/imported_struct.rb
+++ b/tests/search/struct_and_map_types/imported_struct.rb
@@ -129,7 +129,7 @@ class ImportedStructTest < SearchTest
   end
 
   def assert_same_element(field, same_element, exp_result)
-    query = "select * from sources * where #{field} contains sameElement(#{same_element})"
+    query = "select * from sources child where #{field} contains sameElement(#{same_element})"
     assert_result("yql", query, exp_result)
   end
 


### PR DESCRIPTION
…sts.

With the change in #2699 we expect each query to have zero errors. This is not the case when querying a document type that doesn't have the sameElement field.

@baldersheim please review