### PR TITLE
Increase context size to match 4x increase in slots

### DIFF
--- a/tests/performance/llama/app/services.xml
+++ b/tests/performance/llama/app/services.xml
@@ -16,7 +16,7 @@
         <!-- File is approx 130Mb" -->
         <model url="https://data.vespa.oath.cloud/gguf_models/Llama-160M-Chat-v1.Q6_K.gguf" />
 
-        <contextSize>2048</contextSize>
+        <contextSize>8192</contextSize>
         <parallelRequests>40</parallelRequests>
         <maxQueueSize>5</maxQueueSize>
         <maxTokens>100</maxTokens>


### PR DESCRIPTION
@hmusum Please review.

We previously increased from 10 to 40 slots. When running on 10 we didn't have any context shifts, with 40 we got a lot. Testing increased context size to see if performance returns.