### PR TITLE
Wait longer when pinging config server

### DIFF
--- a/lib/node_server.rb
+++ b/lib/node_server.rb
@@ -773,7 +773,7 @@ class NodeServer
       # Optimization: Don't start unless it's necessary
       # Ping configserver to be sure that our assumption is correct
       begin
-        ping_configserver(10)
+        ping_configserver(20)
         return
       rescue StandardError => se
         testcase_output("Config server state: running, but not responding to ping, so starting it anyway")


### PR DESCRIPTION
Even if config server is running, it may not be up and ready to receive requests, observed to take longer than 10 seconds in a run of tests/search/jvmtuning.rb

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
