### PR TITLE
Align nearest neighbor search parameters.

### DIFF
--- a/tests/performance/ecommerce_hybrid_search/dataprep/generate_feed_query.py
+++ b/tests/performance/ecommerce_hybrid_search/dataprep/generate_feed_query.py
@@ -336,7 +336,7 @@ def es_knn(embedding, category: str) -> dict:
         "field": "embedding",
         "query_vector": embedding.tolist(),
         "num_candidates": 100,
-        "k": 10,
+        "k": 100,
     }
     if category:
         return {**knn, "filter": [{"term": {"category": category}}]}


### PR DESCRIPTION
This should ensure similar amount of work when searching a HNSW index in Vespa (targetHits=100) and ES (num_candidates=100, k=100).

@radu-gheorghe please review