### PR TITLE
Revert "Enable all tests for streaming"

### DIFF
--- a/lib/indexed_search_test.rb
+++ b/lib/indexed_search_test.rb
@@ -1,6 +1,20 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-require 'indexed_streaming_search_test'
+require 'search_test'
 
-class IndexedSearchTest < IndexedStreamingSearchTest
+class IndexedSearchTest < SearchTest
+
+  def param_setup(params)
+    @params = params
+    setup
+  end
+
+  def deploy_app(app, deploy_params = {})
+    app.search_type(@params[:search_type]) if @params != nil
+    super(app, deploy_params)
+  end
+
+  def self.testparameters
+    { "ELASTIC" => { :search_type => "ELASTIC" } }
+  end
 
 end


### PR DESCRIPTION
Reverts vespa-engine/system-test#3362

@toregge please review

Will merge this after a system test run on factory.