### PR TITLE
changed Elasticsearch analysis to get closer to Vespa's

### DIFF
--- a/tests/performance/ecommerce_hybrid_search/app_es/index-settings.json
+++ b/tests/performance/ecommerce_hybrid_search/app_es/index-settings.json
@@ -1,10 +1,39 @@
 {
-  "settings": {"number_of_shards": 1, "number_of_replicas": 1},
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 1,
+    "analysis": {
+      "analyzer": {
+        "lowercase_normalize_stem": {
+          "tokenizer": "standard",
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "porter2_english_stemmer"
+          ]
+        }
+      },
+      "filter": {
+        "porter2_english_stemmer": {
+          "type": "stemmer",
+          "language": "porter2"
+        }
+      }
+    }
+  },
   "mappings": {
     "properties": {
       "id": {"type": "integer", "index": false},
-      "title": {"type": "text", "similarity": "BM25"},
-      "description": {"type": "text", "similarity": "BM25"},
+      "title": {
+        "type": "text",
+        "similarity": "BM25",
+        "analyzer": "lowercase_normalize_stem"
+      },
+      "description": {
+        "type": "text",
+        "similarity": "BM25",
+        "analyzer": "lowercase_normalize_stem"
+      },
       "category": {"type": "keyword"},
       "price": {"type": "integer", "index": false},
       "average_rating": {"type": "float", "index": false},


### PR DESCRIPTION
I've tried all stemming implementations for English and this is the closest I got to Vespa. I've taken [this example from the documentation](https://docs.vespa.ai/en/text-matching.html#index-and-attribute):

```
    "Liebe ist für alle da",
    "A Head Full of Dreams",
    "Hardwired...To Self-Destruct",
    "When We All Fall Asleep, Where Do We Go?",
    "Love Is Here To Stay"
```

In Vespa, docs say:
```
["lieb","ist","fur","all","da"]
["a","head","full","of","dream"]
["hardwire","to","self","destruct"]
["when","we","all","fall","asleep","where","do","we","go"]
["love","is","here","to","stay"]
```

While in Elasticsearch, I get:
```
% curl -s -XPOST localhost:9200/my_index/_analyze -H "Content-Type: application/json" -d' 
{
  "text": [
    "Liebe ist für alle da",
    "A Head Full of Dreams",
    "Hardwired...To Self-Destruct",
    "When We All Fall Asleep, Where Do We Go?",
    "Love Is Here To Stay"
  ],
  "field": "description"
}' | jq -r '[.tokens[].token] | join(" ")'
lieb ist fur all da a head full of dream hardwir to self destruct when we all fall asleep where do we go love is here to stay
```

Note that all tokens are the same, except for `hardwired`, which turned into `hardwir` in Elasticsearch and `hardwire` in Vespa. I can make stemming more aggressive in Elasticsearch, but then others differ more (e.g. `stay -> stai`...)

/cc @jobergum 