### PR TITLE
Add validation override

### DIFF
--- a/tests/search/hierarchic_distribution/flat_to_hierarchic_transition.rb
+++ b/tests/search/hierarchic_distribution/flat_to_hierarchic_transition.rb
@@ -20,7 +20,8 @@ class FlatToHierarchicTransitionTest < FeedAndQueryTestBase
                   node(NodeSpec.new("node1", 0))).
             group(NodeGroup.new(1, "mygroup1").
                   node(NodeSpec.new("node1", 1))))).
-      storage(StorageCluster.new("mycluster", 2))
+      storage(StorageCluster.new("mycluster", 2)).
+      validation_override('redundancy-increase')
   end
 
   def assert_satisfied_within_timeout(timeout: 60*2)


### PR DESCRIPTION
The change from flat to hierarchic is from 1 group with 2 nodes having redundancy 1 (1 copy in the group, 50% of docs per node) to 2 groups with 1 node in each, with redundancy 2, distribution 1|* => copies on 2 of the groups => 100% of docs per node.

So we need a validation override in this test when the change in https://github.com/vespa-engine/vespa/pull/32422 is merged

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
