### PR TITLE
Revert "Only add streaming.selection parameter when in streaming mode."

### DIFF
--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -989,11 +989,7 @@ class TestCase
     end
     node.stop
     node.start
-    query = "sddocname:#{doc_type}&nocache"
-    if is_streaming
-      query += "&streaming.selection=true"
-    end
-    wait_for_hitcount(query, exp_hits, 180)
+    wait_for_hitcount("sddocname:#{doc_type}&nocache&streaming.selection=true", exp_hits, 180)
   end
 
 end


### PR DESCRIPTION
Reverts vespa-engine/system-test#2830

Many system tests broke due to is_streaming not being a known member function.
