### PR TITLE
Add test case for reindexing of new, trivially true bool field

### DIFF
--- a/tests/search/reindexing/add_const_field/item.0.sd
+++ b/tests/search/reindexing/add_const_field/item.0.sd
@@ -1,0 +1,12 @@
+# Copyright Vespa.ai. All rights reserved.
+
+schema item {
+  field item_indexed_at_seconds type long {
+        indexing: now | summary | attribute
+  }
+  document item {
+    field title type string {
+        indexing: index | summary
+    }
+  }
+}

--- a/tests/search/reindexing/add_const_field/item.1.sd
+++ b/tests/search/reindexing/add_const_field/item.1.sd
@@ -1,0 +1,15 @@
+# Copyright Vespa.ai. All rights reserved.
+
+schema item {
+  field item_indexed_at_seconds type long {
+        indexing: now | summary | attribute
+  }
+  field const_bool type bool {
+    indexing: true | attribute
+  }
+  document item {
+    field title type string {
+        indexing: index | summary
+    }
+  }
+}


### PR DESCRIPTION
The test case checks that, if a trivially true bool field is added to a schema, then the  correct value (`true`) is assigned to old documents after reindexing.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
