### PR TITLE
ignore spurious exceptions while waiting for sync

### DIFF
--- a/lib/nodetypes/distributor.rb
+++ b/lib/nodetypes/distributor.rb
@@ -98,6 +98,9 @@ class Distributor < VDSNode
         if state == nil
           return true
         end
+      rescue => ignore
+        # Do nothing (could not parse bucket status page, or similar)
+        puts "Ignoring exception #{ignore}"
       rescue Errno::ECONNREFUSED
         # Do nothing
       end


### PR DESCRIPTION
@vekterli please review

dirty fix for this problem:
ERROR IN 'BucketReadiness::test_visiting_while_nodes_down_and_up__INDEXED()': RuntimeError: Unknown node idealstate entry: 'Setting node 0 as active: copy is ready'. Failed to parse string 'Setting node 0 as active: copy is ready, has 39 docs and ideal state priority 0'