### PR TITLE
Don't run node retirement tests with multiple providers MERGEOK

### DIFF
--- a/tests/vds/retiringnode.rb
+++ b/tests/vds/retiringnode.rb
@@ -1,8 +1,8 @@
 # Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-require 'multi_provider_storage_test'
+require 'vds_test'
 
-class RetiringNode < MultiProviderStorageTest
+class RetiringNode < VdsTest
 
   def setup
     set_owner("vekterli")


### PR DESCRIPTION
@baldersheim please review

Can't set log level on `searchnode` if there's no search node running...

I don't think running these with DummyPersistence gives us anything worthwhile at this point in time.
