### PR TITLE
Reapply "Dont report performance data to factory backend when running perf profiling"

### DIFF
--- a/lib/factory/backend_client.rb
+++ b/lib/factory/backend_client.rb
@@ -77,7 +77,7 @@ class BackendClient
         path = File.join(dir, filename)
         if filename == "perf"
           testdata.concat(get_perf_data(path))
-        elsif filename == "performance" && !testcase.has_active_sanitizers
+        elsif filename == "performance" && !testcase.has_active_sanitizers && testcase.perf_recording == "off"
           testdata.concat(get_performance_results(path))
         end
       end

--- a/lib/performance_test.rb
+++ b/lib/performance_test.rb
@@ -36,7 +36,6 @@ class PerformanceTest < TestCase
     @perf_data_file = File.join(@perf_data_dir,'record.data')
     @perf_stat_file = File.join(@perf_data_dir,'perf_stats')
     @script_user = get_script_user
-    @perf_recording = arg_pack[:perf_recording]
   end
 
   def timeout_seconds

--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -52,7 +52,7 @@ class TestCase
     @hostlist = args[:hostlist]
     @outputdir = args[:outputdir]
     @sanitizers = nil
-    @perf_recording = arg[:perf_recording]
+    @perf_recording = args[:perf_recording]
     @valgrind = args[:valgrind]
     @valgrind_opt = args[:valgrind_opt]
     @keep_tmpdir = args[:keep_tmpdir]

--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -30,7 +30,7 @@ class TestCase
   include Assertions
   include TestBase
 
-  attr_reader :selfdir, :dirs, :testcase_file, :cmd_args, :timeout, :max_memory, :keep_tmpdir, :leave_loglevels, :tls_env, :https_client
+  attr_reader :selfdir, :dirs, :testcase_file, :cmd_args, :timeout, :max_memory, :keep_tmpdir, :leave_loglevels, :tls_env, :https_client, :perf_recording
   attr_accessor :hostlist, :num_hosts, :valgrind, :valgrind_opt, :failure_recorded, :testcategoryrun_id, :module_name, :required_hostnames, :expected_logged, :method_name
   attr_accessor :dirty_nodeproxies, :dirty_environment_settings
   attr_accessor :sanitizers
@@ -52,6 +52,7 @@ class TestCase
     @hostlist = args[:hostlist]
     @outputdir = args[:outputdir]
     @sanitizers = nil
+    @perf_recording = arg[:perf_recording]
     @valgrind = args[:valgrind]
     @valgrind_opt = args[:valgrind_opt]
     @keep_tmpdir = args[:keep_tmpdir]


### PR DESCRIPTION
Reverts vespa-engine/system-test#3882