### PR TITLE
Revert "Now streaming and indexed resolves to same cluster name"

### DIFF
--- a/tests/search/generic_config/generic_config.rb
+++ b/tests/search/generic_config/generic_config.rb
@@ -104,7 +104,7 @@ class GenericConfig < IndexedStreamingSearchTest
   end
 
   def dotest_searchcluster_config(prefix)
-    id = "#{prefix}/cluster.search"
+    id = is_streaming ? prefix : "#{prefix}/cluster.search"
     assert(vespa.adminserver.execute("#{@getconfig} -n vespa.config.search.core.proton -i #{id}/0") =~ /numsummarythreads 34/)
     assert(vespa.adminserver.execute("#{@getconfig} -n vespa.config.search.core.proton -i #{id}/1") =~ /numsummarythreads 32/)
     assert(vespa.adminserver.execute("#{@getconfig} -n vespa.config.search.core.proton -i #{id}/0") =~ /flush.idleinterval 700/)


### PR DESCRIPTION
Reverts vespa-engine/system-test#3534
@hmusum or @geirst PR