### PR TITLE
Revert "Set jvm-omit-stack-trace-in-fast-throw to false for system tests"

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -38,7 +38,6 @@
         { "id" : "unknown-config-definition", "rules" : [ { "value" : "fail" } ] },
         { "id" : "sort-blueprints-by-cost", "rules" : [ { "value" : true } ] },
         { "id" : "content-layer-metadata-feature-level", "rules" : [ { "value" : 1 } ] },
-        { "id" : "persistence-thread-max-feed-op-batch-size", "rules" : [ { "value" : 64 } ] },
-        { "id" : "jvm-omit-stack-trace-in-fast-throw", "rules" : [ { "value" : false } ] }
+        { "id" : "persistence-thread-max-feed-op-batch-size", "rules" : [ { "value" : 64 } ] }
     ]
 }


### PR DESCRIPTION
Reverts vespa-engine/system-test#3926

Broke a cuple of system tests, looks like this revaled a bug related to overriding jvm options in services.xml, need to look into it