### PR TITLE
Reduce cluster controller health ping timeout to speed up CC tests

### DIFF
--- a/tests/vds/clustercontroller.rb
+++ b/tests/vds/clustercontroller.rb
@@ -15,6 +15,10 @@ class ClusterControllerTest < VdsTest
                         clustercontroller("node1").
                         clustercontroller("node1"))
     app.redundancy(2).num_nodes(2)
+    if not valgrind
+      app.config(ConfigOverride.new('vespa.config.content.fleetcontroller')
+                               .add('get_node_state_request_timeout', 10.0))
+    end
     deploy_app(app)
     start
   end


### PR DESCRIPTION
@baldersheim please review. We might be able to reduce this value further, but since pings are also used for failure detection we can't set it so low that it triggers spurious failures (not reducing when the test is running under Valgrind for this reason).

Some tests transitively depend on information that is piggy-backed on the `GetNodeState` health ping long-poll RPC, which by default has a timeout of 120 seconds (answered after 60 seconds). Reduce this to 10 seconds to limit amount of time spent waiting in the worst case.

