### PR TITLE
Reapply "Use client params and default_feed_client only"

### DIFF
--- a/lib/nodetypes/feeder.rb
+++ b/lib/nodetypes/feeder.rb
@@ -156,6 +156,7 @@ module Feeder
     if params[:do_sync]
       execute("sync")
     end
+    puts "feed_stream, params: #{params}, default feed client: #{testcase.default_feed_client}"
     if !params[:client]
       params[:client] = testcase.default_feed_client
     end

--- a/lib/nodetypes/feeder.rb
+++ b/lib/nodetypes/feeder.rb
@@ -157,8 +157,7 @@ module Feeder
       execute("sync")
     end
     if !params[:client]
-      # Set default feeder to 'vespa-feeder'
-      params[:client] = :vespa_feeder
+      params[:client] = testcase.default_feed_client
     end
     if !params[:stderr]
       params[:stderr] = :true
@@ -303,10 +302,12 @@ module Feeder
 
   private
   def select_feeder(params)
-    if params[:client] == :vespa_feeder
-      return "#{testcase.feeder_binary} "
-    elsif params[:client] == :vespa_feed_client
-      return "vespa-feed-client"
+    if params[:client] == :vespa_feed_client
+      return "vespa-feed-client "
+    elsif params[:client] == :vespa_feeder
+      return "vespa-feeder --abortondataerror no --abortonsenderror no"
+    elsif params[:client] == :vespa_feed_perf
+      return "vespa-feed-perf"
     else
       raise "Unsupported feed client '#{client}'"
     end

--- a/lib/performance_test.rb
+++ b/lib/performance_test.rb
@@ -77,8 +77,8 @@ class PerformanceTest < TestCase
       2
   end
 
-  def feeder_binary
-    "vespa-feed-perf"
+  def default_feed_client
+    :vespa_feed_perf
   end
 
   def prepare

--- a/lib/performance_test.rb
+++ b/lib/performance_test.rb
@@ -184,7 +184,7 @@ class PerformanceTest < TestCase
   end
 
   def run_stream_feeder(streamer_command, custom_fillers=[], feederparams={})
-    client = feederparams.key?(:client) ? feederparams[:client] : :vespa_feeder
+    client = feederparams.key?(:client) ? feederparams[:client] : default_feed_client
     out = feed_stream(streamer_command,
                       feederparams.merge({:client => client, :mode => "benchmark"}))
     post_process_feed_output(out, client, custom_fillers)

--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -142,9 +142,8 @@ class TestCase
   def prepare
   end
 
-  # Returns the name of the feeder binary to be used.
-  def feeder_binary
-    "vespa-feeder --abortondataerror no --abortonsenderror no"
+  def default_feed_client
+    :vespa_feeder
   end
 
   def can_share_configservers?(method_name=nil)

--- a/tests/performance/parent_child/parent_child_perf.rb
+++ b/tests/performance/parent_child/parent_child_perf.rb
@@ -34,9 +34,9 @@ class ParentChildPerfTest < PerformanceTest
     @num_ad_docs = 2000000
   end
 
-  def feeder_binary
+  def default_feed_client
     # TODO Duration of the feed tests should be increased so that feedclient startup cost does not matter.
-    "vespa-feeder"
+    :vespa_feeder
   end
 
   def test_parent_child_feeding_ranking_matching


### PR DESCRIPTION
Reverts vespa-engine/system-test#3970