### PR TITLE
UnlockDiagnosticVMOptions to enable perf map dump.

### DIFF
--- a/lib/performance_test.rb
+++ b/lib/performance_test.rb
@@ -210,7 +210,7 @@ class PerformanceTest < TestCase
 
 
   def perfmap_jvmarg
-    "-XX:+DumpPerfMapAtExit"
+    "-XX:+UnlockDiagnosticVMOptions -XX:+DumpPerfMapAtExit"
   end
 
   def run_predicate_search_library_benchmark(node, benchmark_params)


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
