### PR TITLE
Change Elasticsearch to dot_product similarity

### DIFF
--- a/tests/performance/ecommerce_hybrid_search/app_es/index-settings.json
+++ b/tests/performance/ecommerce_hybrid_search/app_es/index-settings.json
@@ -12,7 +12,7 @@
         "type": "dense_vector",
         "dims": 384,
         "index": true,
-        "similarity": "cosine",
+        "similarity": "dot_product",
         "index_options": {"type": "hnsw", "ef_construction": 200, "m": 16}
       }
     }


### PR DESCRIPTION
With our normalized vectors, the score should be exactly the same as "cosine", but we don't force Elasticsearch to normalize vectors at query time. Which is similar to what our prenormalized-angular does: effectively orders by cosine similarity, assuming vectors are normalized.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
