### PR TITLE
Re-enable AVX3_DL vectorization on factory

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -5,7 +5,8 @@
             "rules" : [
                 {
                     "value" : [
-                        "VESPA_BITVECTOR_RANGE_CHECK=true"
+                        "VESPA_BITVECTOR_RANGE_CHECK=true",
+                        "VESPA_INTERNAL_VECTORIZATION_TARGET_LEVEL=AVX3_DL"
                     ]
                 }
             ]


### PR DESCRIPTION
@hmusum please review. Round two.

Previously failed due to log warnings due to system test nodes not having sufficiently new hardware. That has now been reduced to `info` level, so should no longer fail.
