### PR TITLE
Extend Document V1 API continuation visiting test with `stream=true`

### DIFF
--- a/lib/document_api_v1.rb
+++ b/lib/document_api_v1.rb
@@ -21,7 +21,7 @@ class DocumentApiV1
   attr_reader :host, :port
 
   @@known_request_params = [:concurrency, :condition, :create, :cluster, :continuation, "format.tensors",
-                            :fieldSet, :route, :selection, :wantedDocumentCount, :bucketSpace].to_set
+                            :fieldSet, :route, :selection, :wantedDocumentCount, :bucketSpace, :stream].to_set
 
   def initialize(host, port, test_case)
     @host = host

--- a/tests/vds/documentapi/visit_many_documents.rb
+++ b/tests/vds/documentapi/visit_many_documents.rb
@@ -4,7 +4,7 @@ require 'vds_test'
 class VisitManyDocumentsTest < VdsTest
 
   def setup
-    set_owner("geirst")
+    set_owner('vekterli')
     deploy_app(default_app.distribution_bits(8))
     container = (vespa.qrserver["0"] or vespa.container.values.first)
     @tmp_bin_dir = container.create_tmp_bin_dir
@@ -27,9 +27,15 @@ class VisitManyDocumentsTest < VdsTest
   def test_visit_many_documents
     set_description("Test visiting of many documents using continuation token")
     feed_documents
+    [false, true].each { |stream|
+      visit_with_continuation(stream)
+    }
+  end
 
+  def visit_with_continuation(stream)
+    puts "Visiting via Document V1 API with stream=#{stream}"
     doc_ids = Set.new
-    params = {:selection => "music", :cluster => "storage", :wantedDocumentCount => @wanted_doc_count}
+    params = {:selection => "music", :cluster => "storage", :wantedDocumentCount => @wanted_doc_count, :stream => stream}
     continuation = nil
     visit_count = 0
     loop do


### PR DESCRIPTION
@bjorncs please review.

Depends on https://github.com/vespa-engine/vespa/pull/33126
Relates to https://github.com/vespa-engine/vespa/issues/32645