### PR TITLE
Revert "Enable distributor operation cancellation on factory"

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -39,7 +39,6 @@
         { "id" : "use-reconfigurable-dispatcher", "rules" : [ { "value" : true } ] },
         { "id" : "write-config-server-session-data-as-blob", "rules" : [ { "value" : true } ] },
         { "id" : "dynamic-heap-size", "rules" : [ { "value" : true } ] },
-        { "id" : "unknown-config-definition", "rules" : [ { "value" : "fail" } ] },
-        { "id" : "content-layer-metadata-feature-level", "rules" : [ { "value" : 1 } ] }
+        { "id" : "unknown-config-definition", "rules" : [ { "value" : "fail" } ] }
     ]
 }


### PR DESCRIPTION
Reverts vespa-engine/system-test#3063

Looks like at least one performance test fails (core dump in distributor)