### PR TITLE
Remove unused env var VESPA_MBUS_DOCUMENTAPI_USE_PROTOBUF

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -6,7 +6,6 @@
                 {
                     "value" : [
                         "VESPA_BITVECTOR_RANGE_CHECK=true",
-                        "VESPA_MBUS_DOCUMENTAPI_USE_PROTOBUF=true",
                         "VESPA_FILE_DOWNLOAD_BACKOFF_INITIAL_TIME_MS=1000"
                     ]
                 }


### PR DESCRIPTION
Seems like this is not used anymore