### PR TITLE
Increase test timeout

### DIFF
--- a/tests/performance/llama/llama.rb
+++ b/tests/performance/llama/llama.rb
@@ -18,6 +18,10 @@ class LlamaPerformanceTest < PerformanceTest
     super
   end
 
+  def timeout_seconds
+    5000
+  end
+
   def test_llama_inference
     set_description("Test inference of a local llm")
 
@@ -29,7 +33,6 @@ class LlamaPerformanceTest < PerformanceTest
 
     warmup
     run_queries
-
   end
 
   def generate_queries


### PR DESCRIPTION
Test timeout for performance tests was decreased in https://github.com/vespa-engine/system-test/pull/3783, need to increase it for this test.

Consider reducing runtime of test, it is by far the longest-running test now.