### PR TITLE
Set number_of_replicas to 0

### DIFF
--- a/tests/performance/ecommerce_hybrid_search/app_es/index-settings.json
+++ b/tests/performance/ecommerce_hybrid_search/app_es/index-settings.json
@@ -1,7 +1,7 @@
 {
   "settings": {
     "number_of_shards": 1,
-    "number_of_replicas": 1,
+    "number_of_replicas": 0,
     "analysis": {
       "analyzer": {
         "lowercase_normalize_stem": {


### PR DESCRIPTION
We effectively have 0 replicas during the performance test because we have one node. The replica will be unassigned.

I'm changing this for visibility - so the configured setting will be the same as the effective setting.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
