### PR TITLE
Add tests for conditional Remove with inconsistent replicas

### DIFF
--- a/tests/search/inconsistent_replicas/inconsistent_conditional_remove.rb
+++ b/tests/search/inconsistent_replicas/inconsistent_conditional_remove.rb
@@ -1,0 +1,33 @@
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+require_relative 'inconsistent_buckets_base'
+
+class InconsistentConditionalRemoveTest < InconsistentBucketsBase
+
+  def setup
+    set_owner('vekterli')
+    super
+  end
+
+  def remove_with_condition(condition)
+    vespa.document_api_v1.remove(updated_doc_id, :condition => condition)
+  end
+
+  def test_conditional_remove_matching_existing_doc_is_applied
+    set_description('Test that conditional Remove is applied when document versions are inconsistent ' +
+                    'across replicas and the condition _matches_ the newest document')
+    make_replicas_inconsistent_for_single_document
+    remove_with_condition('music.title == "second title"') # Newest doc version
+    verify_document_is_removed_on_all_nodes
+  end
+
+  def test_conditional_remove_mismatching_existing_doc_is_not_applied
+    set_description('Test that conditional Remove is NOT applied when document versions are inconsistent ' +
+                    'across replicas and the condition _does not match_ the newest document')
+    make_replicas_inconsistent_for_single_document
+    assert_precondition_failure {
+      remove_with_condition('music.title == "first title"')
+    }
+    verify_document_has_expected_contents(title: 'second title') # Just checks newest version
+  end
+
+end

--- a/tests/search/inconsistent_replicas/updates_to_inconsistent_buckets.rb
+++ b/tests/search/inconsistent_replicas/updates_to_inconsistent_buckets.rb
@@ -21,10 +21,7 @@ class UpdatesToInconsistentBucketsTest < InconsistentBucketsBase
     set_description('Test that updates trigger write-repair when documents across ' +
                     'replicas have diverging timestamps')
 
-    feed_doc_with_field_value(title: 'first title')
-    mark_content_node_down(1)
-    feed_doc_with_field_value(title: 'second title')
-    mark_content_node_up(1) # Node 1 will have old version of document
+    make_replicas_inconsistent_for_single_document
     update_doc_with_field_value(title: 'third title', create_if_missing: create_if_missing)
 
     verify_document_has_expected_contents_on_all_nodes(title: 'third title')
@@ -76,10 +73,7 @@ class UpdatesToInconsistentBucketsTest < InconsistentBucketsBase
     set_description('Test that conditional updates trigger write-repair when documents across ' +
                     'replicas have diverging timestamps')
 
-    feed_doc_with_field_value(title: 'first title')
-    mark_content_node_down(1)
-    feed_doc_with_field_value(title: 'second title')
-    mark_content_node_up(1) # Node 1 will have old version of document
+    make_replicas_inconsistent_for_single_document
 
     begin
       update_doc_with_field_value(title: 'third title', create_if_missing: create_if_missing, condition: condition)


### PR DESCRIPTION
@havardpe please review

All the new tests will fail at the moment, as write-repair is not yet wired into conditional Remove operations.

Also factor out some common bits and simplify precondition testing with some not-too-subtle inspiration from the Doc V1 API tests.

