### PR TITLE
remove factory auth fallback

### DIFF
--- a/lib/factory/factory_http_client.rb
+++ b/lib/factory/factory_http_client.rb
@@ -3,22 +3,7 @@
 require 'timeout'
 require 'json'
 require 'zlib'
-
-begin
-  require 'factory_authentication'
-rescue LoadError
-  class FactoryAuthentication
-    def factory_api
-      nil
-    end
-    def client
-      nil
-    end
-    def token
-      nil
-    end
-  end
-end
+require 'factory_authentication'
 
 class FactoryHttpClient
 


### PR DESCRIPTION
Due to the chain of requirements, backend_reporter won't set BACKEND_CLIENT_OVERRIDE to true if factory_authentication.rb is not present and thus tests won't run locally (without reporting data to factory)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
