### PR TITLE
Use single value attributes instead of one array attribute.

### DIFF
--- a/tests/performance/range_search/create_docs.cpp
+++ b/tests/performance/range_search/create_docs.cpp
@@ -7,59 +7,29 @@
 #include <unistd.h>
 #include <vector>
 
-constexpr int per_thousand = 1000;
+using IntVector = std::vector<int>;
 
-/**
- * Class used to generate a set of values to be inserted into a subset of documents.
+/*
+ * Generates the set of values to be inserted into a field.
  *
  * When searching for range(my_field, LOWER, UPPER) this will match 'values_in_range'
- * unique values (or posting lists) and return the given number of 'hits'.
+ * unique values (or posting lists) and return a number of hits given by the 'hits_ratio'.
  *
  * LOWER = hits_ratio * 100000 + values_in_range
  * UPPER = LOWER + values_in_range
  */
-class ValueGenerator {
-private:
-    int _hits_per_value;
-    int _curr_value;
-    int _i;
-    int _doc_mod;
-    int _doc_mod_bias;
-
-public:
-    ValueGenerator(int hits, int hits_ratio, int values_in_range, int doc_mod_bias)
-        : _hits_per_value(hits / values_in_range),
-          _curr_value(hits_ratio * 100000 + values_in_range),
-          _i(0),
-          _doc_mod(per_thousand / hits_ratio),
-          _doc_mod_bias(doc_mod_bias % _doc_mod)
-    {
-    }
-    bool use_doc(int doc_id) const {
-        return (doc_id % _doc_mod) == _doc_mod_bias;
-    }
-    int next() {
-        int result = _curr_value;
-        if (++_i % _hits_per_value == 0) {
-            ++_curr_value;
-        }
-        return result;
-    }
-};
-
-using IntVector = std::vector<int>;
-using ValueGeneratorVector = std::vector<ValueGenerator>;
-
-ValueGeneratorVector make_generators(int num_docs, bool verbose) {
-    ValueGeneratorVector result;
-    // Specifies the amount of the corpus that will hit (per thousand) for a range query term.
-    for (int ratio : {1, 10, 50, 100, 200, 500}) {
-        int hits = ((size_t)num_docs * (size_t)ratio) / per_thousand;
-        for (int values_in_range : {1, 10, 100, 1000, 10000}) {
-            if (hits >= values_in_range) {
-                result.emplace_back(hits, ratio, values_in_range, rand());
-                if (verbose) {
-                    printf("ValueGenerator(%d,%d,%d)\n", hits, ratio, values_in_range);
+IntVector make_range_values(int num_docs, int values_in_range) {
+    IntVector result(num_docs, 0);
+    int i = 0;
+    for (int hits_ratio : {1, 10, 50, 100, 200, 500}) {
+        int hits = ((size_t)num_docs * (size_t)hits_ratio) / 1000;
+        if (hits >= values_in_range) {
+            int hits_per_value = hits / values_in_range;
+            int value = hits_ratio * 100000 + values_in_range;
+            for (int j = 0; j < hits; ++j) {
+                result[i++] = value;
+                if ((j + 1) % hits_per_value == 0) {
+                    ++value;
                 }
             }
         }
@@ -67,78 +37,63 @@ ValueGeneratorVector make_generators(int num_docs, bool verbose) {
     return result;
 }
 
-void make_range_values(int doc_id, ValueGeneratorVector& gens, IntVector& result) {
-    result.clear();
-    for (auto& gen : gens) {
-        if (gen.use_doc(doc_id)) {
-            result.push_back(gen.next());
+IntVector make_filter(int num_docs) {
+    IntVector result(num_docs, 0);
+    int i = 0;
+    for (int hits_ratio : {1, 10, 50, 100, 200, 500}) {
+        int hits = ((size_t)num_docs * (size_t)hits_ratio) / 1000;
+        for (int j = 0; j < hits; ++j) {
+            result[i++] = hits_ratio;
         }
     }
+    return result;
 }
 
-void make_filter(int doc_id, IntVector& result) {
-    result.clear();
-    // Specifies the amount of the corpus that will hit (per thousand) for a filter query term.
-    for (int filter : {1, 10, 50, 100, 200, 500}) {
-        if ((doc_id % per_thousand) < filter) {
-            result.push_back(filter);
-        }
+void shuffle(IntVector& vector, int seed) {
+    std::default_random_engine engine(seed);
+    std::shuffle(vector.begin(), vector.end(), engine);
+}
+
+using RangeValuesData = std::vector<std::pair<int, IntVector>>;
+
+RangeValuesData make_range_values_data(int num_docs) {
+    RangeValuesData result;
+    for (int values_in_range : {1, 10, 100, 1000, 10000}) {
+        auto values = make_range_values(num_docs, values_in_range);
+        shuffle(values, 1234);
+        result.emplace_back(values_in_range, std::move(values));
     }
+    return result;
 }
 
-void print_array(const IntVector& array) {
-    printf("[");
-    bool first = true;
-    for (auto val : array) {
-        if (!first) {
-            printf(",");
-        }
-        printf("%d", val);
-        first = false;
-    }
-    printf("]");
-}
-
-void print_docs(int num_docs, const IntVector& values_ids, const IntVector& filter_ids, ValueGeneratorVector& gens) {
+void print_docs(int num_docs, const RangeValuesData& values, const IntVector& filter) {
     printf("[\n");
-    IntVector array;
     for (int doc_id = 0; doc_id < num_docs; ++doc_id) {
         if (doc_id > 0) {
             printf(",\n");
         }
-        printf("{\"put\":\"id:test:test::%d\",\"fields\":{\"values_fast\":", doc_id);
-        make_range_values(values_ids[doc_id], gens, array);
-        print_array(array);
-        printf(",\"values_slow\":");
-        print_array(array);
-        printf(",\"filter\":");
-        make_filter(filter_ids[doc_id], array);
-        print_array(array);
+        printf("{\"put\":\"id:test:test::%d\",\"fields\":{", doc_id);
+        for (const auto& elem : values) {
+            printf("\"v_%d\":%d,", elem.first, elem.second[doc_id]);
+        }
+        printf("\"filter\":%d", filter[doc_id]);
         printf("}}");
     }
     printf("\n]\n");
 }
 
-IntVector shuffled_ids(int num_docs, int seed) {
-    IntVector result(num_docs);
-    std::iota(result.begin(), result.end(), 0);
-    std::default_random_engine engine(seed);
-    std::shuffle(std::begin(result), std::end(result), engine);
-    return result;
-}
-
 /**
  * This program generates documents used for performance testing of range search.
  *
- * The 'values_fast' and 'values_slow' fields are populated such that 30 different range queries can be used:
- *   - 6 catagories of queries return a subset of the corpus: 0.1%, 1%, 5%, 10%, 20%, 50%.
- *   - Each category supports 5 different amounts of unique values in the range: 1, 10, 100, 1000, 10000.
- *     The documents are spread evenly across the unique values in such range.
+ * The 'v_%d' and 'v_%d_fs' fields (10 in total) are populated such that 30 different range queries can be used:
+ *   - Each field uses a given number of unique values in a range: 1, 10, 100, 1000, 10000.
+ *   - Each field supports 6 catagories of queries that each return a subset of the corpus: 0.1%, 1%, 5%, 10%, 20%, 50%.
  *
  * Examples:
- *   - range(values, 20000100, 20000200) returns 20% of the corpus, and has 100 values in the range.
- *   - range(values,  5001000,  5002000) returns 5% of the corpus, and has 1000 values in the range.
- * See ValueGenerator for more details.
+ *   - range(v_100,  20000100, 20000200) returns 20% of the corpus, and has 100 values in the range.
+ *   - range(v_1000,  5001000,  5002000) returns 5% of the corpus, and has 1000 values in the range.
+ *
+ * See make_range_values() for more details.
  * Note: 10M documents are needed in order to support all combinations.
  *
  * The 'filter' field is populated such that a query filter term returns a subset of the corpus: 0.1%, 1%, 5%, 10%, 20%, 50%.
@@ -160,9 +115,10 @@ int main(int argc, char *argv[]) {
                 return 1;
         }
     }
-    srand(1234);
-    auto gens = make_generators(num_docs, verbose);
-    print_docs(num_docs, shuffled_ids(num_docs, 1234), shuffled_ids(num_docs, 5678), gens);
+    auto values = make_range_values_data(num_docs);
+    auto filter = make_filter(num_docs);
+    shuffle(filter, 5678);
+    print_docs(num_docs, values, filter);
     return 0;
 }
 

--- a/tests/performance/range_search/range_search.rb
+++ b/tests/performance/range_search/range_search.rb
@@ -78,7 +78,7 @@ class RangeSearchPerfTest < PerformanceTest
     if filter_hits_ratio > 0
       filter = " and filter = #{filter_hits_ratio}"
     end
-    field_name = fast_search ? "values_fast" : "values_slow"
+    field_name = "v_#{values_in_range}#{fast_search ? '_fs' : ''}"
     "/search/?" + URI.encode_www_form("yql" => "select * from sources * where range(#{field_name}, #{lower}, #{upper})#{filter}",
                                       "hits" => "0")
   end

--- a/tests/performance/range_search/test.sd
+++ b/tests/performance/range_search/test.sd
@@ -1,19 +1,57 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 schema test {
   document test {
-    field values_fast type array<int> {
+    # The following 5 fields has different number of unique values in the ranges ('values_in_range') used when querying:
+    # [1, 10, 100, 1000, 10000]
+    field v_1 type int {
+      indexing: attribute | summary
+      rank: filter
+    }
+    field v_10 type int {
+      indexing: attribute | summary
+      rank: filter
+    }
+    field v_100 type int {
+      indexing: attribute | summary
+      rank: filter
+    }
+    field v_1000 type int {
+      indexing: attribute | summary
+      rank: filter
+    }
+    field v_10000 type int {
+      indexing: attribute | summary
+      rank: filter
+    }
+    field filter type int {
       indexing: attribute | summary
       attribute: fast-search
       rank: filter
     }
-    field values_slow type array<int> {
-      indexing: attribute | summary
-      rank: filter
-    }
-    field filter type array<int> {
-      indexing: attribute | summary
-      attribute: fast-search
-      rank: filter
-    }
+  }
+  field v_1_fs type int {
+    indexing: input v_1 | attribute | summary
+    attribute: fast-search
+    rank: filter
+  }
+  field v_10_fs type int {
+    indexing: input v_10 | attribute | summary
+    attribute: fast-search
+    rank: filter
+  }
+  field v_100_fs type int {
+    indexing: input v_100 | attribute | summary
+    attribute: fast-search
+    rank: filter
+  }
+  field v_1000_fs type int {
+    indexing: input v_1000 | attribute | summary
+    attribute: fast-search
+    rank: filter
+  }
+  field v_10000_fs type int {
+    indexing: input v_10000 | attribute | summary
+    attribute: fast-search
+    rank: filter
   }
 }


### PR DESCRIPTION
This better reflects the baseline usage of range search.

@toregge please review
@baldersheim FYI