### PR TITLE
Restart when changing indexing mode

### DIFF
--- a/tests/search/schemachanges/schemachanges_need_refeed_reconfig.rb
+++ b/tests/search/schemachanges/schemachanges_need_refeed_reconfig.rb
@@ -94,10 +94,12 @@ class SchemaChangesNeedRefeedReconfigTest < IndexedSearchTest
     feed_and_wait_for_docs("test", 1, :file => @test_dir + "feed.0.xml")
 
     @params[:search_type] = "ELASTIC"
+    vespa.stop_base # Indexing mode change leads to changed config id for search nodes, a restart is required
     redeploy_output = deploy_app(app)
     gen = get_generation(redeploy_output).to_i
     assert_match(/Document type 'test' in cluster 'search' changed indexing mode from 'streaming' to 'indexed'/, redeploy_output)
 
+    start
     wait_for_convergence(gen)
 
     # Feed should be accepted


### PR DESCRIPTION
Changing indexing mode leads to search nodes getting new config ids. Since they might get new config for old config id before being restarted they might get wrong/empty config, which leads to unstabe test.