### PR TITLE
Remove setting for feature flag jvm-omit-stack-trace-in-fast-throw

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -39,7 +39,6 @@
         { "id" : "sort-blueprints-by-cost", "rules" : [ { "value" : true } ] },
         { "id" : "content-layer-metadata-feature-level", "rules" : [ { "value" : 1 } ] },
         { "id" : "persistence-thread-max-feed-op-batch-size", "rules" : [ { "value" : 64 } ] },
-        { "id" : "symmetric-put-and-activate-replica-selection", "rules" : [ { "value" : true } ] },
-        { "id" : "jvm-omit-stack-trace-in-fast-throw", "rules" : [ { "value" : false } ] }
+        { "id" : "symmetric-put-and-activate-replica-selection", "rules" : [ { "value" : true } ] }
     ]
 }


### PR DESCRIPTION
Default value is false (and will soon be remove), so not needed

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
