### PR TITLE
Handle case where CC heartbeat response is sent between feed ops in test

### DIFF
--- a/tests/vds/clustercontroller.rb
+++ b/tests/vds/clustercontroller.rb
@@ -222,11 +222,12 @@ class ClusterControllerTest < VdsTest
     while true
       buckets = get_cluster_v2_storage_bucket_count(0, deadline)
       puts buckets
-      # At this point, bucket count will be either 0 or 2, but shall eventually be stable at 2
-      break if buckets != 0
+      # At this point, bucket count will be either 0, 1 or 2, but shall eventually be stable at 2
+      # It's possible that the internal DB bucket count snapshot happens _after_ doc 1 has been fed
+      # but _before_ doc 2 has been fed, hence the possibility of observing 1 document.
+      break if buckets == 2
       sleep 1
     end
-    assert_equal(2, buckets)
 
     # Restarting a content node should never surface an outdated bucket count through the API
     vespa.stop_content_node('storage', '0')


### PR DESCRIPTION
@baldersheim please review

Test feeds 2 docs to independent buckets, and expects that the bucket count reported back to the CC is initially 0, then 2. This does not hold true if the bucket DB state is sampled and sent back to the cluster controller _after_ the first document has been fed but _before_ the second document has been fed, in which case 1 bucket will be reported.

Test has been relaxed to accept intermediate values before settling on 2 buckets reported.

