### PR TITLE
Revert "Warn when using user config with unknown config definition"

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -38,7 +38,6 @@
         { "id" : "enable-global-phase", "rules" : [ { "value" : true } ] },
         { "id" : "use-reconfigurable-dispatcher", "rules" : [ { "value" : true } ] },
         { "id" : "write-config-server-session-data-as-blob", "rules" : [ { "value" : true } ] },
-        { "id" : "dynamic-heap-size", "rules" : [ { "value" : true } ] },
-        { "id" : "unknown-config-definition", "rules" : [ { "value" : true } ] }
+        { "id" : "dynamic-heap-size", "rules" : [ { "value" : true } ] }
     ]
 }


### PR DESCRIPTION
Reverts vespa-engine/system-test#3041

Pleas review only. I suspect that some tests will fail due to warnings in log, merge in case this happens