### PR TITLE
Revert "Switch default feed client to vespa-feed-client"

### DIFF
--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -143,7 +143,7 @@ class TestCase
   end
 
   def default_feed_client
-    :vespa_feed_client
+    :vespa_feeder
   end
 
   def can_share_configservers?(method_name=nil)


### PR DESCRIPTION
Reverts vespa-engine/system-test#3968

Some failing tests that need to be looked into and fixed, too many to keep this