### PR TITLE
add (disabled) openai rag system-test

### DIFF
--- a/tests/container/openai_llm/LocalSecrets.java
+++ b/tests/container/openai_llm/LocalSecrets.java
@@ -1,0 +1,28 @@
+package ai.vespa.test;
+
+import ai.vespa.secret.Secret;
+import ai.vespa.secret.Secrets;
+import com.yahoo.component.annotation.Inject;
+
+public class LocalSecrets implements Secrets {
+
+    private static final String OPENAI_API_KEY = "<YOUR_OPENAI_API_KEY>";
+
+    @Inject
+    public LocalSecrets() {
+        System.out.println("Starting LocalSecrets....");
+    }
+
+    @Override
+    public Secret get(String key) {
+        System.out.println("Key: " + key + " requested");
+        
+        if (key.equals("openAiKey")) {
+            return () -> OPENAI_API_KEY;
+        }
+        
+        throw new IllegalArgumentException("Secret with key '" + key + "' not found in secrets");
+    }
+
+
+}

--- a/tests/container/openai_llm/app/schemas/passage.sd
+++ b/tests/container/openai_llm/app/schemas/passage.sd
@@ -1,0 +1,24 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+schema passage {
+  document passage {
+    field id type string {
+      indexing: summary | attribute
+    }
+
+    field text type string {
+      indexing: summary | index
+      index: enable-bm25
+    }
+  }
+  
+  fieldset default {
+    fields: text
+  }
+
+  rank-profile default {
+    first-phase {
+        expression: bm25(text)
+    }
+  }
+}

--- a/tests/container/openai_llm/app/services.xml
+++ b/tests/container/openai_llm/app/services.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<services version="1.0">
+
+  <container id="default" version="1.0">
+    <!-- Mock secrets for local testing -->
+    <component id="secrets" class="ai.vespa.test.LocalSecrets" />
+
+    <!-- Setup OpenAI client - also works directly as a generator -->
+    <component id="openai" class="ai.vespa.llm.clients.OpenAI">
+      <config name="ai.vespa.llm.clients.llm-client">
+        <apiKeySecretName>openAiKey</apiKeySecretName>
+      </config>
+    </component>
+
+    <search>
+        <chain id="openai" inherits="vespa">
+            <searcher id="ai.vespa.search.llm.RAGSearcher">
+                <config name="ai.vespa.search.llm.llm-searcher">
+                    <providerId>openai</providerId>
+                </config>
+            </searcher>
+        </chain>
+    </search>
+      
+    <document-api/>
+    <nodes>
+      <node hostalias="node1" />
+    </nodes>
+  </container>
+
+  <content id="msmarco" version="1.0">
+    <redundancy>1</redundancy>
+    <documents>
+      <document mode="index" type="passage"/>
+    </documents>
+    <nodes>
+      <node hostalias="node1" distribution-key="0"/>
+    </nodes>
+  </content>
+
+</services>

--- a/tests/container/openai_llm/data/one.jsonl
+++ b/tests/container/openai_llm/data/one.jsonl
@@ -1,0 +1,6 @@
+{
+    "put": "id:msmarco:passage::0", 
+    "fields": {
+        "text": "The presence of communication amid scientific minds was equally important to the success of the Manhattan Project as scientific intellect was. The only cloud hanging over the impressive achievement of the atomic researchers and engineers is what their success truly meant; hundreds of thousands of innocent lives obliterated.", 
+        "id": "0"
+    }}

--- a/tests/container/openai_llm/openai_rag.rb
+++ b/tests/container/openai_llm/openai_rag.rb
@@ -1,0 +1,94 @@
+require 'search_container_test'
+
+
+class GenerateOpenAI < SearchContainerTest
+  def setup
+    @valgrind = false
+    set_owner('glebashnik')
+    set_description('Test feeding generator with OpenAI API')
+  end
+
+  def timeout_seconds
+    600
+  end
+  
+  # This test is disabled because it requires either an API-key or a mock OpenAI-compatible server.
+  def no_test_openai_rag
+    add_bundle(selfdir + 'LocalSecrets.java')
+    deploy(selfdir + 'app')
+    start
+    feed(:file => selfdir + "data/one.jsonl")
+    wait_for_hitcount('query=manhattan', 1)
+    prompt = "What was the Manhattan project?"
+    assert_json_response(prompt)
+    assert_sse_response(prompt)
+  end
+
+  def assert_json_response(prompt)
+    query = {
+      'searchChain' => 'openai',
+      'query' => prompt,
+      'format' => 'json',
+    }
+    result = search(query)
+    puts "Result is: #{result}"
+    parsed_data = JSON.parse(result)
+  
+    # Assert that the root object exists with id "token_stream"
+    assert_equal(true, parsed_data.has_key?("root"), "Response missing root element")
+    assert_equal("token_stream", parsed_data["root"]["id"], "Root id is not token_stream")
+    
+    # Assert that we have event_stream in children
+    event_stream = parsed_data["root"]["children"].find { |child| child["id"] == "event_stream" }
+    assert_not_nil(event_stream, "Missing event_stream in children")
+    
+    # Assert minimum number of tokens (children of event_stream)
+    token_children = event_stream["children"]
+    assert_not_nil(token_children, "Missing children in event_stream")
+    assert(token_children.length >= 10, "Expected at least 10 tokens, but got #{token_children.length}")
+    
+    # Verify token format for a few tokens
+    tokens_with_text = token_children.select { |t| t["fields"] && t["fields"]["token"] }
+    assert(tokens_with_text.length > 0, "No tokens with text found")
+end
+
+  def assert_sse_response(prompt)
+    query = {
+      'searchChain' => 'openai',
+      'query' => prompt,
+      'format' => 'sse',
+      'traceLevel' => '1',
+    }
+    result = search(query)
+    puts "Result is: #{result}"
+  
+    # Check for prompt event
+    assert_equal(true, result.include?("event: prompt"), "Missing prompt event")
+    assert_equal(true, result.include?("data: {\"prompt\":"), "Missing prompt data")
+    
+    # Check for token events
+    token_events = result.scan(/event: token/)
+    assert(token_events.length >= 10, "Expected at least 10 token events, got #{token_events.length}")
+    
+    # Check token data format
+    token_data_matches = result.scan(/data: \{"token":"[^"]*"\}/)
+    assert(token_data_matches.length >= 10, "Expected at least 10 token data entries, got #{token_data_matches.length}")
+
+    # Check proper SSE format (events followed by data)
+    assert_equal(true, result.include?("event: token\ndata: {\"token\":"), "Incorrect SSE format")
+  end
+
+  def search(query)
+    query = "/search/?" + URI.encode_www_form(query.to_a)
+    puts "Query is: #{query}"
+    container = vespa.container.values.first
+    result = container.http_get("localhost", Environment.instance.vespa_web_service_port, query, nil, {})
+    assert_equal(200, result.code.to_i)
+    result.body
+  end
+
+  def teardown
+    stop
+  end
+
+end


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Adds a disabled system-test for RAGSearcher using OpenAI-client llm.
Run from vespa-branch `thomasht86/add-openai-java-client` until that is merged. 