### PR TITLE
Simplify and cleanup DocumentUpdate

### DIFF
--- a/lib/documentupdate.rb
+++ b/lib/documentupdate.rb
@@ -86,11 +86,16 @@ class AlterUpdate
 end
 
 class SimpleAlterUpdate
+
+  attr_reader :arraytype, :fieldname, :operation, :params
+
   def initialize(operation, fieldname, number, key = nil)
     @operation = operation
     @fieldname = fieldname
     @number = number
     @key = key
+    @arraytype = false
+    @params = [number]
   end
 
   def to_xml
@@ -169,8 +174,8 @@ class DocumentUpdate
     JSON.dump({"fields" => fields})
   end
 
-  def to_json(operation, in_array = false)
-    to_update_json
+  def to_json
+    JSON.dump({"update" => @documentid, "fields" => fields})
   end
 
   def fields
@@ -183,10 +188,6 @@ class DocumentUpdate
       end
     end
     fields
-  end
-
-  def to_update_json
-    JSON.dump({"update" => @documentid, "fields" => fields})
   end
 
 end

--- a/lib/documentupdate.rb
+++ b/lib/documentupdate.rb
@@ -174,7 +174,7 @@ class DocumentUpdate
     JSON.dump({"fields" => fields})
   end
 
-  def to_json
+  def to_json(operation = :update, in_array = false)
     JSON.dump({"update" => @documentid, "fields" => fields})
   end
 

--- a/lib/test/documentupdate_test.rb
+++ b/lib/test/documentupdate_test.rb
@@ -24,8 +24,19 @@ class DocumentUpdateTest < Test::Unit::TestCase
         'artist' => { 'assign' => 'groovy lads' }
       }
     }
-    assert_equal(expected_with_update, JSON.parse(update.to_update_json))
-    assert_equal(expected_with_update, JSON.parse(update.to_json(:update)))
+    assert_equal(expected_with_update, JSON.parse(update.to_json))
+  end
+
+  def test_simple_alter_update
+    update = DocumentUpdate.new('doctype', 'id:foo:music::bar')
+    update.addSimpleAlterOperation('increment', 'increment_field', 10)
+    expected = {
+      'update' => 'id:foo:music::bar',
+      'fields' => {
+        'increment_field' => { 'increment' => 10 }
+      }
+    }
+    assert_equal(expected, JSON.parse(update.to_json))
   end
 
 end


### PR DESCRIPTION
Get rid of to_update_json. Support serializing SimpleAlterOperation to json

