### PR TITLE
Revert "Fail when using user config with unknown config definition"

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -39,6 +39,6 @@
         { "id" : "use-reconfigurable-dispatcher", "rules" : [ { "value" : true } ] },
         { "id" : "write-config-server-session-data-as-blob", "rules" : [ { "value" : true } ] },
         { "id" : "dynamic-heap-size", "rules" : [ { "value" : true } ] },
-        { "id" : "unknown-config-definition", "rules" : [ { "value" : "fail" } ] }
+        { "id" : "unknown-config-definition", "rules" : [ { "value" : "warn" } ] }
     ]
 }


### PR DESCRIPTION
Some failures, need to analyze/fix them before we can use 'fail'