### PR TITLE
Adjust documents coverage when using match-phase limiting.

### DIFF
--- a/tests/search/reportcoverage/reportcoverage.rb
+++ b/tests/search/reportcoverage/reportcoverage.rb
@@ -89,7 +89,8 @@ class ReportCoverage < IndexedSearchTest
     coverage = result["root"]["coverage"]
     puts coverage.to_s
     assert_equal(23, coverage["coverage"])
-    assert_equal(23420, coverage["documents"])
+    # This number depends on how the range search iterator (used by match-phase limiting) calculates approximation of number of hits.
+    assert_equal(23416, coverage["documents"])
     assert_equal(false, coverage["full"])
     assert_equal(2, coverage["nodes"])
     assert_equal(1, coverage["results"])
@@ -107,7 +108,8 @@ class ReportCoverage < IndexedSearchTest
     degraded = coverage["degraded"]
     puts coverage.to_s
     assert_equal(65, coverage["coverage"])
-    assert_equal(65376, coverage["documents"])
+    # This number depends on how the range search iterator (used by match-phase limiting) calculates approximation of number of hits.
+    assert_equal(65368, coverage["documents"])
     assert_equal(false, coverage["full"])
     assert_equal(2, coverage["nodes"])
     assert_equal(1, coverage["results"])


### PR DESCRIPTION
This depends on how the range search iterator calculates approximation of number of hits. This was changed in https://github.com/vespa-engine/vespa/pull/29125, as part of optimizing numeric range search.

@baldersheim please review
@aressem @toregge FYI