### PR TITLE
Bump total document count to 3M across locations

### DIFF
--- a/tests/performance/feeding_bucket_contention/feeding_bucket_contention.rb
+++ b/tests/performance/feeding_bucket_contention/feeding_bucket_contention.rb
@@ -52,7 +52,7 @@ class FeedingWithBucketContentionTest < PerformanceTest
     start
     # Initially feed with shuffled documents to measure baseline case, then re-feed docs sequentially.
     [true, false].each do |shuffle_feed|
-      feed_docs_to_locations(locations: 2000, docs_per_location: 1000, shuffle: shuffle_feed)
+      feed_docs_to_locations(locations: 3000, docs_per_location: 1000, shuffle: shuffle_feed)
     end
     stop
   end


### PR DESCRIPTION
@baldersheim or @geirst please review

3 million docs should hopefully push shuffled feeding time up to around 30 seconds. Luxury problems...