### PR TITLE
Revert "Enable AVX3_DL vectorization on factory"

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -5,8 +5,7 @@
             "rules" : [
                 {
                     "value" : [
-                        "VESPA_BITVECTOR_RANGE_CHECK=true",
-                        "VESPA_INTERNAL_VECTORIZATION_TARGET_LEVEL=AVX3_DL"
+                        "VESPA_BITVECTOR_RANGE_CHECK=true"
                     ]
                 }
             ]


### PR DESCRIPTION
@toregge please review
@hmusum FYI

As suspected, warnings were emitted due to underlying hardware not matching the desired acceleration level. Reverting for now, will try again once this has been dealt with.