### PR TITLE
Don't enable document api

### DIFF
--- a/tests/search/bool_type/bool_type.rb
+++ b/tests/search/bool_type/bool_type.rb
@@ -14,7 +14,7 @@ class BoolTypeTest < IndexedStreamingSearchTest
 
   def test_bool_attribute_search
     set_description("Test search on attributes of type 'bool', and use in document selections, both with and without attribute backing")
-    deploy_app(SearchApp.new.sd(selfdir + "test.sd").enable_document_api)
+    deploy_app(SearchApp.new.sd(selfdir + "test.sd"))
     @doctype = "test"
     start
     feed(:file => selfdir + "docs.json")

--- a/tests/search/fieldmatchfeatures/fieldmatchfeatures.rb
+++ b/tests/search/fieldmatchfeatures/fieldmatchfeatures.rb
@@ -12,7 +12,7 @@ class FieldMatchFeatures < IndexedStreamingSearchTest
 
   def test_field_match
     set_description("Test the fieldMatch feature")
-    deploy_app(SearchApp.new.sd(selfdir + "fieldmatch.sd").enable_document_api)
+    deploy_app(SearchApp.new.sd(selfdir + "fieldmatch.sd"))
     start
     feed_and_wait_for_docs("fieldmatch", 23, :file => selfdir + "fieldmatch.json")
     run_field_match
@@ -20,7 +20,7 @@ class FieldMatchFeatures < IndexedStreamingSearchTest
 
   def test_field_term_match
     set_description("Test the fieldTermMatch feature")
-    deploy_app(SearchApp.new.sd(selfdir + "fieldtermmatch.sd").enable_document_api)
+    deploy_app(SearchApp.new.sd(selfdir + "fieldtermmatch.sd"))
     start
     feed_and_wait_for_docs("fieldtermmatch", 1, :file => selfdir + "fieldtermmatch.json")
 
@@ -39,7 +39,7 @@ class FieldMatchFeatures < IndexedStreamingSearchTest
 
   def test_phrase
     set_description("Test fieldMatch feature when using phrase search")
-    deploy_app(SearchApp.new.sd(selfdir + "fmphrase.sd").enable_document_api)
+    deploy_app(SearchApp.new.sd(selfdir + "fmphrase.sd"))
     start
     feed_and_wait_for_docs("fmphrase", 1, :file => selfdir + "fmphrase.json")
     run_phrase_test

--- a/tests/search/nearest_neighbor/ann_with_filter.rb
+++ b/tests/search/nearest_neighbor/ann_with_filter.rb
@@ -9,7 +9,7 @@ class ApproximateNearestNeighborWithFilterTest < IndexedOnlySearchTest
 
   def test_ann_with_filters
     set_description("Test approximate nearest neighbor search with filters and tuning of strategies (pre- vs post-filter)")
-    deploy_app(SearchApp.new.sd(selfdir + "ann_with_filter/test.sd").threads_per_search(1).enable_document_api)
+    deploy_app(SearchApp.new.sd(selfdir + "ann_with_filter/test.sd").threads_per_search(1))
     start
     feed_docs
 

--- a/tests/search/nearest_neighbor/distance_metrics.rb
+++ b/tests/search/nearest_neighbor/distance_metrics.rb
@@ -12,7 +12,7 @@ class DistanceMetricsTest < IndexedStreamingSearchTest
   end
 
   def test_distance_metrics
-    deploy_app(SearchApp.new.sd(selfdir+'distances.sd').threads_per_search(1).enable_document_api)
+    deploy_app(SearchApp.new.sd(selfdir+'distances.sd').threads_per_search(1))
     start
     feed_doc
     check_euclidean_distance_metrics

--- a/tests/search/nearest_neighbor/geo_nns.rb
+++ b/tests/search/nearest_neighbor/geo_nns.rb
@@ -73,8 +73,7 @@ class GeoNnsTest < IndexedStreamingSearchTest
     app = SearchApp.new.
         sd(selfdir + "geo.sd").
         num_parts(2).redundancy(2).ready_copies(num_ready_copies).
-        threads_per_search(1).
-        enable_document_api
+        threads_per_search(1)
     deploy_app(app)
   end
 

