### PR TITLE
install awscli from source

### DIFF
--- a/docker/Dockerfile.almalinux8
+++ b/docker/Dockerfile.almalinux8
@@ -60,7 +60,8 @@ RUN dnf install -y dnf-plugins-core && \
         wget \
         zstd && \
     (source /opt/rh/gcc-toolset/enable && gem install ffi libxml-ruby) && \
-    pip3 install --no-cache-dir --upgrade pip && \
+    curl -sSLf "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && ./aws/install && rm -rf aws awscliv2.zip && \
     pip3 install --no-cache-dir awscli && \
     (source /opt/rh/gcc-toolset/enable && pip3 install --no-cache-dir xgboost scikit-learn) && \
     echo ": \${JAVA_HOME:=$(dirname $(dirname $(readlink -f /usr/bin/java)))}" > /etc/mavenrc
@@ -117,4 +118,3 @@ RUN --mount=type=bind,target=/context-root,source=./,ro \
     rm -f $VESPA_HOME/.m2/settings.xml
 
 ENTRYPOINT ["bash", "-lc", "source /opt/rh/gcc-toolset/enable && /opt/vespa-systemtests/lib/node_server.rb $NODE_SERVER_OPTS"]
-


### PR DESCRIPTION
pip3 installs old version of aws cli (1.24)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
