### PR TITLE
fix: prevent killing unwanted processes in the cleanup steps [MERGEOK]

### DIFF
--- a/lib/vespa_cleanup.rb
+++ b/lib/vespa_cleanup.rb
@@ -58,7 +58,7 @@ class VespaCleanup
 
   def collect_stale_processes(node)
     pids = []
-    ps_output = execute(node, "ps auxww | sed 's,\\s\\S*/, ,g' | grep -E '(vespa-feeder|vespa-fbench|vespa-visit|vespa-|vespa-config-sentinel|vespa-logd|vespa-runserver|java.*ai.vespa.feed.client)' | grep -v node_server | grep -v grep")
+    ps_output = execute(node, "ps auxww | sed 's,\\s\\S*/, ,g' | grep -E '(vespa-feeder|vespa-fbench|vespa-visit|vespa-|vespa-config-sentinel|vespa-logd|vespa-runserver|java.*ai.vespa.feed.client|java.*jdisc.export)' | grep -E -v 'node_server|grep|buildkite|make.-j'")
     ps_output.split("\n").each { |process_line|
       pid = process_line.split[1]
       pids << pid unless pid == 1


### PR DESCRIPTION
@aressem
this should probably be much tighter matching only the actually-likely leftover processes