### PR TITLE
Add tests for using imported fields as part of Document V1 batch update/remove conditions

### DIFF
--- a/lib/document_api_v1.rb
+++ b/lib/document_api_v1.rb
@@ -90,6 +90,7 @@ class DocumentApiV1
     response = connection.getConnection.delete(path)
     @connectionPool.release(connection)
     assert_response_ok(response)
+    response.body
   end
 
   def assert_response_ok(response)


### PR DESCRIPTION
@havardpe please review

Note: both these tests will currently _fail_, and will continue to do so until the Document V1 timestamp `TestAndSetCondition` wiring is in place. This is as expected.