### PR TITLE
Reapply "Switch default feed client to vespa-feed-client"

### DIFF
--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -143,7 +143,7 @@ class TestCase
   end
 
   def default_feed_client
-    :vespa_feeder
+    :vespa_feed_client
   end
 
   def can_share_configservers?(method_name=nil)


### PR DESCRIPTION
Reverts vespa-engine/system-test#3977

Please review only.
Will merge when (most of the) failing tests from last attempt have been fixed