### PR TITLE
Run test with reduced scope if sanitizers present

### DIFF
--- a/tests/performance/feeding_and_recovery/feeding_and_recovery.rb
+++ b/tests/performance/feeding_and_recovery/feeding_and_recovery.rb
@@ -392,8 +392,7 @@ class FeedingAndRecoveryTest < PerformanceTest
   end
 
   def test_feeding_and_recovery
-    return if has_active_sanitizers
-    @test_params = FullParams.new
+    @test_params = has_active_sanitizers ? SmallParams.new : LargeParams.new
     sniffer = MetricSniffer.new(["feeder.throughput"])
     run_elastic_feeding_benchmark(3, [sniffer]) { stop }
     dps = (sniffer.get("feeder.throughput").to_i * 0.8).to_i


### PR DESCRIPTION
@baldersheim please review. With the reduced scope I can run this test locally with TSan instrumentation without reducing my laptop to a smoldering pile of rubble. Actual performance test nodes are even more beefy.

It's better to run the test with a reasonable runtime rather than not at all when sanitizer instrumentation is present.
