### PR TITLE
Revert "Run each test case in a separate process."

### DIFF
--- a/lib/drb_endpoint.rb
+++ b/lib/drb_endpoint.rb
@@ -30,10 +30,10 @@ class DrbEndpoint
     end
   end
 
-  def create_tls_client(endpoint, object, force_service_restart)
+  def create_tls_client(endpoint, object)
     # Only do this once per class to avoid dangling threads and open ports for every client
     @@self_service_mutex.synchronize do
-      if @@self_uri.nil? || force_service_restart
+      if @@self_uri.nil?
         verify_cert_files_present
         # DRb has a completely bonkers API and basically offers no way of setting
         # client connection config aside from creating a dummy service and keeping
@@ -54,9 +54,9 @@ class DrbEndpoint
     DRbObject.new(nil, uri)
   end
 
-  def create_client(with_object: nil, force_service_restart: false)
+  def create_client(with_object: nil)
     if secure?
-      create_tls_client(@endpoint, with_object, force_service_restart)
+      create_tls_client(@endpoint, with_object)
     else
       create_insecure_client(@endpoint, with_object)
     end

--- a/lib/test_base.rb
+++ b/lib/test_base.rb
@@ -62,9 +62,7 @@ module TestBase
     end
   end
 
-  DRUBY_REPORTER_PORT  = 27180
-  DRUBY_NODE_POOL_PORT = 27183  # Same as DRUBY_REMOTE_PORT for now
-  DRUBY_REMOTE_PORT    = 27183
+  DRUBY_REMOTE_PORT = 27183
 
   # absolute path to the systemtests/tests/
   INSTALL_DIR = $:.find {|path| path =~ /systemtests.*\/tests$/} || ""

--- a/lib/test_node_pool.rb
+++ b/lib/test_node_pool.rb
@@ -17,7 +17,7 @@ class TestNodePool
     @lock = Mutex.new
     @max_available_nodes = 0
 
-    addr = ":#{TestBase::DRUBY_NODE_POOL_PORT}"
+    addr = ":#{TestBase::DRUBY_REMOTE_PORT}"
     endpoint = DrbEndpoint.new(addr)
     endpoint.start_service(for_object: self)
     uri = URI.parse(DRb.current_server.uri)
@@ -29,7 +29,7 @@ class TestNodePool
 
     while Time.now.to_i < endtime
       begin
-        TCPSocket.new("127.0.0.1", TestBase::DRUBY_NODE_POOL_PORT).close
+        TCPSocket.new("127.0.0.1", TestBase::DRUBY_REMOTE_PORT).close
         node_allocator_up = true
         break
       rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH


### PR DESCRIPTION
Reverts vespa-engine/system-test#2943

Merge in case of failures.