### PR TITLE
stop expecting snapshots

### DIFF
--- a/tests/vds/clustercontroller.rb
+++ b/tests/vds/clustercontroller.rb
@@ -99,7 +99,6 @@ class ClusterControllerTest < VdsTest
     puts page
     assert_match(/.*Cluster Controller Status Page - Node status for distributor\.1.*/, page)
     assert_match(/.*href="\.\.">Back to cluster.*/, page)
-    assert_match(/.*snapshot.*/, page)
   end
   
   # Useful test wrapper to test manually faster, avoiding setup and teardown


### PR DESCRIPTION
it seems that this test expects some metric snapshots to appear on the status page, but those were removed in https://github.com/vespa-engine/vespa/pull/28250

@vekterli / @baldersheim please review
