### PR TITLE
Remove setting of VESPA_FILE_DOWNLOAD_BACKOFF_INITIAL_TIME_MS env var…

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -5,8 +5,7 @@
             "rules" : [
                 {
                     "value" : [
-                        "VESPA_BITVECTOR_RANGE_CHECK=true",
-                        "VESPA_FILE_DOWNLOAD_BACKOFF_INITIAL_TIME_MS=1000"
+                        "VESPA_BITVECTOR_RANGE_CHECK=true"
                     ]
                 }
             ]


### PR DESCRIPTION
…iable

Default is now 1000

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
