### PR TITLE
Temporarily disable AVX3_DL to see effects on CPU power license levels, if any

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -6,7 +6,7 @@
                 {
                     "value" : [
                         "VESPA_BITVECTOR_RANGE_CHECK=true",
-                        "VESPA_INTERNAL_VECTORIZATION_TARGET_LEVEL=AVX3_DL"
+                        "VESPA_INTERNAL_VECTORIZATION_TARGET_LEVEL=AVX3"
                     ]
                 }
             ]

--- a/tests/performance/grouping/grouping.rb
+++ b/tests/performance/grouping/grouping.rb
@@ -99,7 +99,7 @@ class GroupingTest < PerformanceTest
     perf_dump = ""
     perf_t = Thread.new {
       proton_pid = vespa.search['search'].first.get_pid()
-      perf_stat_cmd = "perf stat -I 2000 --pid=#{proton_pid} -e '" +
+      perf_stat_cmd = "perf stat -I 1000 --pid=#{proton_pid} -e '" +
                       "cpu/event=0x28,umask=0x18,name=core_power_lvl1_turbo_license/," +
                       "cpu/event=0x28,umask=0x20,name=core_power_lvl2_turbo_license/' sleep 30 2>&1"
       perf_dump = vespa.search['search'].first.execute(perf_stat_cmd, :exceptiononfailure => false)


### PR DESCRIPTION
@arnej27959 please review.

According to the `perf stat` output, the CPU is spending a lot of time in power license level 1, which I did not really expect. Let's compare with the baseline to see what shade of red this particular herring has.

Also, dump cycle stats every second instead of every 2 seconds.