### PR TITLE
Dont kill scripts that matches paths.

### DIFF
--- a/lib/vespa_cleanup.rb
+++ b/lib/vespa_cleanup.rb
@@ -58,7 +58,7 @@ class VespaCleanup
 
   def collect_stale_processes(node)
     pids = []
-    ps_output = execute(node, "ps auxww | grep -E '(vespa-feeder|vespa-fbench|vespa-visit|vespa-|vespa-config-sentinel|vespa-logd|vespa-runserver|java.*ai.vespa.feed.client)' | grep -v node_server | grep -v grep")
+    ps_output = execute(node, "ps auxww | grep -E '(vespa-feeder|vespa-fbench|vespa-visit|vespa-|vespa-config-sentinel|vespa-logd|vespa-runserver|java.*ai.vespa.feed.client)' | grep -v node_server | grep -v -E '\.(sh|rb)$' | grep -v grep")
     ps_output.split("\n").each { |process_line|
       pid = process_line.split[1]
       pids << pid unless pid == 1


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The pattern matching here is a bit flimsy. Running basic_search.rb test from a path containing vespa-engine will end up with the ruby script being killed. Quick fix for now.