### PR TITLE
Print performance results as json objects instead of ruby format.

### DIFF
--- a/lib/performance/resultmodel.rb
+++ b/lib/performance/resultmodel.rb
@@ -3,6 +3,7 @@
 require 'rubygems'
 require 'builder'
 require 'xml'
+require 'json'
 
 require 'rexml/document'
 require 'performance/system'
@@ -130,6 +131,13 @@ module Perf
         :parameters => @parameters,
         :metrics => @metrics.transform_keys { |m, s| s.nil? ? [m] : [m, s] },
       }.to_s
+    end
+
+    def to_json
+      {
+        :parameters => @parameters,
+        :metrics => @metrics.transform_keys { |m, s| s.nil? ? m : [m, s] }
+      }.to_json
     end
 
     def Result.read(path)

--- a/lib/performance_test.rb
+++ b/lib/performance_test.rb
@@ -435,7 +435,7 @@ class PerformanceTest < TestCase
 
   def check_performance(method)
     puts "#### Performance results ####"
-    get_performance_results.each { |result| puts result }
+    get_performance_results.each { |result| puts result.to_json }
     puts "\n"
   end
 


### PR DESCRIPTION
This makes it easier to process the results from a test when e.g. generating a custom report.

@toregge please review