### PR TITLE
Support dumping distributor bucket DB on consistency failure

### DIFF
--- a/lib/nodetypes/distributor.rb
+++ b/lib/nodetypes/distributor.rb
@@ -4,6 +4,12 @@ require 'environment'
 
 class Distributor < VDSNode
 
+  def initialize(*args)
+    super(*args)
+    @remember_last_in_sync_db_state = false
+    @last_in_sync_db_state = nil
+  end
+
   def is_synced?
     statuspage = get_status_page("/distributor?page=buckets")
     if !has_expected_bucket_db_prologue(statuspage)
@@ -19,8 +25,19 @@ class Distributor < VDSNode
     }
 
     @lastidealstatus = count
+    if @remember_last_in_sync_db_state and count == 0
+      @last_in_sync_db_state = statuspage
+    end
 
     return @lastidealstatus == 0
+  end
+
+  def remember_last_in_sync_db_state
+    @remember_last_in_sync_db_state = true
+  end
+
+  def last_in_sync_db_state
+    @last_in_sync_db_state
   end
 
   def has_expected_bucket_db_prologue(statuspage)

--- a/lib/nodetypes/storage.rb
+++ b/lib/nodetypes/storage.rb
@@ -639,6 +639,10 @@ class Storage
         if params[:failure_listener]
           params[:failure_listener].notify_failure(bucket, i, e.to_s)
         end
+        if params[:dump_distributor_db_states_on_failure]
+          @testcase.output("Last in-sync bucket DB state on distributor #{i}:")
+          @testcase.output(@distributor[i.to_s].last_in_sync_db_state)
+        end
         raise
       end
       checked_buckets_total += 1
@@ -774,19 +778,21 @@ class Storage
       node.wait_until_no_pending_bucket_moves
     end
 
-    @testcase.output("Waiting for distributors...")
-    # Don't include blocklisted (presumably down) distributors in testing
-    @distributor.each do | key, distrib |
-      next if blocklist.include? key
-      distrib.wait_until_all_pending_bucket_info_requests_done
-      distrib.wait_until_synced(timeout)
-    end
-
     crosscheck_buckets_params = {}
     if should_crosscheck_active?
       crosscheck_buckets_params[:check_active] = :single_active_per_bucket
     end
     crosscheck_buckets_params.merge! @bucket_crosscheck_params
+
+    @testcase.output("Waiting for distributors...")
+    # Don't include blocklisted (presumably down) distributors in testing
+    @distributor.each do | key, distrib |
+      next if blocklist.include? key
+      distrib.remember_last_in_sync_db_state if crosscheck_buckets_params[:dump_distributor_db_states_on_failure]
+      distrib.wait_until_all_pending_bucket_info_requests_done
+      distrib.wait_until_synced(timeout)
+    end
+
     @testcase.output("Cross checking buckets (check active states: " +
                      "#{crosscheck_buckets_params[:check_active]})")
     validate_cluster_bucket_state(crosscheck_buckets_params)

--- a/tests/search/bucketreadiness/bucketreadiness_visiting.rb
+++ b/tests/search/bucketreadiness/bucketreadiness_visiting.rb
@@ -81,6 +81,11 @@ class BucketReadiness < BucketReadinessBase
     wait_for_hitcount(get_query("3"), docs)
     assert_visit_count(3, docs)
 
+    # TODO this is temporary for debugging
+    vespa.storage['mycluster'].set_bucket_crosscheck_params(
+        :dump_distributor_db_states_on_failure => true
+    )
+
     start_and_wait(0)
     wait_for_hitcount(get_query("0,3"), docs)
     assert_visit_count(4, docs)


### PR DESCRIPTION
@geirst please review

Debugging aid for one test that on rare occasions appears to not sufficiently wait for maintenance ops to be completed, causing spurious consistency check failures due to running prior to the cluster fully settling.

Now lets a test specify that the state of the bucket DB on a distributor should be dumped on failure, allowing for a manual inspection and comparison.
