### PR TITLE
Use new limit to control usage of bitvector query time.

### DIFF
--- a/tests/performance/mmap_vs_directio/app/schemas/wikimedia.sd
+++ b/tests/performance/mmap_vs_directio/app/schemas/wikimedia.sd
@@ -27,11 +27,10 @@ schema wikimedia {
     }
   }
 
-  rank-profile use_bitvectors {
-    rank title: filter
-    rank text: filter
-    first-phase {
-      expression: attribute(id)
+  rank-profile use_bitvectors inherits default {
+    rank-properties {
+      # This is set to 1/64 which is the limit for generating bitvectors.
+      vespa.matching.diskindex.bitvector_limit: 0.015625
     }
   }
 


### PR DESCRIPTION
Use bitvector if it exists, resulting in degraded bm25 score contribution. Otherwise use posocc posting list with full bm25 score contribution.

@toregge please review
@vekterli FYI