### PR TITLE
Set resource-limit-low-watermark-difference to 0.0

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -32,6 +32,8 @@
         { "id" : "write-config-server-session-data-as-blob", "rules" : [ { "value" : true } ] },
         { "id" : "unknown-config-definition", "rules" : [ { "value" : "fail" } ] },
         { "id" : "content-layer-metadata-feature-level", "rules" : [ { "value" : 1 } ] },
-        { "id" : "zookeeper-pre-alloc-size", "rules" : [ { "value" : 16384 } ] }
+        { "id" : "zookeeper-pre-alloc-size", "rules" : [ { "value" : 16384 } ] },
+        { "id" : "resource-limit-low-watermark-difference", "rules" : [ { "value" : 0.0 } ] }
     ]
+
 }


### PR DESCRIPTION
Needed for some system tests that tests feed block feature