--- a/tests/search/raw_attributes/raw_attributes.rb
+++ b/tests/search/raw_attributes/raw_attributes.rb
@@ -12,7 +12,7 @@ class RawAttributesTest < IndexedStreamingSearchTest
   end
 
   def test_raw_attribute
-    deploy_app(SearchApp.new.sd(selfdir+'test.sd').enable_document_api)
+    deploy_app(SearchApp.new.sd(selfdir+'test.sd'))
     start
     feed_and_wait_for_docs('test', 5, :file => selfdir + 'docs.json')
     5.times do |id|

--- a/tests/search/tensor_feed/tensor_feed.rb
+++ b/tests/search/tensor_feed/tensor_feed.rb
@@ -13,7 +13,7 @@ class TensorFeedTest < IndexedStreamingSearchTest
 
   def test_tensor_json_feed
     set_description("Test feeding of tensor field and retrieval via search and visit")
-    deploy_app(SearchApp.new.sd(@base_dir + "test.sd").enable_document_api)
+    deploy_app(SearchApp.new.sd(@base_dir + "test.sd"))
     start
     feed_and_wait_for_docs("test", 4, :file => @base_dir + "docs.json")
 

--- a/tests/search/tensor_feed/tensor_feed_hex.rb
+++ b/tests/search/tensor_feed/tensor_feed_hex.rb
@@ -14,7 +14,7 @@ class TensorFeedHexTest < IndexedStreamingSearchTest
 
   def test_tensor_hex_feed
     set_description("Test hex format feeding of tensor field and retrieval via search and visit")
-    deploy_app(SearchApp.new.sd(@base_dir + "test.sd").enable_document_api)
+    deploy_app(SearchApp.new.sd(@base_dir + "test.sd"))
     start
     feed_and_wait_for_docs("test", 4, :file => @base_dir + "docs.json")
 

--- a/tests/search/tensor_feed/tensor_modify_update.rb
+++ b/tests/search/tensor_feed/tensor_modify_update.rb
@@ -13,7 +13,7 @@ class TensorModifyUpdateTest < IndexedStreamingSearchTest
 
   def test_modify_updates
     set_description("Test tensor modify updates (replace, add, multiply) in dense, sparse and mixed tensor attributes and fields")
-    deploy_app(SearchApp.new.sd(@base_dir + "test.sd").enable_document_api)
+    deploy_app(SearchApp.new.sd(@base_dir + "test.sd"))
     start
     feed_and_wait_for_docs("test", 1, :file => @base_dir + "docs.json")
 

--- a/tests/search/tensor_summaryfeatures/tensor_summaryfeatures.rb
+++ b/tests/search/tensor_summaryfeatures/tensor_summaryfeatures.rb
@@ -9,7 +9,7 @@ class TensorSummaryFeatureTest < IndexedStreamingSearchTest
 
   def test_tensor_in_summaryfeatures
     set_description("Test that tensors are surfaced correctly in summaryfeatures")
-    deploy_app(SearchApp.new.sd(selfdir + "test.sd").enable_document_api)
+    deploy_app(SearchApp.new.sd(selfdir + "test.sd"))
     start
     feed_and_wait_for_docs("test", 1, :file => selfdir + "docs.json")
 
@@ -28,7 +28,7 @@ class TensorSummaryFeatureTest < IndexedStreamingSearchTest
     add_bundle(selfdir+"TensorAccessingSearcher.java")
 
     set_description("Test that tensors are accessible in searchers")
-    deploy_app(SearchApp.new.sd(selfdir + "test.sd").enable_document_api)
+    deploy_app(SearchApp.new.sd(selfdir + "test.sd"))
     start
     feed_and_wait_for_docs("test", 1, :file => selfdir + "docs.json")
 

--- a/tests/search/test_and_set/test_and_set.rb
+++ b/tests/search/test_and_set/test_and_set.rb
@@ -6,8 +6,7 @@ class TestAndSetTest < IndexedStreamingSearchTest
     set_owner("vekterli")
     set_description("Test test and set functionality in Vespa")
     deploy_app(SearchApp.new.
-                sd(selfdir + "weather.sd").
-                enable_document_api)
+                sd(selfdir + "weather.sd"))
     start
   end
 


### PR DESCRIPTION
There is already a container with document-api enabled that will be used when using document api when feeding/visiting etc.

Depends on https://github.com/vespa-engine/system-test/pull/3834