### PR TITLE
Reduce timeout for performance tests to 1 hour

### DIFF
--- a/lib/performance_test.rb
+++ b/lib/performance_test.rb
@@ -40,8 +40,7 @@ class PerformanceTest < TestCase
   end
 
   def timeout_seconds
-    # Two hours
-    3600*2
+    3600
   end
 
   def can_share_configservers?(method_name=nil)


### PR DESCRIPTION
When something is wrong and a test does not finish until the test run itself times out it is too long to wait for 2 hours. We should probably reduce this even more and increase for any test that needs more time
