### PR TITLE
Revert "Use vespa-feed-client as default feed client"

### DIFF
--- a/lib/nodetypes/feeder.rb
+++ b/lib/nodetypes/feeder.rb
@@ -157,8 +157,8 @@ module Feeder
       execute("sync")
     end
     if !params[:client]
-      # Set default feeder to 'vespa-feed-client'
-      params[:client] = :vespa_feed_client
+      # Set default feeder to 'vespa-feeder'
+      params[:client] = :vespa_feeder
     end
     if !params[:stderr]
       params[:stderr] = :true
@@ -278,14 +278,14 @@ module Feeder
 
   private
   def select_feeder(params)
-    if params[:client] == :vespa_feed_client
+    if params[:client] == :vespa_feeder
       if params[:feeder_binary]
         return params[:feeder_binary]
       else
         return "#{testcase.feeder_binary} "
       end
-    elsif params[:client] == :vespa_feeder
-      return "vespa-feeder --abortondataerror no --abortonsenderror no"
+    elsif params[:client] == :vespa_feed_client
+      return "vespa-feed-client"
     else
       raise "Unsupported feed client '#{client}'"
     end

--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -143,7 +143,7 @@ class TestCase
 
   # Returns the name of the feeder binary to be used.
   def feeder_binary
-    "vespa-feed-client"
+    "vespa-feeder --abortondataerror no --abortonsenderror no"
   end
 
   def can_share_configservers?(method_name=nil)


### PR DESCRIPTION
Reverts vespa-engine/system-test#3778

Will probably break something, so can be merged as soon as a test run has started