### PR TITLE
Reapply "Change syntax for specifying weighted set fields in doc generation"

### DIFF
--- a/lib/test/document_test.rb
+++ b/lib/test/document_test.rb
@@ -36,48 +36,23 @@ class DocumentTest < Test::Unit::TestCase
     assert_equal(1, map['foo'])
     assert_equal(2, map['bar'])
     ws = fields['weighted_set']
-    assert_equal('baz', ws[0][0])
-    assert_equal(10, ws[0][1])
-    assert_equal('quux', ws[1][0])
-    assert_equal(11, ws[1][1])
+    assert_equal('baz', ws.keys[0])
+    assert_equal(10, ws['baz'])
+    assert_equal('quux', ws.keys[1])
+    assert_equal(11, ws['quux'])
     struct = fields['struct']
     assert_equal('John & Martha Smith', struct[:name])
     assert_equal('1 High Street', struct[:address])
     assert_equal('Some string, insert <text> here', fields['misc'])
   end
 
-  def test_to_xml
+  def test_to_json
     document = Document.create_from_xml(REXML::Document.new(@@xml1).root)
     add_fields(document)
-    expected_xml = <<EOS
-<document documenttype="music" documentid="id:music:music::http://music.yahoo.com/Yello/Pocket+Universe+%5BBonus+Track%5D">
-  <artist>Yello</artist>
-  <map>
-    <item><key>foo</key><value>1</value></item>
-    <item><key>bar</key><value>2</value></item>
-  </map>
-  <misc>Some string, insert &lt;text&gt; here</misc>
-  <novalue/>
-  <popularity/>
-  <price>9.99</price>
-  <struct>
-    <name>John &amp; Martha Smith</name>
-    <address>1 High Street</address>
-  </struct>
-  <title>Pocket Universe [Bonus Track]</title>
-  <tracks>
-    <item>Track 1</item>
-    <item>Track 2</item>
-  </tracks>
-  <url>http://music.yahoo.com/Yello/Pocket+Universe+%5BBonus+Track%5D</url>
-  <weighted_set>
-    <item weight="10">baz</item>
-    <item weight="11">quux</item>
-  </weighted_set>
-  <year>1999</year>
-</document>
+    expected_json = <<EOS
+{"fields":{"artist":"Yello","popularity":null,"title":"Pocket Universe [Bonus Track]","url":"http://music.yahoo.com/Yello/Pocket+Universe+%5BBonus+Track%5D","novalue":null,"price":9.99,"year":1999,"tracks":["Track 1","Track 2"],"map":{"foo":1,"bar":2},"weighted_set":{"baz":10,"quux":11},"struct":"#<struct Struct::Customer name=\\"John & Martha Smith\\", address=\\"1 High Street\\">","misc":"Some string, insert <text> here"}}
 EOS
-    assert_equal(expected_xml, document.to_xml + "\n")
+    assert_equal(expected_json, document.fields_to_json + "\n")
   end
 
   def add_fields(document)
@@ -86,9 +61,10 @@ EOS
     document.add_field('year', 1999)
     document.add_field('tracks', ['Track 1', 'Track 2'])
     document.add_field('map', { 'foo' => 1, 'bar' => 2})
-    document.add_field('weighted_set', [['baz', 10], ['quux', 11]])
+    document.add_field('weighted_set', {'baz' => 10, 'quux' => 11})
     Struct.new("Customer", :name, :address)
     document.add_field('struct', Struct::Customer.new("John & Martha Smith", "1 High Street"))
     document.add_field('misc', "Some string, insert <text> here")
   end
+
 end

--- a/tests/search/feed_during_reconfig/feed_during_reconfig.rb
+++ b/tests/search/feed_during_reconfig/feed_during_reconfig.rb
@@ -19,8 +19,8 @@ class FeedDuringReconfig < IndexedStreamingSearchTest
     for i in docid_begin...docid_begin + num_docs do
       doc = Document.new("test", "id:test:test::" + "%05d" % i)
       doc.add_field("f1", "But if you meet a friendly horse. Will you communicate by morse?")
-      doc.add_field("tags", [["No, I speak only kaudervelsk", 1], ["No, I speak only kaudervelsk", 2], ["No, I speak only kaudervelsk", 3]])
-      doc.add_field("wset", [["No, I speak only kaudervelsk", 1], ["No, I speak only kaudervelsk", 2], ["No, I speak only kaudervelsk", 3]])
+      doc.add_field("tags", {"No, I speak only kaudervelsk" => 1, "No, I speak only kaudervelsk" => 2, "No, I speak only kaudervelsk" => 3})
+      doc.add_field("wset", {"No, I speak only kaudervelsk" => 1, "No, I speak only kaudervelsk" => 2, "No, I speak only kaudervelsk" => 3})
       doc.add_field("arraystring", ["No, I speak only kaudervelsk", "No, I speak only kaudervelsk", "No, I speak only kaudervelsk"])
       ds.add(doc)
     end

--- a/tests/search/grouping_wand/grouping_wand.rb
+++ b/tests/search/grouping_wand/grouping_wand.rb
@@ -22,14 +22,14 @@ class GroupingWand < IndexedStreamingSearchTest
           doc.add_field("a", a)
           doc.add_field("b", b)
           doc.add_field("c", c)
-          doc.add_field("wset", [ ["a#{a}", 1], ["b#{b}", 1], ["c#{c}", 1] ])
+          doc.add_field("wset", {"a#{a}" => 1, "b#{b}" => 1, "c#{c}" => 1})
           doc.add_field("n", docs.documents.length)
           docs.add(doc)
         end
       end
     end
