### PR TITLE
Specify user-specific part of doc id

### DIFF
--- a/tests/vds/data/base64.json
+++ b/tests/vds/data/base64.json
@@ -1,3 +1,3 @@
 [
-  {"id":"id:storage_test:music:n=1234:","fields":{"artist":"Unknown artist from the moon","title":"TestTitle"}}
+  {"id":"id:storage_test:music:n=1234:1","fields":{"artist":"Unknown artist from the moon","title":"TestTitle"}}
 ]


### PR DESCRIPTION
vespa-feed-client fails when this is missing

