### PR TITLE
Use correct dimensionality for the model from hf

### DIFF
--- a/tests/search/embedding/app_colbert_embedder_fp16/schemas/doc.sd
+++ b/tests/search/embedding/app_colbert_embedder_fp16/schemas/doc.sd
@@ -1,0 +1,72 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+schema doc {
+
+  document doc {
+
+    field text type string {
+      indexing: index | summary
+    }
+
+  }
+
+  field embedding_compressed type tensor<int8>(dt{},x[16]) {
+      indexing: input text | embed colbert | attribute
+  }
+  field embedding_bfloat type tensor<bfloat16>(dt{},x[128]) {
+      indexing: input text | embed colbert | attribute
+  }
+
+  field embedding_float type tensor<float>(dt{},x[128]) {
+      indexing: input text | embed colbert | attribute
+  }
+
+  rank-profile default {
+    inputs {
+      query(qt) tensor<float>(qt{},x[128])
+    }
+
+    function maxSimBFloat() {
+      expression {
+         sum(
+            reduce(
+                sum(
+                    query(qt) * cell_cast(attribute(embedding_bfloat),float), x
+                 ),
+                 max, dt
+            ),
+            qt
+          )
+      }
+    }
+
+    function maxSimFloat() {
+      expression {
+         sum(
+            reduce(
+                sum(
+                    query(qt) * attribute(embedding_float), x
+                 ),
+                 max, dt
+            ),
+            qt
+          )
+      }
+    }
+
+    first-phase {
+      expression: nativeRank(text) 
+    }
+
+    summary-features {
+      query(qt)
+      maxSimBFloat
+      maxSimFloat
+      attribute(embedding_compressed)
+      attribute(embedding_bfloat)
+      attribute(embedding_float)
+    }
+
+  }
+
+}

--- a/tests/search/embedding/embedding.rb
+++ b/tests/search/embedding/embedding.rb
@@ -141,7 +141,7 @@ class Embedding < IndexedStreamingSearchTest
             search(Searching.new).
             docproc(DocumentProcessing.new).
             jvmoptions('-Xms4g -Xmx4g')).
-        sd(selfdir + 'app_colbert_embedder/schemas/doc.sd').
+        sd(selfdir + 'app_colbert_embedder_fp16/schemas/doc.sd').
         indexing_cluster('default').indexing_chain('indexing'))
     start
     feed_and_wait_for_docs("doc", 1, :file => selfdir + "docs.json")


### PR DESCRIPTION
Address test failure related to the fp16 model the test uses will emit 128 dimensional floats and not 32 like the other models used in colbert related tests. 

https://factory.vespa.oath.cloud/testrun/81738011/test/Embedding::test_colbert_embedding_fp16__INDEXED

```java.lang.IllegalArgumentException: Not possible to map token vector embedding with 128 dimensions into tensor with 32``` 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
