### PR TITLE
Support compressOnRotation for access log and disable for test

### DIFF
--- a/lib/app_generator/container.rb
+++ b/lib/app_generator/container.rb
@@ -385,7 +385,7 @@ class AccessLog
   chained_setter :fileNamePattern
   chained_setter :symlinkName
   chained_setter :compressionFormat
-
+  chained_setter :compressOnRotation
 
   def initialize(type)
     @type = type
@@ -398,6 +398,7 @@ class AccessLog
           :fileNamePattern => @fileNamePattern,
           :symlinkName => @symlinkName,
           :compressionFormat => @compressionFormat,
+          :compressOnRotation => @compressOnRotation,
           :rotationInterval => @rotationInterval).to_s
   end
 end

--- a/lib/app_generator/test/containertest.rb
+++ b/lib/app_generator/test/containertest.rb
@@ -136,12 +136,13 @@ class ContainerAppGenTest < Test::Unit::TestCase
     actual =
       Container.new.component(AccessLog.new("vespa").
                               fileNamePattern("#{Environment.instance.vespa_home}/logs/vespa/access/QueryAccessLog.%Y%m%d%H%M%S").
+                              compressOnRotation(false).
                               rotationInterval("0 1 ...")).
       to_xml("")
 
     expected_substr =
     "<container id=\"default\" version=\"1.0\">
-       <accesslog fileNamePattern=\"#{Environment.instance.vespa_home}/logs/vespa/access/QueryAccessLog.%Y%m%d%H%M%S\" rotationInterval=\"0 1 ...\" type=\"vespa\" />"
+       <accesslog compressOnRotation=\"false\" fileNamePattern=\"#{Environment.instance.vespa_home}/logs/vespa/access/QueryAccessLog.%Y%m%d%H%M%S\" rotationInterval=\"0 1 ...\" type=\"vespa\" />"
 
     assert_substring_ignore_whitespace(actual, expected_substr)
   end

--- a/tests/search/accesslog/accesslogtest.rb
+++ b/tests/search/accesslog/accesslogtest.rb
@@ -13,7 +13,8 @@ class AccessLogTest < IndexedStreamingSearchTest
                    documentapi(ContainerDocumentApi.new).
                    docproc(DocumentProcessing.new).
                    component(AccessLog.new("vespa").
-                       fileNamePattern("logs/vespa/access/QueryAccessLog.default"))).
+                       fileNamePattern("logs/vespa/access/QueryAccessLog.default").
+                       compressOnRotation("false"))).
                sd(SEARCH_DATA+"music.sd"))
     start
   end


### PR DESCRIPTION
If test runs at NN:00 log will be rotated and compressed, reading that log will just give garbage unless decompressss. Workaround by disabling compression.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
