### PR TITLE
Reapply "Set jvm-omit-stack-trace-in-fast-throw to false for system tests"

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -38,6 +38,7 @@
         { "id" : "unknown-config-definition", "rules" : [ { "value" : "fail" } ] },
         { "id" : "sort-blueprints-by-cost", "rules" : [ { "value" : true } ] },
         { "id" : "content-layer-metadata-feature-level", "rules" : [ { "value" : 1 } ] },
-        { "id" : "persistence-thread-max-feed-op-batch-size", "rules" : [ { "value" : 64 } ] }
+        { "id" : "persistence-thread-max-feed-op-batch-size", "rules" : [ { "value" : 64 } ] },
+        { "id" : "jvm-omit-stack-trace-in-fast-throw", "rules" : [ { "value" : false } ] }
     ]
 }


### PR DESCRIPTION
Reverts vespa-engine/system-test#3931

Trying again after fix in https://github.com/vespa-engine/vespa/pull/31226 was merged