### PR TITLE
Reduce zookeeper-pre-alloc-size from 64k to 16k

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -41,6 +41,7 @@
         { "id" : "symmetric-put-and-activate-replica-selection", "rules" : [ { "value" : true } ] },
         { "id" : "enforce-strictly-increasing-cluster-state-versions", "rules" : [ { "value" : true } ] },
         { "id" : "distribution-config-from-cluster-controller", "rules" : [ { "value" : true } ] },
-        { "id" : "config-server-session-expiry-time", "rules" : [ { "value" : 30 } ] }
+        { "id" : "config-server-session-expiry-time", "rules" : [ { "value" : 30 } ] },
+        { "id" : "zookeeper-pre-alloc-size", "rules" : [ { "value" : 16384 } ] }
     ]
 }


### PR DESCRIPTION
Please review only, will try this out when factory is stable