### PR TITLE
Track value type for document update operations

### DIFF
--- a/lib/test/documentupdate_test.rb
+++ b/lib/test/documentupdate_test.rb
@@ -39,4 +39,39 @@ class DocumentUpdateTest < Test::Unit::TestCase
     assert_equal(expected, JSON.parse(update.to_json))
   end
 
+  def test_add_operation
+    # Single value
+    update = DocumentUpdate.new('doctype', 'id:foo:music::bar')
+    update.addOperation('assign', 'some_field', 10)
+    expected = {
+      'update' => 'id:foo:music::bar',
+      'fields' => {
+        'some_field' => { 'assign' => 10 }
+      }
+    }
+    assert_equal(expected, JSON.parse(update.to_json))
+
+    # Array as value
+    update = DocumentUpdate.new('doctype', 'id:foo:music::bar')
+    update.addOperation('assign', 'some_array_field', [10, 20])
+    expected = {
+      'update' => 'id:foo:music::bar',
+      'fields' => {
+        'some_array_field' => { 'assign' => [10, 20] }
+      }
+    }
+    assert_equal(expected, JSON.parse(update.to_json))
+
+    # Weighted set as value
+    update = DocumentUpdate.new('doctype', 'id:foo:music::bar')
+    update.addOperation('assign', 'some_weighted_set_field', {"10" => 50, "20" => 100})
+    expected = {
+      'update' => 'id:foo:music::bar',
+      'fields' => {
+        'some_weighted_set_field' => { 'assign' => {"10" => 50, "20" => 100} }
+      }
+    }
+    assert_equal(expected, JSON.parse(update.to_json))
+  end
+
 end


### PR DESCRIPTION
Makes it possible to separate arrays and weighted sets when creating json from document updates

