### PR TITLE
Tag all queries as english.

### DIFF
--- a/tests/performance/ecommerce_hybrid_search/app/search/query-profiles/default.xml
+++ b/tests/performance/ecommerce_hybrid_search/app/search/query-profiles/default.xml
@@ -1,0 +1,3 @@
+<query-profile id="default">
+    <field name="model.language">en</field>
+</query-profile>


### PR DESCRIPTION
This avoids wasting CPU on language detection in the container when all documents are already tagged as english during feeding.

@toregge please review
@thomasht86 @baldersheim FYI