### PR TITLE
Remove feature flag setting for container-dump-heap-on-shutdown-timeout

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -29,7 +29,6 @@
         { "id" : "rpc-events-before-wakeup", "rules" : [ { "value" : 1 } ] },
         { "id" : "async-message-handling-on-schedule", "rules" : [ { "value" : true } ] },
         { "id" : "max-uncommitted-memory", "rules" : [ { "value" : 130000 } ] },
-        { "id" : "container-dump-heap-on-shutdown-timeout", "rules" : [ { "value" : true } ] },
         { "id" : "resource-limit-disk", "rules" : [ { "value" : 0.9 } ] },
         { "id" : "summary-decode-policy", "rules" : [ { "value" : "on-demand" } ] },
         { "id" : "write-config-server-session-data-as-blob", "rules" : [ { "value" : true } ] },


### PR DESCRIPTION
Use same as default value (false)