### PR TITLE
stop using File.exists

### DIFF
--- a/lib/performance_test.rb
+++ b/lib/performance_test.rb
@@ -497,7 +497,7 @@ class PerformanceTest < TestCase
   # If the file already exists in the test directory, use that directly instead.
   def download_file_from_s3(file_name, vespa_node, dir = "")
     url = "https://data.vespa-cloud.com/tests/performance/#{dir}"
-    if File.exists?(selfdir + file_name)
+    if File.exist?(selfdir + file_name)
       # Place the file in the test directory to avoid downloading during manual testing.
       puts "Using local file #{file_name}"
       selfdir + file_name

--- a/tests/performance/ecommerce_hybrid_search/ecommerce_hybrid_search_base.rb
+++ b/tests/performance/ecommerce_hybrid_search/ecommerce_hybrid_search_base.rb
@@ -18,7 +18,7 @@ class EcommerceHybridSearchTestBase < PerformanceTest
   end
 
   def download_file(file_name, vespa_node, url="https://data.vespa-cloud.com/tests/performance/ecommerce_hybrid_search")
-    if File.exists?(selfdir + file_name)
+    if File.exist?(selfdir + file_name)
       # Place the file in the test directory to avoid downloading during manual testing.
       puts "Using local file: #{file_name}"
       selfdir + file_name


### PR DESCRIPTION
File.exists? is an alias for File.exist? that is removed in newer ruby versions.

@hmusum please review
