### PR TITLE
Add test checking availability of /state/v1/-endpoints

### DIFF
--- a/lib/vespa_model.rb
+++ b/lib/vespa_model.rb
@@ -13,7 +13,7 @@ require 'environment'
 class VespaModel
 
   attr_reader :nodeproxies, :hostalias, :adminserver, :configservers, :logserver
-  attr_reader :qrserver, :storage, :search, :slobrok, :qrs
+  attr_reader :qrserver, :storage, :search, :slobrok, :qrs, :services
   attr_reader :metricsproxies
   attr_reader :container, :clustercontrollers, :default_document_api_port, :document_api_v1
 
@@ -47,6 +47,7 @@ class VespaModel
     @slobrok = {}
     @clustercontrollers = {}
     @stop_hooks = []
+    @services = []
   end
 
   def content_node(cluster, index)
@@ -706,6 +707,9 @@ class VespaModel
     end
 
     remote_serviceobject = node_handle.get_service(service)
+    unless remote_serviceobject.nil?
+      @services.append(remote_serviceobject)
+    end
     if service["servicetype"] == "qrserver"
       clustername = service["clustername"]
       @qrs[clustername].add_service(remote_serviceobject)

--- a/tests/search/statev1/statev1.rb
+++ b/tests/search/statev1/statev1.rb
@@ -12,50 +12,40 @@ class StateV1 < IndexedStreamingSearchTest
     start
 
     # Note that we do not test all services since a VespaNode object is not created for every service
-    puts "Checking " + @vespa.services.length.to_s + " services"
+    puts "Testing #{@vespa.services.length.to_s} services"
 
-    # As of the creation of this test, there are 9 services that are tested
-    # To make sure that the test fails if the services list is empty (or fewer services than expected are added to it),
-    # we add the following assert
-    assert(@vespa.services.length >= 9, "The number of services that are tested should at least be 9")
+    # As a sanity check, make sure that there is at least one service being tested
+    assert(@vespa.services.length > 0, "There should be at least one service being tested")
 
     @vespa.services.each do |service|
-      puts "Testing service '" + service.servicetype + "'"
+      puts "Testing service '#{service.servicetype}'"
 
       unless service.get_state_port.nil?
-        # /state/v1/config
-        config = get_state_v1(service, "config")
+        puts "/state/v1/config"
+        config = service.get_state_v1("config")
         # service should be reporting a generation
         generation = config["config"]["generation"]
-        assert(!generation.nil?)
+        assert_not_nil generation
 
-        # /state/v1/version
-        version = get_state_v1(service, "version")
+        puts "/state/v1/version"
+        version = service.get_state_v1("version")
         # service should be reporting a version number
         version_number = version["version"]
-        assert(!version_number.nil?)
+        assert_not_nil version_number
 
-        # /state/v1/health
-        health = get_state_v1(service, "health")
+        puts "/state/v1/health"
+        health = service.get_state_v1("health")
         # service should be reporting itself as up
         assert_equal("up", health["status"]["code"])
 
-        # /state/v1/metrics
-        metrics = get_state_v1(service, "metrics")
+        puts "/state/v1/metrics"
+        metrics = service.get_state_v1("metrics")
         # service should be reporting itself as up
         assert_equal("up", metrics["status"]["code"])
       else
         puts "The service does not have a state port"
       end
     end
-  end
-
-  def get_state_v1(service, path)
-    puts "Getting state/v1/" + path
-    answer = nil
-    assert_nothing_raised() { answer = service.get_state_v1(path) }
-    assert(!answer.nil?, "Answer is nil")
-    answer
   end
 
   def teardown

--- a/tests/search/statev1/statev1.rb
+++ b/tests/search/statev1/statev1.rb
@@ -1,0 +1,65 @@
+# Copyright Vespa.ai. All rights reserved.
+require 'indexed_streaming_search_test'
+
+class StateV1 < IndexedStreamingSearchTest
+
+  def setup
+    set_owner("boeker")
+  end
+
+  def test_availability
+    deploy_app(SearchApp.new.sd(selfdir + "test.sd"))
+    start
+
+    # Note that we do not test all services since a VespaNode object is not created for every service
+    puts "Checking " + @vespa.services.length.to_s + " services"
+
+    # As of the creation of this test, there are 9 services that are tested
+    # To make sure that the test fails if the services list is empty (or fewer services than expected are added to it),
+    # we add the following assert
+    assert(@vespa.services.length >= 9, "The number of services that are tested should at least be 9")
+
+    @vespa.services.each do |service|
+      puts "Testing service '" + service.servicetype + "'"
+
+      unless service.get_state_port.nil?
+        # /state/v1/config
+        config = get_state_v1(service, "config")
+        # service should be reporting a generation
+        generation = config["config"]["generation"]
+        assert(!generation.nil?)
+
+        # /state/v1/version
+        version = get_state_v1(service, "version")
+        # service should be reporting a version number
+        version_number = version["version"]
+        assert(!version_number.nil?)
+
+        # /state/v1/health
+        health = get_state_v1(service, "health")
+        # service should be reporting itself as up
+        assert_equal("up", health["status"]["code"])
+
+        # /state/v1/metrics
+        metrics = get_state_v1(service, "metrics")
+        # service should be reporting itself as up
+        assert_equal("up", metrics["status"]["code"])
+      else
+        puts "The service does not have a state port"
+      end
+    end
+  end
+
+  def get_state_v1(service, path)
+    puts "Getting state/v1/" + path
+    answer = nil
+    assert_nothing_raised() { answer = service.get_state_v1(path) }
+    assert(!answer.nil?, "Answer is nil")
+    answer
+  end
+
+  def teardown
+    stop
+  end
+
+end

--- a/tests/search/statev1/test.sd
+++ b/tests/search/statev1/test.sd
@@ -1,0 +1,11 @@
+# Copyright Vespa.ai. All rights reserved.
+schema test {
+  document test {
+    field body type string {
+      indexing: summary | index
+    }
+  }
+  fieldset default {
+    fields: body
+  }
+}


### PR DESCRIPTION
This test checks that the four /state/v1/-endpoints config, version, health, and metrics are available for most services.

This PR depends on https://github.com/vespa-engine/vespa/pull/33842.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