-    feedfile = dirs.tmpdir + "input.xml"
-    docs.write_xml(feedfile)
+    feedfile = dirs.tmpdir + "input.json"
+    docs.write_json(feedfile)
 
     num_docs = docs.documents.length
     feed_and_wait_for_docs("test", num_docs, :file => feedfile)

--- a/tests/search/indexmanager/indexmanager.rb
+++ b/tests/search/indexmanager/indexmanager.rb
@@ -110,20 +110,20 @@ class IndexManagerTest < IndexedOnlySearchTest
   end
 
   def feed_puts(doc_set, doc_set_id)
-    file = dirs.tmpdir + "feed-puts-#{doc_set_id}.xml"
-    doc_set.write_xml(file)
+    file = dirs.tmpdir + "feed-puts-#{doc_set_id}.json"
+    doc_set.write_json(file)
     feed_and_verify(file)
   end
 
   def feed_removes(doc_set, doc_set_id, phase_id)
-    file = dirs.tmpdir + "feed-removes-#{doc_set_id}-#{phase_id}.xml"
-    doc_set.write_rm_xml(file)
+    file = dirs.tmpdir + "feed-removes-#{doc_set_id}-#{phase_id}.json"
+    doc_set.write_json(file, :remove)
     feed_and_verify(file)
   end
 
   def feed_updates(doc_set, doc_set_id, phase_id)
-    file = dirs.tmpdir + "feed-updates-#{doc_set_id}-#{phase_id}.xml"
-    doc_set.write_xml(file)
+    file = dirs.tmpdir + "feed-updates-#{doc_set_id}-#{phase_id}.json"
+    doc_set.write_json(file, :update)
     feed_and_verify(file)
   end
 

--- a/tests/search/indexmanager/indexmanagerdocgenerator.rb
+++ b/tests/search/indexmanager/indexmanagerdocgenerator.rb
@@ -73,7 +73,7 @@ class IndexManagerDocGenerator
     for i in docid_begin...docid_begin + num_docs do
       doc = Document.new("test", get_docid(i))
       word = send(handle_doc_func, i % @mod, i)
-      doc.add_field("features", [[word,i+1]])
+      doc.add_field("features", word => i+1)
       doc.add_field("staticscore", i+1)
       ds.add(doc)
     end

--- a/tests/search/indexmanager/indexmanagerdocgenerator.rb
+++ b/tests/search/indexmanager/indexmanagerdocgenerator.rb
@@ -85,7 +85,15 @@ class IndexManagerDocGenerator
   end
 
   def gen_updates(docid_begin, num_docs)
-    gen_doc_set(docid_begin, num_docs, :handle_update_doc)
+    ds = DocumentSet.new()
+    for i in docid_begin...docid_begin + num_docs do
+      doc = DocumentUpdate.new("test", get_docid(i))
+      word = send(:handle_update_doc, i % @mod, i)
+      doc.addOperation("assign", "features", word => i+1)
+      doc.addOperation("assign", "staticscore", i+1)
+      ds.add(doc)
+      end
+    ds
   end
 
   def gen_removes(docid_begin, num_docs)

--- a/tests/search/wand/wand.rb
+++ b/tests/search/wand/wand.rb
@@ -21,8 +21,8 @@ class WeakAnd < IndexedStreamingSearchTest
 
   def gen_and_feed(gen_mod, num_docs, gen_function)
     gen = WandDocGenerator.new(gen_mod)
-    file = dirs.tmpdir + "temp.#{gen_function}.#{gen_mod}.#{num_docs}.xml"
-    gen.send(gen_function, 1, num_docs).write_xml(file)
+    file = dirs.tmpdir + "temp.#{gen_function}.#{gen_mod}.#{num_docs}.json"
+    gen.send(gen_function, 1, num_docs).write_json(file)
     feed_and_wait_for_docs("test", num_docs, :file => file)
     return gen
   end
@@ -108,7 +108,6 @@ class WeakAnd < IndexedStreamingSearchTest
     gen = gen_and_feed(7, 97, "gen_filter_docs")
 
     foo = "?#{get_wand('all:1', @wand_type)}&hits=400"
-    puts "EINAR " + foo
     assert_hitcount(foo, 97)
     gen.words.sort.each do |word,hits|
       verify_filter_hits(word, hits)

--- a/tests/search/wand/wanddocgenerator.rb
+++ b/tests/search/wand/wanddocgenerator.rb
@@ -38,7 +38,7 @@ class WandDocGenerator
 
   def ranking_gen_func(doc, docid)
       word = handle_put_doc(docid % @mod, docid)
-      doc.add_field("features", [[word, docid]])
+      doc.add_field("features", {word => docid})
   end
 
   def gen_ranking_docs(docid_begin, num_docs)
@@ -47,7 +47,7 @@ class WandDocGenerator
      
   def filter_gen_func(doc, docid)
       word = handle_put_doc(docid % @mod, docid)
-      doc.add_field("features", [["all", docid]])
+      doc.add_field("features", {"all" => docid})
       doc.add_field("filter", word)
   end
 
@@ -56,17 +56,17 @@ class WandDocGenerator
   end
 
   def wand_no_hit(doc)
-    doc.add_field("features", [["nohit", 1]])
+    doc.add_field("features", {"nohit" => 1})
     doc.add_field("filter", "hit")
   end
 
   def wand_good_hit(doc)
-    doc.add_field("features", [["hit", 100]])
+    doc.add_field("features", {"hit" => 100})
     doc.add_field("filter", "nohit")
   end
 
   def wand_bad_hit(doc)
-    doc.add_field("features", [["hit", 1]])
+    doc.add_field("features", {"hit" => 1})
     doc.add_field("filter", "hit")
   end
 


### PR DESCRIPTION
Same as https://github.com/vespa-engine/system-test/pull/3816 with fixed document updates generation in IndexManagerDocGenerator