### PR TITLE
Use correct port

### DIFF
--- a/tests/search/test_and_set/test_and_set.rb
+++ b/tests/search/test_and_set/test_and_set.rb
@@ -18,7 +18,7 @@ class TestAndSetTest < IndexedStreamingSearchTest
 
   def test_with_vespa_http_client
     run_tests(->(feedfile) {
-      feed(:file => feed_filename(feedfile, :json), :client => :vespa_feed_client, :port => 19020)
+      feed(:file => feed_filename(feedfile, :json), :client => :vespa_feed_client)
     })
   end
 


### PR DESCRIPTION
Use default web server port now that we feed to default container

Fix after changes in https://github.com/vespa-engine/system-test/pull/3836