### PR TITLE
The reserved document for a multivalue attribute vector has an empty ..

### DIFF
--- a/tests/search/feed_block/feed_block.rb
+++ b/tests/search/feed_block/feed_block.rb
@@ -176,7 +176,7 @@ class FeedBlockTest < FeedBlockBase
 
   def run_feed_block_document_v1_api_two_nodes_test(error_msg)
     @num_parts = 2
-    @beforelimit = 36
+    @beforelimit = 37
     # Allow feeding, but with very low multivalue limit, allows @beforelimit docs
     deploy_app_with_low_multivalue_limit
     start


### PR DESCRIPTION
…vector.

This tracks changes in vespa-engine/vespa#26769

@geirst : please review
@baldersheim : FYI
