### PR TITLE
Don't check for `metrics` element in output before snapshot is taken

### DIFF
--- a/tests/search/proton_state_server/proton_state_server.rb
+++ b/tests/search/proton_state_server/proton_state_server.rb
@@ -16,9 +16,8 @@ class ProtonStateServer < IndexedSearchTest
     feed_and_wait_for_docs("test", 5, :file => selfdir + "docs.xml")
     node = @vespa.search["search"].first
     metrics = node.get_state_v1_metrics
-    # pp metrics
+    # node should be reporting itself as up
     assert_equal("up", metrics["status"]["code"])
-    assert_not_nil(metrics["metrics"])
     config = node.get_state_v1_config
     # pp config
     assert_equal(generation, config["config"]["proton"]["generation"])


### PR DESCRIPTION
@baldersheim please review.

We already have other tests that check the actual JSON metrics as part of the state API, so not really worth it to twiddle thumbs for another 60 seconds just to check if a particular element eventually appears.

