### PR TITLE
Add performance test for feeding with high contention

### DIFF
--- a/tests/performance/feeding_bucket_contention/create_docs.cpp
+++ b/tests/performance/feeding_bucket_contention/create_docs.cpp
@@ -1,0 +1,68 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <algorithm>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+#include <utility>
+#include <unistd.h>
+
+void gen_put(uint32_t user_id, size_t doc_id) {
+    printf("{\"put\":\"id:test:test:g=%u:%zu\",\"fields\":{\"id\":%zu}}", user_id, doc_id, doc_id);
+}
+
+int main(int argc, char* argv[]) {
+    int seed = 1234;
+    bool shuffle = false;
+    uint32_t locations = 0;
+    uint32_t docs_per_location = 0;
+
+    int option;
+    // Note: opt parsing has signed-ness mismatch, but we trust the input to be non-negative.
+    while ((option = getopt(argc, argv, "n:d:sh")) != -1) {
+        switch (option) {
+        case 'n':
+            locations = std::stoi(optarg);
+            break;
+        case 'd':
+            docs_per_location = std::stoi(optarg);
+            break;
+        case 's':
+            shuffle = true;
+            break;
+        case 'h':
+            std::cerr << argv[0] << " -s (shuffle) -h (help) -n <location count> -d <docs per location>" << std::endl;
+            return 1;
+        default:
+            return 1;
+        }
+    }
+    if (locations == 0 || docs_per_location == 0) {
+        std::cerr << "Must specify at least 1 location with 1 document" << std::endl;
+        return 1;
+    }
+    using LocationAndDocId = std::pair<uint32_t, size_t>;
+    std::vector<LocationAndDocId> docs;
+    docs.reserve(locations * docs_per_location);
+    for (uint32_t loc = 0; loc < locations; ++loc) {
+        for (uint32_t doc = 0; doc < docs_per_location; ++doc) {
+            // Let doc ID itself be distinct also _across_ locations
+            docs.emplace_back(loc, (loc * docs_per_location) + doc);
+        }
+    }
+    if (shuffle) {
+        std::default_random_engine engine(seed);
+        std::shuffle(std::begin(docs), std::end(docs), engine);
+    }
+    printf("[\n");
+    for (size_t i = 0; i < docs.size(); ++i) {
+        if (i > 0) {
+            printf(",\n");
+        }
+        gen_put(docs[i].first, docs[i].second);
+    }
+    printf("\n]\n");
+    return 0;
+}
+

--- a/tests/performance/feeding_bucket_contention/feeding_bucket_contention.rb
+++ b/tests/performance/feeding_bucket_contention/feeding_bucket_contention.rb
@@ -1,0 +1,74 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+require 'performance_test'
+require 'app_generator/search_app'
+require 'uri'
+
+class FeedingWithBucketContentionTest < PerformanceTest
+
+  def setup
+    super
+    set_owner('vekterli')
+  end
+
+  def teardown
+    super
+  end
+
+  # Controls PerformanceTest-specific app generator distribution bits
+  def distribution_bits
+    16
+  end
+
+  def test_feeding_docs_with_bucket_contention
+    set_description('Test feeding performance when feed has high affinity to specific ' +
+                    'buckets instead of being evenly distributed. Feeds to a number of ' +
+                    'locations (ID-specified groups) with many documents in sequence per ' +
+                    'location. This triggers "worst-case" write lock contention against ' +
+                    'buckets (amortized 1 bucket per distinct location).')
+    # Test configuration rationale:
+    #  - 16 distribution bits to avoid implicitly measuring overhead of bucket splitting.
+    #  - Only 4 persistence threads to make persistence-level lock contention relatively
+    #    _more_ expensive than it would be when feed is distributed across many threads.
+    #  - 1000 docs per location to avoid hitting the bucket split limits (modulo those
+    #    pigeon hole cases where multiple locations hash to the same bucket).
+    deploy_app(
+      SearchApp.new.
+        container(
+          Container.new('container').
+            jvmoptions('-Xms8g -Xmx8g').
+            docproc(DocumentProcessing.new).
+            documentapi(ContainerDocumentApi.new)).
+        admin_metrics(Metrics.new).
+        indexing('container').
+        sd(selfdir + 'test.sd').
+        storage(StorageCluster.new('search', 1).distribution_bits(16)).
+        config(ConfigOverride.new('vespa.config.content.stor-filestor').
+          #add('max_feed_op_batch_size', '1024'). # <- for manual testing, use feature flag on factory
+          add('num_threads', '4').
+          add('num_response_threads', '2')))
+    @container = vespa.container.values.first
+    compile_create_docs
+    start
+    # Initially feed with shuffled documents to measure baseline case, then re-feed docs sequentially.
+    [true, false].each do |shuffle_feed|
+      feed_docs_to_locations(locations: 500, docs_per_location: 1000, shuffle: shuffle_feed)
+    end
+    stop
+  end
+
+  def feed_docs_to_locations(locations:, docs_per_location:, shuffle:)
+    puts "Feeding #{docs_per_location} docs per #{locations} locations. Shuffle prior to feeding: #{shuffle ? 'yes' : 'no'}"
+    command = "#{@create_docs} -n #{locations} -d #{docs_per_location}#{shuffle ? ' -s' : ''}"
+    run_stream_feeder(command, [parameter_filler('type', 'feed'),
+                                parameter_filler('shuffled', shuffle.to_s)])
+  end
+
+  def compile_create_docs
+    tmp_bin_dir = @container.create_tmp_bin_dir
+    @create_docs = "#{tmp_bin_dir}/create_docs"
+    src_path = "#{selfdir}create_docs.cpp"
+    @container.execute("g++ -Wl,-rpath,#{Environment.instance.vespa_home}/lib64/ -g -O3 -o #{@create_docs} #{src_path}")
+  end
+
+end

--- a/tests/performance/feeding_bucket_contention/test.sd
+++ b/tests/performance/feeding_bucket_contention/test.sd
@@ -1,0 +1,12 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+schema test {
+  document test {
+    field id type long {
+      indexing: summary
+    }
+  }
+  document-summary minimal {
+    summary id {}
+  }
+}


### PR DESCRIPTION
@geirst please review. Includes a heavily modified version of `create_docs` from `nearest_neighbor_streaming` that allows for shuffling across _all_ docs, not just user IDs.
@baldersheim FYI. Starting out with 500K docs (500 locations * 1K docs).

Test feeding performance when feed has high affinity to specific buckets instead of being evenly distributed. Feeds to a number of locations (ID-specified groups) with many documents in sequence per location. This triggers "worst-case" write lock contention against buckets (amortized 1 bucket per distinct location).

Test is done in 2 phases:
 1. Feed fully shuffled (i.e randomly distributed) to get a baseline.
 2. Re-feed in sequential order.
