### PR TITLE
Inject container thread pool

### DIFF
--- a/tests/performance/container/http/java/src/main/java/com/yahoo/performance/handler/HelloWorldHandler.java
+++ b/tests/performance/container/http/java/src/main/java/com/yahoo/performance/handler/HelloWorldHandler.java
@@ -1,6 +1,7 @@
 package com.yahoo.performance.handler;
 
 import com.google.inject.Inject;
+import com.yahoo.container.handler.threadpool.ContainerThreadPool;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
@@ -16,8 +17,8 @@ import java.util.concurrent.Executor;
 public class HelloWorldHandler extends ThreadedHttpRequestHandler {
 
     @Inject
-    public HelloWorldHandler(Executor executor, Metric metric) {
-        super(executor, metric);
+    public HelloWorldHandler(ContainerThreadPool pool, Metric metric) {
+        super(pool, metric);
     }
 
     @Override


### PR DESCRIPTION
Use the dedicated handler thread pool instead of the default pool

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
