### PR TITLE
Simplify and make test use just one searcher to add hits

### DIFF
--- a/tests/container/search_chains/app/hosts.xml
+++ b/tests/container/search_chains/app/hosts.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<hosts>
-  <host name="foo1">
-    <alias>node1</alias>
-  </host>
-  <host name="foo2">
-    <alias>node2</alias>
-  </host>
-</hosts>

--- a/tests/container/search_chains/app/services.xml
+++ b/tests/container/search_chains/app/services.xml
@@ -8,7 +8,7 @@
 
   <container version="1.0">
     <nodes>
-      <node hostalias="node2" />
+      <node hostalias="node1" />
     </nodes>
 
       <search>
@@ -73,7 +73,7 @@
           </searcher>
 
           <searcher id="com.yahoo.prelude.statistics.StatisticsSearcher" />
-          <searcher id="com.yahoo.search.searchchain.example.ExampleSearcher" />
+          <searcher id="AddHitSearcher2" class="com.yahoo.example.AddHitSearcher" />
         </chain>
 
         <chain id="derived_6" inherits="base_6">
@@ -93,7 +93,7 @@
           </searcher>
 
           <searcher id="com.yahoo.prelude.statistics.StatisticsSearcher" />
-          <searcher id="com.yahoo.search.searchchain.example.ExampleSearcher" />
+          <searcher id="AddHitSearcher2" class="com.yahoo.example.AddHitSearcher" />
         </chain>
 
         <chain id="derived_7" inherits="base_7">
@@ -113,7 +113,7 @@
           </searcher>
 
           <searcher id="com.yahoo.prelude.statistics.StatisticsSearcher" />
-          <searcher id="com.yahoo.search.searchchain.example.ExampleSearcher" />
+          <searcher id="AddHitSearcher2" class="com.yahoo.example.AddHitSearcher" />
         </chain>
 
         <chain id="derived_8" inherits="base_8" excludes="AddHitSearcher com.yahoo.prelude.statistics.StatisticsSearcher" />

--- a/tests/container/search_chains/search_chains.rb
+++ b/tests/container/search_chains/search_chains.rb
@@ -5,17 +5,17 @@ class SearchChainsTest < SearchContainerTest
 
   def initialize(*args)
     super(*args)
-    @num_hosts = 2
   end
 
   def setup
     set_owner("nobody")
-    set_description("Tests the new search chain config, as explained in the search-chain.html vespadoc")
+    set_description("Tests the search chain config, as explained in https://docs.vespa.ai/en/components/chained-components.html")
     add_bundle_dir(File.expand_path(selfdir), "com.yahoo.example.AddHitSearcher")
     deploy(selfdir+"app")
     start
   end
 
+  # Gives as many hits as there are AddHitSearcher instances in the chain, see services.xml
   def test_resultset_lengths
     assert_length(0, ["simple_1"])
 


### PR DESCRIPTION
* Use a second AddHitSearcher intance to add hit no. 2
* Simplify to use just one node in test

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
