### PR TITLE
Add json select query test for IN operator

### DIFF
--- a/tests/search/select_json_query/music.sd
+++ b/tests/search/select_json_query/music.sd
@@ -1,0 +1,26 @@
+# Copyright Vespa.ai. All rights reserved.
+
+schema music {
+
+  document music {
+
+    field title type string {
+      indexing: index | summary
+    }
+
+    field artist type string {
+      indexing: index | summary
+      match: word
+    }
+
+    field year type int {
+      indexing: summary | attribute
+    }
+  }
+
+  fieldset default {
+    fields: title
+  }
+
+}
+

--- a/tests/search/select_json_query/select_json_query.rb
+++ b/tests/search/select_json_query/select_json_query.rb
@@ -4,23 +4,68 @@ require 'indexed_streaming_search_test'
 class SelectJsonQuery < IndexedStreamingSearchTest
 
   def setup
-    set_owner("hmusum")
+    set_owner("boeker")
     set_description("Test that we can POST Json payload with a 'select' query")
-    deploy_app(SearchApp.new.sd(SEARCH_DATA+"music.sd"))
+    deploy_app(SearchApp.new.sd(selfdir + "music.sd"))
     start
+  end
+
+  def feed_doc(id, doc_template)
+    doc = Document.new("music", "id:test:music::#{id}}").
+      add_field("title", doc_template[:title]).
+      add_field("artist", doc_template[:artist]).
+      add_field("year", doc_template[:year])
+    vespa.document_api_v1.put(doc)
   end
 
   def test_search
     start
 
-    feed(:file => SEARCH_DATA + "music.10.json")
-    select_json_string = "{ 'select': { 'where': { 'contains': ['default', 'country'] } } }"
-    result = post_query(select_json_string)
-    assert_equal(1, result.hit.length)
+    feed_doc(0, { :title => "Blues" })
+    feed_doc(1, { :title => "Country Blues" })
+
+    assert_hits(1, "'select': { 'where': { 'contains': ['default', 'country'] } }")
+  end
+
+  def test_in
+    start
+
+    feed_doc(0, { :title => "Last Night in Hamburg",
+                  :artist => "The Beatles",
+                  :year => "1999" })
+
+    feed_doc(1, { :title => "Try This [Clean] [Bonus DVD]",
+                  :artist => "Pink",
+                  :year => "2003" })
+
+    feed_doc(2, { :title => "Endless Pain (Remastered)",
+                  :artist => "Kreator",
+                  :year => "2001" })
+
+    assert_hits(1,"'select': { 'where': { 'in': ['year', 1999] } }")
+    assert_hits(1,"'select': { 'where': { 'in': ['year', 2001] } }")
+    assert_hits(1, "'select': { 'where': { 'in': ['year', 2003] } }")
+    assert_hits(2, "'select': { 'where': { 'in': ['year', 1999, 2001] } }")
+    assert_hits(2, "'select': { 'where': { 'in': ['year', 1999, 2003] } }")
+    assert_hits(2, "'select': { 'where': { 'in': ['year', 2001, 2003] } }")
+    assert_hits(3, "'select': { 'where': { 'in': ['year', 1999, 2001, 2003] } }")
+
+    assert_hits(1, "'select': { 'where': { 'in': ['artist', 'Pink'] } }")
+    assert_hits(1, "'select': { 'where': { 'in': ['artist', 'The Beatles'] } }")
+    assert_hits(1, "'select': { 'where': { 'in': ['artist', 'Kreator'] } }")
+    assert_hits(2, "'select': { 'where': { 'in': ['artist', 'Pink', 'The Beatles'] } }")
+    assert_hits(2, "'select': { 'where': { 'in': ['artist', 'Pink', 'Kreator'] } }")
+    assert_hits(2, "'select': { 'where': { 'in': ['artist', 'The Beatles', 'Kreator'] } }")
+    assert_hits(3, "'select': { 'where': { 'in': ['artist', 'Pink', 'The Beatles', 'Kreator'] } }")
+  end
+
+  def assert_hits(expected_hits, query)
+    result = post_query(query)
+    assert_equal(expected_hits, result.hit.length)
   end
 
   def post_query(query)
-    vespa.container.values.first.post_search("/search/", query, 0, {'Content-Type' => 'application/json'})
+    vespa.container.values.first.post_search("/search/", "{ " + query + ", 'streaming.selection': 'true' }", 0, {'Content-Type' => 'application/json'})
   end
 
   def teardown

--- a/tests/search/select_json_query/select_json_query.rb
+++ b/tests/search/select_json_query/select_json_query.rb
@@ -1,0 +1,30 @@
+# Copyright Vespa.ai. All rights reserved.
+require 'indexed_streaming_search_test'
+
+class SelectJsonQuery < IndexedStreamingSearchTest
+
+  def setup
+    set_owner("hmusum")
+    set_description("Test that we can POST Json payload with a 'select' query")
+    deploy_app(SearchApp.new.sd(SEARCH_DATA+"music.sd"))
+    start
+  end
+
+  def test_search
+    start
+
+    feed(:file => SEARCH_DATA + "music.10.json")
+    select_json_string = "{ 'select': { 'where': { 'contains': ['default', 'country'] } } }"
+    result = post_query(select_json_string)
+    assert_equal(1, result.hit.length)
+  end
+
+  def post_query(query)
+    vespa.container.values.first.post_search("/search/", query, 0, {'Content-Type' => 'application/json'})
+  end
+
+  def teardown
+    stop
+  end
+
+end


### PR DESCRIPTION
Adds a json select query test that basically just tests the IN operator. Should be extended with more examples. Uses a custom schema since the IN operator does not work for string fields with `match:text`.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.