### PR TITLE
Revert "Streaming search does not respect case sensitivity yet."

### DIFF
--- a/tests/search/in_operator/in_operator.rb
+++ b/tests/search/in_operator/in_operator.rb
@@ -69,14 +69,8 @@ class InOperator < IndexedStreamingSearchTest
     end
     assert_equal([0], my_query("ss in ('W24')", []))
     assert_equal([0], my_query("ssfs in ('W24')", []))
-    if is_streaming
-      # This is due to streaming search incorrectly handles case sensitivity
-      assert_equal([0], my_query("ssc in ('W24')", []))
-      assert_equal([0], my_query("ssfsc in ('W24')", []))
-    else
-      assert_equal([], my_query("ssc in ('W24')", []))
-      assert_equal([], my_query("ssfsc in ('W24')", []))
-    end
+    assert_equal([], my_query("ssc in ('W24')", []))
+    assert_equal([], my_query("ssfsc in ('W24')", []))
     assert_equal([0], my_query("ssi in ('w24')", []))
     assert_equal([0], my_query("sai in ('w24')", []))
     assert_equal([0], my_query("swi in ('w24')", []))


### PR DESCRIPTION
Reverts vespa-engine/system-test#3185
@geirst Now it does