### PR TITLE
Don't call show_kernel_core_pattern if active sanitizers

### DIFF
--- a/tests/search/coredump/coredump.rb
+++ b/tests/search/coredump/coredump.rb
@@ -119,8 +119,7 @@ class CoreDump < IndexedOnlySearchTest
   end
 
   def teardown
-    unless has_active_sanitizers
-      show_kernel_core_pattern(vespa.adminserver)
+    show_kernel_core_pattern(vespa.adminserver) unless has_active_sanitizers
     stop
   end
 

--- a/tests/search/coredump/coredump.rb
+++ b/tests/search/coredump/coredump.rb
@@ -119,7 +119,8 @@ class CoreDump < IndexedOnlySearchTest
   end
 
   def teardown
-    show_kernel_core_pattern(vespa.adminserver)
+    unless has_active_sanitizers
+      show_kernel_core_pattern(vespa.adminserver)
     stop
   end
 


### PR DESCRIPTION
Will just fail for test_coredump_compression, since no node is available

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
