### PR TITLE
Add test to expect 404 when doing a get on unknown document type

### DIFF
--- a/tests/vds/documentapi/document_api_v1_base.rb
+++ b/tests/vds/documentapi/document_api_v1_base.rb
@@ -82,6 +82,11 @@ class DocumentApiV1Base < SearchTest
     assert_equal(404, response.code.to_i)
   end
 
+  def assert_not_found_with_path(path)
+    response = vespa.document_api_v1.http_get(path)
+    assert_equal(404, response.code.to_i)
+  end
+
   def assert_fails_with_precondition_violation
     begin
       yield

--- a/tests/vds/documentapi/document_api_v1_part3.rb
+++ b/tests/vds/documentapi/document_api_v1_part3.rb
@@ -51,4 +51,8 @@ class DocumentApiVdsPart3 < DocumentApiV1Base
     }
   end
 
+  def test_get_unknown_document_type_returns_404_not_found
+    assert_not_found_with_path("/document/v1/storage_test/unknown/docid/somethingrandom")
+  end
+
 end


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
