### PR TITLE
Remove unnecessary config setting

### DIFF
--- a/tests/config/deploy/deploy.rb
+++ b/tests/config/deploy/deploy.rb
@@ -604,7 +604,6 @@ include ApplicationV2Api
 
   def set_config_server_config(fields_and_values = {})
     default_for_this_test = {
-      "maintainerIntervalMinutes" => 1,
       "canReturnEmptySentinelConfig" => true,
     }
 


### PR DESCRIPTION
SessionsMaintainer does not use this value for interval anymore

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
