### PR TITLE
Use TLSv1.2 for HTTPS connections to work around Ruby Net::HTTP bug

### DIFF
--- a/lib/https_client.rb
+++ b/lib/https_client.rb
@@ -21,6 +21,7 @@ class HttpsClient
       http.cert = ssl_ctx.cert
       http.key = ssl_ctx.key
       http.verify_mode = ssl_ctx.verify_mode
+      http.ssl_version = :TLSv1_2 # TODO remove once https://bugs.ruby-lang.org/issues/19017 is resolved
     end
     http
   end


### PR DESCRIPTION
@bjorncs please review.

https://bugs.ruby-lang.org/issues/19017 may cause hanging until timeout when TLSv1.3 is used.

Remove workaround once this is resolved.
