### PR TITLE
Use document api on qrserver if one exists

### DIFF
--- a/lib/vespa_model.rb
+++ b/lib/vespa_model.rb
@@ -302,7 +302,11 @@ class VespaModel
     end
     @deployments += 1
 
-    @document_api_v1 = DocumentApiV1.new(adminserver.hostname, @default_document_api_port, @testcase)
+    document_api_port = Environment.instance.vespa_web_service_port
+    if (@qrserver["0"] and @qrserver["0"].http_port == @default_document_api_port)
+      document_api_port = @default_document_api_port
+    end
+    @document_api_v1 = DocumentApiV1.new(adminserver.hostname, document_api_port, @testcase)
 
     return output
   end


### PR DESCRIPTION
Qrserver should have document-api enabled by default. This will remove the need for an extra container just for document-api, which is how many tests set this up now.

Will probably break something, so review only, will merge at an appropriate time