### PR TITLE
Refeed document set prior to each test case iteration

### DIFF
--- a/tests/performance/document_rest_api/visiting.rb
+++ b/tests/performance/document_rest_api/visiting.rb
@@ -46,7 +46,6 @@ class Visiting < PerformanceTest
   end
 
   def test_process_visit_throughput
-    feed({ :template => @document_template, :count => @document_count })
     run_process_visiting_benchmarks
   end
 
@@ -79,6 +78,9 @@ class Visiting < PerformanceTest
   def run_process_visiting_benchmarks
     { "1-percent" => @selection_1p, "100-percent" => @selection_100p }.each do |s_name, s_value|
       [1, 8].each do |slices|
+        # Each iteration ends with a deletion pass, so ensure corpus is complete before starting a new one.
+        feed({ :template => @document_template, :count => @document_count })
+
         parameters = { :timeChunk => "#{@visit_seconds}s", :cluster => "search", :slices => slices }
         benchmark_operations(legend: "refeed-#{s_name}-#{slices}s", selections: s_value,
                              parameters: parameters.merge({ :destinationCluster => "search" }), method: 'POST')


### PR DESCRIPTION
@bjorncs please review

Each test iteration ends with document deletion, so do an explicit feed step prior to the next iteration to ensure we're testing with the same document set.
