### PR TITLE
Lesters/llama remove warmup

### DIFF
--- a/tests/performance/llama/llama.rb
+++ b/tests/performance/llama/llama.rb
@@ -31,7 +31,6 @@ class LlamaPerformanceTest < PerformanceTest
     deploy_app
     copy_query_file
 
-    warmup
     run_queries
   end
 
@@ -65,14 +64,6 @@ class LlamaPerformanceTest < PerformanceTest
     start(600)
     puts "Application started."
     @container = (vespa.qrserver["0"] or vespa.container.values.first)
-  end
-
-  def warmup
-    puts "Warming up... (encoding all prompts)"
-    run_fbench2(@container, @queries_file_name,
-                {:runtime => 10, :clients => 10, :append_str => "&searchChain=llm&format=sse"},
-                [])
-    puts "Warming up complete"
   end
 
   def run_queries

--- a/tests/performance/llama_7b/app/services.xml
+++ b/tests/performance/llama_7b/app/services.xml
@@ -20,7 +20,7 @@
         <parallelRequests>1</parallelRequests>
         <maxQueueSize>1</maxQueueSize>
         <maxTokens>100</maxTokens>
-        <threads>62</threads>
+        <threads>16</threads>
       </config>
     </component>
 

--- a/tests/performance/llama_7b/llama_7b.rb
+++ b/tests/performance/llama_7b/llama_7b.rb
@@ -31,7 +31,6 @@ class Llama7BPerformanceTest < PerformanceTest
     deploy_app
     copy_query_file
 
-    warmup
     run_queries
   end
 
@@ -65,14 +64,6 @@ class Llama7BPerformanceTest < PerformanceTest
     start(600)
     puts "Application started."
     @container = (vespa.qrserver["0"] or vespa.container.values.first)
-  end
-
-  def warmup
-    puts "Warming up... (encoding all prompts)"
-    run_fbench2(@container, @queries_file_name,
-                {:runtime => 30, :clients => 1, :append_str => "&searchChain=llm&format=sse"},
-                [])
-    puts "Warming up complete"
   end
 
   def run_queries


### PR DESCRIPTION
@baldersheim Please review
@hmusum FYI

Removes unnecessary warmup and reduces threads in the larger 7B test case from 62 to 16. We might consider lowering even further to 4, but it would be nice to see the effect of this reduction first.