### PR TITLE
Add query set with stop-words removed

### DIFF
--- a/tests/performance/mmap_vs_directio/.gitignore
+++ b/tests/performance/mmap_vs_directio/.gitignore
@@ -1,2 +1,4 @@
 enwiki-20240801-pages.*.jsonl.zst
-squad2-questions.fbench.141k.txt
+squad2-questions*.txt
+squad2-questions*.txt.zst
+word_freqs.txt

--- a/tests/performance/mmap_vs_directio/filter_stopwords.rb
+++ b/tests/performance/mmap_vs_directio/filter_stopwords.rb
@@ -1,0 +1,39 @@
+# Copyright Vespa.ai. All rights reserved.
+
+# Takes in raw natural language queries (one per line) and outputs new queries
+# with stop words filtered away. Stop words are all terms with a document frequency
+# greater than or equal to `max_df` configured below.
+# Uses a preprocessed word frequency list file of the form:
+# <total document count>\n
+# <term 1>\t<term 1 document frequency>\n
+# ...
+# <term N>\t<term N document frequency>\n
+
+max_df = 0.20
+stop_words = []
+File.open('word_freqs.txt', 'r') do |f|
+  doc_count = f.readline.to_i
+  f.each_line do |line|
+    parts = line.split("\t")
+    term = parts[0].strip
+    freq = parts[1].strip.to_f
+    term_df = freq / doc_count
+    break if term_df < max_df
+    stop_words << term
+  end
+end
+
+#puts "Stop words: #{stop_words}"
+
+# Create one unified regex for case-insensitively matching all stop words
+# at word boundaries.
+filter_regex = /\b(#{stop_words.join('|')})\b/i
+# Removing stop words leaves around redundant whitespace, so have a secondary
+# cleanup regex to collapse these down to a single space.
+normalize_spaces_regex = /(\s{2,})/
+
+ARGF.each_line do |line|
+  filtered = line.gsub(filter_regex, '').gsub(normalize_spaces_regex, ' ').strip
+  #puts "#{line.strip}\n#{filtered}\n\n"
+  puts filtered
+end

--- a/tests/performance/mmap_vs_directio/filter_stopwords.rb
+++ b/tests/performance/mmap_vs_directio/filter_stopwords.rb
@@ -9,6 +9,11 @@
 # ...
 # <term N>\t<term N document frequency>\n
 
+unless File.exist?('word_freqs.txt')
+  puts "Could not find file word_freqs.txt in the same directory as the script"
+  exit
+end
+
 max_df = 0.20
 stop_words = []
 File.open('word_freqs.txt', 'r') do |f|

--- a/tests/performance/mmap_vs_directio/mmap_vs_directio.rb
+++ b/tests/performance/mmap_vs_directio/mmap_vs_directio.rb
@@ -28,6 +28,7 @@ class MmapVsDirectIoTest < PerformanceTest
     start
 
     query_file_name = 'squad2-questions.fbench.141k.txt'
+    no_stop_words_query_file_name = 'squad2-questions.max-df-20.fbench.141k.txt'
     report_io_stat_deltas do
       feed_file('enwiki-20240801-pages.1M.jsonl.zst')
     end
@@ -47,6 +48,9 @@ class MmapVsDirectIoTest < PerformanceTest
       report_io_stat_deltas do
         benchmark_queries(query_file_name, 'mmap', clients, false)
       end
+      report_io_stat_deltas do
+        benchmark_queries(no_stop_words_query_file_name, 'mmap_no_stop_words', clients, false)
+      end
     end
 
     vespa.stop_content_node('search', 0)
@@ -64,6 +68,9 @@ class MmapVsDirectIoTest < PerformanceTest
     [8, 16, 32, 64].each do |clients|
       report_io_stat_deltas do
         benchmark_queries(query_file_name, 'directio', clients, false)
+      end
+      report_io_stat_deltas do
+        benchmark_queries(no_stop_words_query_file_name, 'directio_no_stop_words', clients, false)
       end
     end
 


### PR DESCRIPTION
@geirst please review

Stop-word is here defined to be all words that occur in at least 20% of all documents in the corpus.

Add simple script for processing raw query file. The script uses a preprocessed word frequency list file (can be found in the same location as the feed/query files).
