### PR TITLE
Revert "Use maven 3.8 and ruby 3.1"

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -12,8 +12,8 @@ RUN dnf -y install epel-release && \
         dnf-plugins-core \
         dnf-plugin-ovl && \
     dnf config-manager --enable powertools && \
-    dnf -y module enable maven:3.8 && \
-    dnf -y module enable ruby:3.1 && \
+    dnf -y module enable maven:3.6 && \
+    dnf -y module enable ruby:3.0 && \
     dnf -y install \
         bind-utils \
         cmake \

--- a/docker/Dockerfile.stream8
+++ b/docker/Dockerfile.stream8
@@ -19,8 +19,8 @@ RUN dnf install -y gcc-c++ python3-devel && \
 ENV VESPA_CONFIGPROXY_JVMARGS="-XX:ThreadStackSize=1024k"
 
 RUN dnf config-manager --enable powertools && \
-    dnf module enable -y ruby:3.1 && \
-    dnf module enable -y maven:3.8 && \
+    dnf module enable -y ruby:3.0 && \
+    dnf module enable -y maven:3.6 && \
     dnf install -y \
         bind-utils \
         gcc-toolset-12-annobin-docs \


### PR DESCRIPTION
Reverts vespa-engine/system-test#2865

Seems like performance tests are struggling after this change (most tests do not finish and run is aborted)