### PR TITLE
Enable distributor operation cancellation on factory

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -39,6 +39,7 @@
         { "id" : "use-reconfigurable-dispatcher", "rules" : [ { "value" : true } ] },
         { "id" : "write-config-server-session-data-as-blob", "rules" : [ { "value" : true } ] },
         { "id" : "dynamic-heap-size", "rules" : [ { "value" : true } ] },
-        { "id" : "unknown-config-definition", "rules" : [ { "value" : "fail" } ] }
+        { "id" : "unknown-config-definition", "rules" : [ { "value" : "fail" } ] },
+        { "id" : "content-layer-metadata-feature-level", "rules" : [ { "value" : 1 } ] }
     ]
 }


### PR DESCRIPTION
@geirst please review
@baldersheim FYI

This changes some fundamental code paths in the distributor, so there's a non-zero chance of test regressions. But that's why we have them.