### PR TITLE
Specify host when feeding

### DIFF
--- a/tests/search/addcontainer/addcontainer.rb
+++ b/tests/search/addcontainer/addcontainer.rb
@@ -30,7 +30,7 @@ class AddContainer < IndexedOnlySearchTest
     deploy_app(app_one_qrserver)
     start
 
-    feed(:file => SEARCH_DATA + "music.10.json")
+    feed(:file => SEARCH_DATA + "music.10.json", :host => vespa.container.values.first)
     wait_for_hitcount("query=sddocname:music", 10)
 
     deploy_app(SearchApp.new.num_hosts(2).sd(SEARCH_DATA + "music.sd").
@@ -46,7 +46,7 @@ class AddContainer < IndexedOnlySearchTest
     # Go back to the previous app
     deploy_app(app_one_qrserver)
     wait_for_hitcount("query=sddocname:music", 10)
-    feed(:file => SEARCH_DATA + "music.777.json")
+    feed(:file => SEARCH_DATA + "music.777.json", :host => vespa.container.values.first)
     wait_for_hitcount("query=sddocname:music", 787)
   end
 


### PR DESCRIPTION
Default is first host in app, which in this case does not alwaysn have a container service running

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
