### PR TITLE
Settle on persistence batch size of 64

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -38,6 +38,6 @@
         { "id" : "unknown-config-definition", "rules" : [ { "value" : "fail" } ] },
         { "id" : "sort-blueprints-by-cost", "rules" : [ { "value" : true } ] },
         { "id" : "content-layer-metadata-feature-level", "rules" : [ { "value" : 1 } ] },
-        { "id" : "persistence-thread-max-feed-op-batch-size", "rules" : [ { "value" : 256 } ] }
+        { "id" : "persistence-thread-max-feed-op-batch-size", "rules" : [ { "value" : 64 } ] }
     ]
 }


### PR DESCRIPTION
@baldersheim please review.

Performance tests show that we do not get any measurable impact by going higher than this.
