### PR TITLE
Handle missing State V1 metrics in test

### DIFF
--- a/lib/json_metrics.rb
+++ b/lib/json_metrics.rb
@@ -15,6 +15,10 @@ class JSONMetrics
     @metrics
   end
 
+  def has_metric_values?
+    not (@metrics.nil? or @metrics['values'].nil?)
+  end
+
   # return a list of all metrics whose name match expr
   def extract(expr)
     result = []

--- a/tests/vds/metrics.rb
+++ b/tests/vds/metrics.rb
@@ -58,6 +58,10 @@ class VdsMetrics < VdsTest
     metric = nil
     360.times do
       metrics = JSONMetrics.new(node.get_state_v1_metrics)
+      if not metrics.has_metric_values?
+        sleep 1 # no snapshot yet
+        next
+      end
       metric = get_last_metric(metrics, name)
       break if expval == metric
       sleep 1


### PR DESCRIPTION
@baldersheim please review

Test uses non-total metric set and therefore needs to wait until metric values are exposed as part of a snapshot. Now also waits until metrics are actually present in the output, which they may not be on process startup if there has not been a snapshot yet.
