### PR TITLE
Enable AVX3_DL vectorization on factory

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -5,7 +5,8 @@
             "rules" : [
                 {
                     "value" : [
-                        "VESPA_BITVECTOR_RANGE_CHECK=true"
+                        "VESPA_BITVECTOR_RANGE_CHECK=true",
+                        "VESPA_INTERNAL_VECTORIZATION_TARGET_LEVEL=AVX3_DL"
                     ]
                 }
             ]


### PR DESCRIPTION
@hmusum please review.

Caveat: when this variable is explicitly set the acceleration target picker will log a warning if the underlying platform is unable to satisfy the desired target level, which may cause some output noise from C++ tools if tests are run on nodes that _don't_ support AVX3_DL. A quick revert if this turns out to be the case and/or a problem.