### PR TITLE
Add flat `perf record` output around `fbench` in test

### DIFF
--- a/tests/performance/grouping/grouping.rb
+++ b/tests/performance/grouping/grouping.rb
@@ -98,11 +98,29 @@ class GroupingTest < PerformanceTest
     # at certain AVX-512 instructions in the wrong way.
     perf_dump = ""
     perf_t = Thread.new {
-      proton_pid = vespa.search['search'].first.get_pid()
-      perf_stat_cmd = "perf stat -I 1000 --pid=#{proton_pid} -e '" +
-                      "cpu/event=0x28,umask=0x18,name=core_power_lvl1_turbo_license/," +
-                      "cpu/event=0x28,umask=0x20,name=core_power_lvl2_turbo_license/' sleep 30 2>&1"
-      perf_dump = vespa.search['search'].first.execute(perf_stat_cmd, :exceptiononfailure => false)
+      search_node = vespa.search['search'].first
+      proton_pid = search_node.get_pid
+      if search_node.execute('uname -m').strip == 'x86_64'
+        perf_stat_cmd = "perf stat -I 1000 --pid=#{proton_pid} -e '" +
+                        "cpu/event=0x28,umask=0x07,name=core_power_lvl0_turbo_license/," +
+                        "cpu/event=0x28,umask=0x18,name=core_power_lvl1_turbo_license/," +
+                        "cpu/event=0x28,umask=0x20,name=core_power_lvl2_turbo_license/' sleep 15 2>&1"
+        search_node.execute(perf_stat_cmd, :exceptiononfailure => false) # Just dump to test output
+      else
+        puts "Search node is not running on an x86-64 CPU, not dumping power license PMUs"
+      end
+      perf_tmp_file = search_node.create_unique_temp_file('perf')
+      perf_report_out_file = search_node.create_unique_temp_file('perf_report')
+      # Only look at user stacks to minimize risk of running into capability problems or
+      # rejections from hypervisors...
+      # TODO `--call-graph`
+      perf_record_cmd = "perf record -a --pid=#{proton_pid} --user-callchains -o #{perf_tmp_file} sleep 30"
+      # TODO `--call-graph='graph,0.01,caller'`, but that output is so large (and wide!),
+      #   we probably need to attach it as a separate report file on factory (see below).
+      perf_report_cmd = "perf report --stdio --stdio-color=never -i #{perf_tmp_file} | head -200 > #{perf_report_out_file}"
+      search_node.execute(perf_record_cmd)
+      search_node.execute(perf_report_cmd)
+      perf_dump = search_node.readfile(perf_report_out_file) # Expected to be fairly bounded in size
     }
     run_fbench(qrserver, 1, 60, [parameter_filler("legend", "single_level")])
     node = vespa.search["search"].first
@@ -110,8 +128,9 @@ class GroupingTest < PerformanceTest
                   parameter_filler("legend", "single_level")])
     puts "Single level mem usage: #{node.memusage_rss(node.get_pid)}"
     perf_t.join
-    puts "Perf stat output:"
+    puts "Perf output:"
     puts perf_dump
+    # TODO if call-graph: attach_to_factory_report('my_perf_output', perf_dump)
 
     File.open(@local_queryfile, "w") { |file|
       file.write("/search/?query=sddocname:groupingbench&nocache&hits=0&" +


### PR DESCRIPTION
@arnej27959 please review. Adds `perf record/report` output and also adds level 0 power license cycle counting to have more numbers to compare.

Xeon power license PMUs are still tracked, but only for the first 15 seconds. Also predicate PMU `perf stat` on the underlying CPU being x86-64. Just skip it entirely otherwise.

