### PR TITLE
Revert "Reapply "Use client params and default_feed_client only""

### DIFF
--- a/lib/nodetypes/feeder.rb
+++ b/lib/nodetypes/feeder.rb
@@ -157,7 +157,8 @@ module Feeder
       execute("sync")
     end
     if !params[:client]
-      params[:client] = testcase.default_feed_client
+      # Set default feeder to 'vespa-feeder'
+      params[:client] = :vespa_feeder
     end
     if !params[:stderr]
       params[:stderr] = :true
@@ -283,12 +284,10 @@ module Feeder
 
   private
   def select_feeder(params)
-    if params[:client] == :vespa_feed_client
-      return "vespa-feed-client "
-    elsif params[:client] == :vespa_feeder
-      return "vespa-feeder --abortondataerror no --abortonsenderror no"
-    elsif params[:client] == :vespa_feed_perf
-      return "vespa-feed-perf"
+    if params[:client] == :vespa_feeder
+      return "#{testcase.feeder_binary} "
+    elsif params[:client] == :vespa_feed_client
+      return "vespa-feed-client"
     else
       raise "Unsupported feed client '#{client}'"
     end

--- a/lib/performance_test.rb
+++ b/lib/performance_test.rb
@@ -77,8 +77,8 @@ class PerformanceTest < TestCase
       2
   end
 
-  def default_feed_client
-    :vespa_feed_perf
+  def feeder_binary
+    "vespa-feed-perf"
   end
 
   def prepare

--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -142,8 +142,9 @@ class TestCase
   def prepare
   end
 
-  def default_feed_client
-    :vespa_feeder
+  # Returns the name of the feeder binary to be used.
+  def feeder_binary
+    "vespa-feeder --abortondataerror no --abortonsenderror no"
   end
 
   def can_share_configservers?(method_name=nil)

--- a/tests/performance/parent_child/parent_child_perf.rb
+++ b/tests/performance/parent_child/parent_child_perf.rb
@@ -34,9 +34,9 @@ class ParentChildPerfTest < PerformanceTest
     @num_ad_docs = 2000000
   end
 
-  def default_feed_client
+  def feeder_binary
     # TODO Duration of the feed tests should be increased so that feedclient startup cost does not matter.
-    :vespa_feeder
+    "vespa-feeder"
   end
 
   def test_parent_child_feeding_ranking_matching


### PR DESCRIPTION
Reverts vespa-engine/system-test#3969

Please review only, will merge In case this still impacts performance tests