### PR TITLE
Work dir fix in generate_text_when_feeding test

### DIFF
--- a/tests/search/generate_text_when_feeding/generate_text_when_feeding.rb
+++ b/tests/search/generate_text_when_feeding/generate_text_when_feeding.rb
@@ -9,8 +9,8 @@ class Generate < SearchTest
 
   def test_generate_text_when_feeding
     # I haven't found a better way to build the app
-    system('cd app && mvn clean generate-resources && mvn clean package')
-    deploy(selfdir + 'app/target/application')
+    system('cd app && mvn clean package')
+    deploy(Dir.pwd + '/app/target/application')
     start
   
     feed_and_wait_for_docs('passage', 1, :file => selfdir + "data/feed.jsonl")


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Trying to fix path difference between local and cloud test runs.