### PR TITLE
Don't check state v1 resources that is not /state/v1/custom

### DIFF
--- a/tests/search/custom_state_api/custom_state_api.rb
+++ b/tests/search/custom_state_api/custom_state_api.rb
@@ -30,7 +30,6 @@ class CustomStateApi < IndexedStreamingSearchTest
   def assert_root_resources(root)
     resources = root["resources"]
     puts "assert_root_resources: #{resources.join(',')}"
-    assert_equal(4, resources.size)
     assert_equal(1, resources.count { |elem| elem["url"].end_with?("/state/v1/custom/component") })
   end
 


### PR DESCRIPTION
This is handled by new system test in tests/search/statev1/statev1.rb now