### PR TITLE
Turn off compression on vespa-feed-client.

### DIFF
--- a/lib/nodetypes/feeder.rb
+++ b/lib/nodetypes/feeder.rb
@@ -211,6 +211,9 @@ module Feeder
       if params[:numconnections]
         p += "--connections #{params[:numconnections]} "
       end
+      if params[:compression]
+        p += "--compression #{params[:compression]} "
+      end
       if params[:max_streams_per_connection]
         p += "--max-streams-per-connection #{params[:max_streams_per_connection]} "
       end

--- a/tests/performance/ecommerce_hybrid_search/ecommerce_hybrid_search.rb
+++ b/tests/performance/ecommerce_hybrid_search/ecommerce_hybrid_search.rb
@@ -30,6 +30,7 @@ class EcommerceHybridSearchTest < EcommerceHybridSearchTestBase
     fillers = [parameter_filler("label", label), system_metric_filler(system_sampler)]
     profiler_start
     run_feeder(node_file, fillers, {:client => :vespa_feed_client,
+                                    :compression => "none",
                                     :localfile => true,
                                     :silent => true,
                                     :disable_tls => false})


### PR DESCRIPTION
Compressing float vectors of size 384 is only wasting CPU.

@toregge please review
@baldersheim FYI