### PR TITLE
Enable FileStor debug logging for node retirement test

### DIFF
--- a/tests/vds/retiringnode.rb
+++ b/tests/vds/retiringnode.rb
@@ -88,6 +88,10 @@ class RetiringNode < MultiProviderStorageTest
   end
 
   def test_retire_doccount
+    ['', '2', '3'].each do |node|
+      vespa.storage['storage'].storage['0'].execute("vespa-logctl searchnode#{node}:persistence.filestor.manager debug=on")
+    end
+
     puts "Retire storage node 1"
     vespa.storage["storage"].get_master_fleet_controller().set_node_state("storage", 2, "s:r");
 


### PR DESCRIPTION
@baldersheim please review

On rare occasions this test fails with empty, orphaned buckets on one of the content nodes (usually when run under Valgrind and things run with the speed and grace of a gazelle stuck in mud). Hypothesis is that some (possibly resent) operation is triggering an implicit bucket creation in the DB that cause a state de-sync between the nodes—debug logging will hopefully point out the source.
