### PR TITLE
Fix tests with new ruby 3.3 and flexmock 5

### DIFF
--- a/lib/test/test_system.rb
+++ b/lib/test/test_system.rb
@@ -19,6 +19,7 @@ class SystemTest < Test::Unit::TestCase
 
   def test_cpuutil
     node = flexmock('node')
+    node.should_receive(:file?).and_return(true)
     node.should_receive(:execute).times(2).
       and_return(IO.read(File.join(File.dirname(__FILE__), "ysar_gather_output.txt")),
                  IO.read(File.join(File.dirname(__FILE__), "ysar_gather_output2.txt")))

--- a/lib/test/unit_test.rb
+++ b/lib/test/unit_test.rb
@@ -1,5 +1,6 @@
 # Copyright Vespa.ai. All rights reserved.
 require 'assertions'
+require 'test_base'
 
 class UnitTest
   include TestBase


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
