### PR TITLE
Cross-check reported and actual Doc V1 visitor document count

### DIFF
--- a/tests/vds/documentapi/visit_many_documents.rb
+++ b/tests/vds/documentapi/visit_many_documents.rb
@@ -52,8 +52,12 @@ class VisitManyDocumentsTest < VdsTest
 
   def get_document_ids(visit_result)
     result = []
+    res_doc_count = visit_result['documentCount'].to_i
     visit_result["documents"].each do |document|
       result.push(document["id"])
+    end
+    if res_doc_count != result.size
+      raise "Inconsistent specified doc count (#{res_doc_count}) and actual returned doc chunks (#{result.size})"
     end
     result
   end


### PR DESCRIPTION
@toregge please review. Test only checked the actual returned concrete document _set_, which fails to detect any discrepancies between its cardinailty and the reported document _count value_.