### PR TITLE
Specifically set number of threads i llama perf test

### DIFF
--- a/tests/performance/llama/app/services.xml
+++ b/tests/performance/llama/app/services.xml
@@ -23,6 +23,7 @@
         <parallelRequests>10</parallelRequests>
         <maxQueueSize>5</maxQueueSize>
         <maxTokens>100</maxTokens>
+        <threads>32</threads>
       </config>
     </component>
 


### PR DESCRIPTION
@hmusum Please review

If performance test nodes only actually have available half the number of cores that `Runtime.getRuntime().availableProcessors()` reports, this might cause quite a lot of contention. Test this by reducing number of threads llama has available.