### PR TITLE
Use single search thread

### DIFF
--- a/tests/search/struct_and_map_types/struct_and_map_grouping.rb
+++ b/tests/search/struct_and_map_types/struct_and_map_grouping.rb
@@ -53,7 +53,7 @@ class StructAndMapGroupingTest < IndexedStreamingSearchTest
   end
 
   def create_app
-    SearchApp.new.sd(selfdir + "grouping/test.sd")
+    SearchApp.new.sd(selfdir + "grouping/test.sd").threads_per_search(1)
   end
 
   def test_struct_and_map_grouping


### PR DESCRIPTION
Using a single thread will trigger the bug where multiple buckets for empty string is created, resulting in a assertion failure and crash for proton.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
