### PR TITLE
Increased generate tests timeouts

### DIFF
--- a/tests/docproc/generate_field/app/services.xml
+++ b/tests/docproc/generate_field/app/services.xml
@@ -16,7 +16,7 @@
                 <!-- <model url="https://data.vespa-cloud.com/gguf_models/Llama-160M-Chat-v1.Q6_K.gguf"/>-->
                 <!-- Approx 750Mb, sometime fails to generate structure output, use responseFormatType TEXT" -->
                 <!-- <model url="https://data.vespa-cloud.com/gguf_models/llama-3.2-1b-instruct-q4_k_m.gguf" /> -->
-                <!-- Approx 2.2GB, should be able to generate structure output" -->
+                <!-- Approx 2.2GB, should be able to generate structure output -->
                 <model url="https://data.vespa-cloud.com/gguf_models/Phi-3.5-mini-instruct-Q4_K_M.gguf"/>
                 <contextSize>1024</contextSize>
             </config>

--- a/tests/docproc/generate_field/generate_field.rb
+++ b/tests/docproc/generate_field/generate_field.rb
@@ -15,7 +15,7 @@ class GenerateField < SearchTest
   def test_generate_field
     add_bundle_dir(selfdir + "bundle", "app")
     deploy(selfdir + "/app")
-    start
+    start(600)
   
     feed_and_wait_for_docs('passage', 1, :file => selfdir + "data/feed.jsonl")
     

--- a/tests/performance/feeding_generate_local_llm/app/services.xml
+++ b/tests/performance/feeding_generate_local_llm/app/services.xml
@@ -12,8 +12,8 @@
                 <contextSize>5000</contextSize>
                 <parallelRequests>10</parallelRequests>
                 <maxQueueSize>5</maxQueueSize>
-                <maxQueueWait>100000</maxQueueWait>
-                <maxEnqueueWait>100000</maxEnqueueWait>
+                <maxQueueWait>200000</maxQueueWait>
+                <maxEnqueueWait>200000</maxEnqueueWait>
                 <maxTokens>200</maxTokens>
                 <maxPromptTokens>200</maxPromptTokens>
             </config>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This should prevent failing tests with new jllama.cpp.
Previous timeouts were a bit too tight.
New jllama.cpp seems to have higher throughput but higher latency deviation.