### PR TITLE
Fail `set_node_state` call if state was not actually modified

### DIFF
--- a/lib/nodetypes/contentclustercontroller.rb
+++ b/lib/nodetypes/contentclustercontroller.rb
@@ -96,6 +96,11 @@ class ContentClusterController < VespaNode
     if res.code.to_i != 200
       raise "Failed to set node state to '#{rest_state}' (HTTP #{res.code}): #{res.body}"
     end
+
+    json_body = JSON.parse(res.body)
+    if json_body['wasModified'] != true
+      raise "Cluster controller refused to set node state to '#{rest_state}'. Reason: #{json_body['reason']}"
+    end
   end
 
   def wait_for_stable_system(cluster)


### PR DESCRIPTION
@baldersheim please review. This is related to some upcoming tests for bucket count tracking/reporting on the cluster controller. Due to the potential blast radius of this change, I'm keeping it as a self-contained—easily revertible—PR.

Existing code assumed that just getting a HTTP 200 meant that the state was applied, but the returned JSON must be checked as well.

