### PR TITLE
Revert "Benchmark feed overload test with old doc v1 queue setting"

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -39,7 +39,7 @@
         { "id" : "content-layer-metadata-feature-level", "rules" : [ { "value" : 1 } ] },
         { "id" : "symmetric-put-and-activate-replica-selection", "rules" : [ { "value" : true } ] },
         { "id" : "zookeeper-pre-alloc-size", "rules" : [ { "value" : 16384 } ] },
-        { "id" : "document-v1-queue-size", "rules" : [ { "value" : 4096 } ] }
+        { "id" : "document-v1-queue-size", "rules" : [ { "value" : 0 } ] }
 
     ]
 }


### PR DESCRIPTION
Reverts vespa-engine/system-test#4331