### PR TITLE
Try 'local'

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>vespaai/renovate-config"
+    "local>vespaai/renovate-config"
   ],
   "dependencyDashboardApproval": true,
   "ignorePaths": [],


### PR DESCRIPTION
Check if using local will grant Renovate access to internal configuration using authenticated APIs

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
