### PR TITLE
Reapply "Support 'update' operation when writing json"

### DIFF
--- a/lib/document.rb
+++ b/lib/document.rb
@@ -57,19 +57,11 @@ class Document
     JSON.dump({"fields" => @fields})
   end
 
-  def to_put_json(in_array = false)
+  def to_json(operation = :put, in_array = false)
     if in_array
-      JSON.dump([{"put" => @documentid, "fields" => @fields}])
+      JSON.dump([{operation.to_s => @documentid, "fields" => @fields}])
     else
-      JSON.dump({"put" => @documentid, "fields" => @fields})
-    end
-  end
-
-  def to_remove_json(in_array = false)
-    if in_array
-      JSON.dump([{"remove" => @documentid, "fields" => @fields}])
-    else
-      JSON.dump({"remove" => @documentid, "fields" => @fields})
+      JSON.dump({operation.to_s => @documentid, "fields" => @fields})
     end
   end
 
@@ -143,12 +135,8 @@ class Document
     f.write(to_rm_xml)
   end
 
-  def write_json(f)
-    f.write(to_put_json)
-  end
-
-  def write_remove_json(f)
-    f.write(to_remove_json)
+  def write_json(f, operation = :put)
+    f.write(to_json(operation))
   end
 
   def ==(other)

--- a/lib/document_set.rb
+++ b/lib/document_set.rb
@@ -51,16 +51,7 @@ class DocumentSet
       else
         f.write(",\n")
       end
-      case operation
-      when :remove
-        f.write(document.to_remove_json(false))
-      when :put
-        f.write(document.to_put_json(false))
-      when :update
-        f.write(document.to_update_json)
-      else
-        raise "Unknown operation #{operation}"
-      end
+      f.write(document.to_json(operation, false))
     end
     f.write("\n]\n")
     f.close()

--- a/lib/documentupdate.rb
+++ b/lib/documentupdate.rb
@@ -169,6 +169,10 @@ class DocumentUpdate
     JSON.dump({"fields" => fields})
   end
 
+  def to_json(operation, in_array = false)
+    to_update_json
+  end
+
   def fields
     fields = {}
     @updateops.each do |u|

--- a/lib/test/documentupdate_test.rb
+++ b/lib/test/documentupdate_test.rb
@@ -25,6 +25,7 @@ class DocumentUpdateTest < Test::Unit::TestCase
       }
     }
     assert_equal(expected_with_update, JSON.parse(update.to_update_json))
+    assert_equal(expected_with_update, JSON.parse(update.to_json(:update)))
   end
 
 end


### PR DESCRIPTION
Reverts vespa-engine/system-test#3814

Please review only. Same as https://github.com/vespa-engine/system-test/pull/3811 , but with added `to_json` for document update