### PR TITLE
Relax check for expected hits when refeeding

### DIFF
--- a/tests/search/reindex_uptime/reindex_uptime.rb
+++ b/tests/search/reindex_uptime/reindex_uptime.rb
@@ -5,7 +5,7 @@ require 'indexed_streaming_search_test'
 class ReindexUptime < IndexedStreamingSearchTest
 
   def setup
-    set_description("Description: Test that VESPA is up during reindexing")
+    set_description("Description: Test that Vespa is up during reindexing")
     set_owner("yngve")
     deploy_app(SearchApp.new.sd(SEARCH_DATA+"music.sd"))
     start
@@ -20,9 +20,9 @@ class ReindexUptime < IndexedStreamingSearchTest
     thread = Thread.new do
       while !done
         hits = search("query=frank").hitcount
-        # We accept one missing hit because when replacing a document in the memory index
-        # we might not hit that document if the search arrives just between removal and insertion.
-        assert(hits >= 39 && hits <= 40, "Unexpected number of hits: #{hits}")
+        # We accept missing hits because when replacing documents in the memory index
+        # we might not hit all documents if the search arrives just between removals and insertions.
+        assert(hits >= 0 && hits <= 40, "Unexpected number of hits: #{hits}")
       end
     end
 


### PR DESCRIPTION
We cannot know how many hits we will get when refeeding docs, removals and insertions might happen for many docs at the same time, so just check that we have between 0 and the number of hits expected after feeding has finished

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
