### PR TITLE
Test filter-first heuristic in ANN performance tests

### DIFF
--- a/tests/performance/nearest_neighbor/NearestNeighborRecallSearcher.java
+++ b/tests/performance/nearest_neighbor/NearestNeighborRecallSearcher.java
@@ -61,17 +61,17 @@ public class NearestNeighborRecallSearcher extends Searcher {
             int exploreHits = props.getInteger("nnr.exploreHits", 0);
             long filterPercent = props.getLong("nnr.filterPercent", 0L);
             double approximateThreshold = Double.parseDouble(props.getString("nnr.approximateThreshold", "0.05"));
-            double acornOneThreshold = Double.parseDouble(props.getString("nnr.acornOneThreshold", "0.00"));
-            double acornOneExploration = Double.parseDouble(props.getString("nnr.acornOneExploration", "0.01"));
+            double filterFirstThreshold = Double.parseDouble(props.getString("nnr.filterFirstThreshold", "0.00"));
+            double filterFirstExploration = Double.parseDouble(props.getString("nnr.filterFirstExploration", "0.01"));
             String idField = props.getString("nnr.idField", "id");
             log.log(Level.FINE, "NNRS.search(): docTensor=" + docTensor +
                     ", queryTensor=" + queryTensor + ", targetHits=" + targetHits +
                     ", exploreHits=" + exploreHits + ", idField=" + idField);
             var exactHits = executeNearestNeighborQuery(query, execution,
-                    docTensor, queryTensor, label, targetHits, exploreHits, filterPercent, approximateThreshold, acornOneThreshold, acornOneExploration, false, idField);
+                    docTensor, queryTensor, label, targetHits, exploreHits, filterPercent, approximateThreshold, filterFirstThreshold, filterFirstExploration, false, idField);
 
             var approxHits = executeNearestNeighborQuery(query, execution,
-                    docTensor, queryTensor, label, targetHits, exploreHits, filterPercent, approximateThreshold, acornOneThreshold, acornOneExploration, true, idField);
+                    docTensor, queryTensor, label, targetHits, exploreHits, filterPercent, approximateThreshold, filterFirstThreshold, filterFirstExploration, true, idField);
 
             try {
                 int recall = calcRecall(exactHits, approxHits, targetHits);
@@ -101,7 +101,7 @@ public class NearestNeighborRecallSearcher extends Searcher {
                                                         String docTensor, String queryTensor,
                                                         String label,
                                                         int targetHits, int exploreHits, long filterPercent,
-                                                        double approximateThreshold, double acornOneThreshold, double acornOneExploration,
+                                                        double approximateThreshold, double filterFirstThreshold, double filterFirstExploration,
                                                         boolean approximate, String idField) {
         var nni = new NearestNeighborItem(docTensor, queryTensor);
         nni.setLabel(label);
@@ -127,8 +127,8 @@ public class NearestNeighborRecallSearcher extends Searcher {
         query.setHits(targetHits);
 
         query.properties().set("ranking.matching.approximateThreshold", approximateThreshold);
-        query.properties().set("ranking.matching.acornOneThreshold", acornOneThreshold);
-        query.properties().set("ranking.matching.acornOneExploration", acornOneExploration);
+        query.properties().set("ranking.matching.filterFirstThreshold", filterFirstThreshold);
+        query.properties().set("ranking.matching.filterFirstExploration", filterFirstExploration);
 
         var vespaChain = parentExecution.searchChainRegistry().getComponent("vespa");
         var execution = new Execution(vespaChain, parentExecution.context());

--- a/tests/performance/nearest_neighbor/NearestNeighborRecallSearcher.java
+++ b/tests/performance/nearest_neighbor/NearestNeighborRecallSearcher.java
@@ -59,7 +59,7 @@ public class NearestNeighborRecallSearcher extends Searcher {
             String label = props.getString("nnr.label", "nns");
             int targetHits = props.getInteger("nnr.targetHits", 10);
             int exploreHits = props.getInteger("nnr.exploreHits", 0);
-            long filterPercent = props.getLong("nnr.filterPercent", 0L);
+            int filterPercent = props.getInteger("nnr.filterPercent", 0);
             double approximateThreshold = Double.parseDouble(props.getString("nnr.approximateThreshold", "0.05"));
             double filterFirstThreshold = Double.parseDouble(props.getString("nnr.filterFirstThreshold", "0.00"));
             double filterFirstExploration = Double.parseDouble(props.getString("nnr.filterFirstExploration", "0.01"));
@@ -100,7 +100,7 @@ public class NearestNeighborRecallSearcher extends Searcher {
     private List<SimpleHit> executeNearestNeighborQuery(Query parentQuery, Execution parentExecution,
                                                         String docTensor, String queryTensor,
                                                         String label,
-                                                        int targetHits, int exploreHits, long filterPercent,
+                                                        int targetHits, int exploreHits, int filterPercent,
                                                         double approximateThreshold, double filterFirstThreshold, double filterFirstExploration,
                                                         boolean approximate, String idField) {
         var nni = new NearestNeighborItem(docTensor, queryTensor);

--- a/tests/performance/nearest_neighbor/ann_gist_base.rb
+++ b/tests/performance/nearest_neighbor/ann_gist_base.rb
@@ -33,12 +33,12 @@ class AnnGistBase < CommonSiftGistBase
       query_and_benchmark(BRUTE_FORCE, 100, 0, filter_percent)
       # Standard HNSW
       query_and_benchmark(HNSW, 100, 0, filter_percent)
-      # Now with ACORN-1 enabled
+      # Now with filter-first heuristic enabled
       query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.40, 0.01)
 
       # Recall for standard HNSW
       calc_recall_for_queries(100, 0, filter_percent)
-      # Recall for ACORN-1
+      # Recall for filter-first heuristic
       calc_recall_for_queries(100, 0, filter_percent, 0.00, 0.40, 0.01)
     end
   end

--- a/tests/performance/nearest_neighbor/ann_gist_base.rb
+++ b/tests/performance/nearest_neighbor/ann_gist_base.rb
@@ -30,14 +30,16 @@ class AnnGistBase < CommonSiftGistBase
     run_target_hits_10_tests
 
     [1, 10, 50, 90, 95, 99].each do |filter_percent|
-      query_and_benchmark(HNSW, 100, 0, filter_percent)
       query_and_benchmark(BRUTE_FORCE, 100, 0, filter_percent)
-    end
-
-    # Now with ACORN-1
-    [1, 10, 50, 90, 95, 99].each do |filter_percent|
+      # Standard HNSW
+      query_and_benchmark(HNSW, 100, 0, filter_percent)
+      # Now with ACORN-1 enabled
       query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.40, 0.01)
-      query_and_benchmark(BRUTE_FORCE, 100, 0, filter_percent, 0.00, 0.40, 0.01)
+
+      # Recall for standard HNSW
+      calc_recall_for_queries(100, 0, filter_percent)
+      # Recall for ACORN-1
+      calc_recall_for_queries(100, 0, filter_percent, 0.00, 0.40, 0.01)
     end
   end
 

--- a/tests/performance/nearest_neighbor/ann_gist_base.rb
+++ b/tests/performance/nearest_neighbor/ann_gist_base.rb
@@ -23,15 +23,21 @@ class AnnGistBase < CommonSiftGistBase
 
     feed_and_benchmark(@docs_300k, "300k-docs")
 
-    query_and_benchmark(BRUTE_FORCE, 10, 0, 0, 1)
+    query_and_benchmark(BRUTE_FORCE, 10, 0)
 
     prepare_queries_for_recall
 
     run_target_hits_10_tests
 
     [1, 10, 50, 90, 95, 99].each do |filter_percent|
-      query_and_benchmark(HNSW, 100, 0, filter_percent, 1)
-      query_and_benchmark(BRUTE_FORCE, 100, 0, filter_percent, 1)
+      query_and_benchmark(HNSW, 100, 0, filter_percent)
+      query_and_benchmark(BRUTE_FORCE, 100, 0, filter_percent)
+    end
+
+    # Now with ACORN-1
+    [1, 10, 50, 90, 95, 99].each do |filter_percent|
+      query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.40, 0.01)
+      query_and_benchmark(BRUTE_FORCE, 100, 0, filter_percent, 0.00, 0.40, 0.01)
     end
   end
 

--- a/tests/performance/nearest_neighbor/ann_sift_base.rb
+++ b/tests/performance/nearest_neighbor/ann_sift_base.rb
@@ -40,12 +40,12 @@ class AnnSiftBase < CommonSiftGistBase
       query_and_benchmark(BRUTE_FORCE, 100, 0, filter_percent)
       # Standard HNSW
       query_and_benchmark(HNSW, 100, 0, filter_percent)
-      # Now with ACORN-1 enabled
+      # Now with filter-first heuristic enabled
       query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.20, 0.01)
 
       # Recall for standard HNSW
       calc_recall_for_queries(100, 0, filter_percent)
-      # Recall for ACORN-1
+      # Recall for filter-first heuristic
       calc_recall_for_queries(100, 0, filter_percent, 0.00, 0.20, 0.01)
     end
 
@@ -53,7 +53,7 @@ class AnnSiftBase < CommonSiftGistBase
       [1, 2, 4, 8, 16].each do |threads|
         # Standard HNSW
         query_and_benchmark(HNSW, 100, 0, 10, 0.05, 0.0, 0.0, 1, threads)
-        # Now with ACORN-1 enabled
+        # Now with filter-first heuristic enabled
         query_and_benchmark(HNSW, 100, 0, 10, 0.00, 0.20, 0.01, 1, threads)
       end
     end

--- a/tests/performance/nearest_neighbor/ann_sift_base.rb
+++ b/tests/performance/nearest_neighbor/ann_sift_base.rb
@@ -30,20 +30,31 @@ class AnnSiftBase < CommonSiftGistBase
 
     feed_and_benchmark((mixed_tensor ? @docs_mixed_1M : @docs_1M), "1M-docs")
 
-    query_and_benchmark(BRUTE_FORCE, 10, 0, 0, 1)
+    query_and_benchmark(BRUTE_FORCE, 10, 0)
 
     prepare_queries_for_recall
 
     run_target_hits_10_tests
 
     [1, 10, 50, 90, 95, 99].each do |filter_percent|
-      query_and_benchmark(HNSW, 100, 0, filter_percent, 1)
-      query_and_benchmark(BRUTE_FORCE, 100, 0, filter_percent, 1)
+      query_and_benchmark(HNSW, 100, 0, filter_percent)
+      query_and_benchmark(BRUTE_FORCE, 100, 0, filter_percent)
+    end
+
+    # Now with ACORN-1
+    [1, 10, 50, 90, 95, 99].each do |filter_percent|
+      query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.20, 0.01)
+      query_and_benchmark(BRUTE_FORCE, 100, 0, filter_percent, 0.00, 0.20, 0.01)
     end
 
     if test_threads_per_search
       [1, 2, 4, 8, 16].each do |threads|
-        query_and_benchmark(HNSW, 100, 0, 10, 1, threads)
+        query_and_benchmark(HNSW, 100, 0, 10, 0.05, 0.00, 0.01, 1, threads)
+      end
+
+      # Now with ACORN-1
+      [1, 2, 4, 8, 16].each do |threads|
+        query_and_benchmark(HNSW, 100, 0, 10, 0.00, 0.20, 0.01, 1, threads)
       end
     end
 

--- a/tests/performance/nearest_neighbor/ann_sift_base.rb
+++ b/tests/performance/nearest_neighbor/ann_sift_base.rb
@@ -37,23 +37,23 @@ class AnnSiftBase < CommonSiftGistBase
     run_target_hits_10_tests
 
     [1, 10, 50, 90, 95, 99].each do |filter_percent|
-      query_and_benchmark(HNSW, 100, 0, filter_percent)
       query_and_benchmark(BRUTE_FORCE, 100, 0, filter_percent)
-    end
-
-    # Now with ACORN-1
-    [1, 10, 50, 90, 95, 99].each do |filter_percent|
+      # Standard HNSW
+      query_and_benchmark(HNSW, 100, 0, filter_percent)
+      # Now with ACORN-1 enabled
       query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.20, 0.01)
-      query_and_benchmark(BRUTE_FORCE, 100, 0, filter_percent, 0.00, 0.20, 0.01)
+
+      # Recall for standard HNSW
+      calc_recall_for_queries(100, 0, filter_percent)
+      # Recall for ACORN-1
+      calc_recall_for_queries(100, 0, filter_percent, 0.00, 0.20, 0.01)
     end
 
     if test_threads_per_search
       [1, 2, 4, 8, 16].each do |threads|
-        query_and_benchmark(HNSW, 100, 0, 10, 0.05, 0.00, 0.01, 1, threads)
-      end
-
-      # Now with ACORN-1
-      [1, 2, 4, 8, 16].each do |threads|
+        # Standard HNSW
+        query_and_benchmark(HNSW, 100, 0, 10, 0.05, 0.0, 0.0, 1, threads)
+        # Now with ACORN-1 enabled
         query_and_benchmark(HNSW, 100, 0, 10, 0.00, 0.20, 0.01, 1, threads)
       end
     end

--- a/tests/performance/nearest_neighbor/ann_sift_base.rb
+++ b/tests/performance/nearest_neighbor/ann_sift_base.rb
@@ -42,11 +42,15 @@ class AnnSiftBase < CommonSiftGistBase
       query_and_benchmark(HNSW, 100, 0, filter_percent)
       # Now with filter-first heuristic enabled
       query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.20, 0.01)
+      # Increased exploration
+      query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.20, 0.012)
 
       # Recall for standard HNSW
       calc_recall_for_queries(100, 0, filter_percent)
       # Recall for filter-first heuristic
       calc_recall_for_queries(100, 0, filter_percent, 0.00, 0.20, 0.01)
+      # Increased exploration
+      calc_recall_for_queries(100, 0, filter_percent, 0.00, 0.20, 0.012)
     end
 
     if test_threads_per_search

--- a/tests/performance/nearest_neighbor/common_ann_base.rb
+++ b/tests/performance/nearest_neighbor/common_ann_base.rb
@@ -13,8 +13,8 @@ class CommonAnnBaseTest < PerformanceTest
   EXPLORE_HITS = "explore_hits"
   FILTER_PERCENT = "filter_percent"
   APPROXIMATE_THRESHOLD = "approximate_threshold"
-  ACORN_ONE_THRESHOLD = "acorn_one_threshold"
-  ACORN_ONE_EXPLORATION = "acorn_one_exploration"
+  FILTER_FIRST_THRESHOLD = "filter_first_threshold"
+  FILTER_FIRST_EXPLORATION = "filter_first_exploration"
   HNSW = "hnsw"
   BRUTE_FORCE = "brute_force"
   RECALL_AVG = "recall.avg"
@@ -67,8 +67,8 @@ class CommonAnnBaseTest < PerformanceTest
     fetch_file_to_localhost(@query_vectors, @local_query_vectors)
   end
 
-  def calc_recall_for_queries(target_hits, explore_hits, filter_percent = 0, approximate_threshold = 0.05, acorn_one_threshold = 0.0, acorn_one_exploration = 0.01, doc_type = "test", doc_tensor = "vec_m16", query_tensor = "q_vec")
-    puts "calc_recall_for_queries: target_hits=#{target_hits}, explore_hits=#{explore_hits}, filter_percent=#{filter_percent}, approximate_threshold=#{approximate_threshold}, acorn_one_threshold=#{acorn_one_threshold}, acorn_one_exploration=#{acorn_one_exploration}, doc_type=#{doc_type}, doc_tensor=#{doc_tensor}, query_tensor=#{query_tensor}"
+  def calc_recall_for_queries(target_hits, explore_hits, filter_percent = 0, approximate_threshold = 0.05, filter_first_threshold = 0.0, filter_first_exploration = 0.01, doc_type = "test", doc_tensor = "vec_m16", query_tensor = "q_vec")
+    puts "calc_recall_for_queries: target_hits=#{target_hits}, explore_hits=#{explore_hits}, filter_percent=#{filter_percent}, approximate_threshold=#{approximate_threshold}, filter_first_threshold=#{filter_first_threshold}, filter_first_exploration=#{filter_first_exploration}, doc_type=#{doc_type}, doc_tensor=#{doc_tensor}, query_tensor=#{query_tensor}"
     result = RecallResult.new(target_hits)
     vectors = []
     num_threads = 5
@@ -83,27 +83,27 @@ class CommonAnnBaseTest < PerformanceTest
     threads = []
     for i in 0...num_threads
       threads << Thread.new(batches[i]) do |batch|
-        calc_recall_for_query_batch(target_hits, explore_hits, filter_percent, approximate_threshold, acorn_one_threshold, acorn_one_exploration, batch, result, doc_type, doc_tensor, query_tensor)
+        calc_recall_for_query_batch(target_hits, explore_hits, filter_percent, approximate_threshold, filter_first_threshold, filter_first_exploration, batch, result, doc_type, doc_tensor, query_tensor)
       end
     end
     threads.each(&:join)
     puts "recall: avg=#{result.avg}, median=#{result.median}, min=#{result.min}, max=#{result.max}, size=#{result.size}, samples_sorted=[#{result.samples.sort.join(',')}], samples=[#{result.samples.join(',')}]"
-    label = "hnsw-th#{target_hits}-eh#{explore_hits}-f#{filter_percent}-at#{approximate_threshold}-aot#{acorn_one_threshold}-aoe#{acorn_one_exploration}"
+    label = "hnsw-th#{target_hits}-eh#{explore_hits}-f#{filter_percent}-at#{approximate_threshold}-fft#{filter_first_threshold}-ffe#{filter_first_exploration}"
     write_report([parameter_filler(TYPE, "recall"),
                   parameter_filler(LABEL, label),
                   parameter_filler(TARGET_HITS, target_hits),
                   parameter_filler(EXPLORE_HITS, explore_hits),
                   parameter_filler(FILTER_PERCENT, filter_percent),
                   parameter_filler(APPROXIMATE_THRESHOLD, approximate_threshold),
-                  parameter_filler(ACORN_ONE_THRESHOLD, acorn_one_threshold),
-                  parameter_filler(ACORN_ONE_EXPLORATION, acorn_one_exploration),
+                  parameter_filler(FILTER_FIRST_THRESHOLD, filter_first_threshold),
+                  parameter_filler(FILTER_FIRST_EXPLORATION, filter_first_exploration),
                   metric_filler(RECALL_AVG, result.avg),
                   metric_filler(RECALL_MEDIAN, result.median)])
   end
 
-  def calc_recall_for_query_batch(target_hits, explore_hits, filter_percent, approximate_threshold, acorn_one_threshold, acorn_one_exploration, vectors, result, doc_type, doc_tensor, query_tensor)
+  def calc_recall_for_query_batch(target_hits, explore_hits, filter_percent, approximate_threshold, filter_first_threshold, filter_first_exploration, vectors, result, doc_type, doc_tensor, query_tensor)
     vectors.each do |vector|
-      raw_recall = calc_recall_in_searcher(target_hits, explore_hits, filter_percent, approximate_threshold, acorn_one_threshold, acorn_one_exploration, vector, doc_type, doc_tensor, query_tensor)
+      raw_recall = calc_recall_in_searcher(target_hits, explore_hits, filter_percent, approximate_threshold, filter_first_threshold, filter_first_exploration, vector, doc_type, doc_tensor, query_tensor)
       result.add(raw_recall)
     end
   end
@@ -114,8 +114,8 @@ class CommonAnnBaseTest < PerformanceTest
     proxy_node.copy_remote_file_to_local_file(proxy_file, local_file)
   end
 
-  def calc_recall_in_searcher(target_hits, explore_hits, filter_percent, approximate_threshold, acorn_one_threshold, acorn_one_exploration, query_vector, doc_type, doc_tensor, query_tensor)
-    query = get_query_for_recall_searcher(target_hits, explore_hits, filter_percent, approximate_threshold, acorn_one_threshold, acorn_one_exploration, query_vector, doc_type, doc_tensor, query_tensor)
+  def calc_recall_in_searcher(target_hits, explore_hits, filter_percent, approximate_threshold, filter_first_threshold, filter_first_exploration, query_vector, doc_type, doc_tensor, query_tensor)
+    query = get_query_for_recall_searcher(target_hits, explore_hits, filter_percent, approximate_threshold, filter_first_threshold, filter_first_exploration, query_vector, doc_type, doc_tensor, query_tensor)
     result = search_with_timeout(20, query)
     assert_hitcount(result, 1)
     hit = result.hit[0]
@@ -127,10 +127,10 @@ class CommonAnnBaseTest < PerformanceTest
     recall.to_i
   end
 
-  def get_query_for_recall_searcher(target_hits, explore_hits, filter_percent, approximate_threshold, acorn_one_threshold, acorn_one_exploration, query_vector, doc_type, doc_tensor, query_tensor)
+  def get_query_for_recall_searcher(target_hits, explore_hits, filter_percent, approximate_threshold, filter_first_threshold, filter_first_exploration, query_vector, doc_type, doc_tensor, query_tensor)
     "query=sddocname:#{doc_type}&summary=minimal&ranking.features.query(#{query_tensor})=#{query_vector}" +
     "&nnr.enable=true&nnr.docTensor=#{doc_tensor}&nnr.targetHits=#{target_hits}&nnr.exploreHits=#{explore_hits}&nnr.filterPercent=#{filter_percent}" +
-    "&nnr.approximateThreshold=#{approximate_threshold}&nnr.acornOneThreshold=#{acorn_one_threshold}&nnr.acornOneExploration=#{acorn_one_exploration}" +
+    "&nnr.approximateThreshold=#{approximate_threshold}&nnr.filterFirstThreshold=#{filter_first_threshold}&nnr.filterFirstExploration=#{filter_first_exploration}" +
     "&nnr.queryTensor=#{query_tensor}"
   end
 

--- a/tests/performance/nearest_neighbor/common_ann_base.rb
+++ b/tests/performance/nearest_neighbor/common_ann_base.rb
@@ -11,10 +11,10 @@ class CommonAnnBaseTest < PerformanceTest
   ALGORITHM = "algorithm"
   TARGET_HITS = "target_hits"
   EXPLORE_HITS = "explore_hits"
+  FILTER_PERCENT = "filter_percent"
   APPROXIMATE_THRESHOLD = "approximate_threshold"
   ACORN_ONE_THRESHOLD = "acorn_one_threshold"
   ACORN_ONE_EXPLORATION = "acorn_one_exploration"
-  FILTER_PERCENT = "filter_percent"
   HNSW = "hnsw"
   BRUTE_FORCE = "brute_force"
   RECALL_AVG = "recall.avg"
@@ -67,8 +67,8 @@ class CommonAnnBaseTest < PerformanceTest
     fetch_file_to_localhost(@query_vectors, @local_query_vectors)
   end
 
-  def calc_recall_for_queries(target_hits, explore_hits, approximate_threshold = 0.05, acorn_one_threshold = 0.0, acorn_one_exploration = 0.01, doc_type = "test", doc_tensor = "vec_m16", query_tensor = "q_vec")
-    puts "calc_recall_for_queries: target_hits=#{target_hits}, explore_hits=#{explore_hits}, approximate_threshold=#{approximate_threshold}, acorn_one_threshold=#{acorn_one_threshold}, acorn_one_exploration=#{acorn_one_exploration}, doc_type=#{doc_type}, doc_tensor=#{doc_tensor}, query_tensor=#{query_tensor}"
+  def calc_recall_for_queries(target_hits, explore_hits, filter_percent = 0, approximate_threshold = 0.05, acorn_one_threshold = 0.0, acorn_one_exploration = 0.01, doc_type = "test", doc_tensor = "vec_m16", query_tensor = "q_vec")
+    puts "calc_recall_for_queries: target_hits=#{target_hits}, explore_hits=#{explore_hits}, filter_percent=#{filter_percent}, approximate_threshold=#{approximate_threshold}, acorn_one_threshold=#{acorn_one_threshold}, acorn_one_exploration=#{acorn_one_exploration}, doc_type=#{doc_type}, doc_tensor=#{doc_tensor}, query_tensor=#{query_tensor}"
     result = RecallResult.new(target_hits)
     vectors = []
     num_threads = 5
@@ -83,16 +83,17 @@ class CommonAnnBaseTest < PerformanceTest
     threads = []
     for i in 0...num_threads
       threads << Thread.new(batches[i]) do |batch|
-        calc_recall_for_query_batch(target_hits, explore_hits, approximate_threshold, acorn_one_threshold, acorn_one_exploration, batch, result, doc_type, doc_tensor, query_tensor)
+        calc_recall_for_query_batch(target_hits, explore_hits, filter_percent, approximate_threshold, acorn_one_threshold, acorn_one_exploration, batch, result, doc_type, doc_tensor, query_tensor)
       end
     end
     threads.each(&:join)
     puts "recall: avg=#{result.avg}, median=#{result.median}, min=#{result.min}, max=#{result.max}, size=#{result.size}, samples_sorted=[#{result.samples.sort.join(',')}], samples=[#{result.samples.join(',')}]"
-    label = "th#{target_hits}-eh#{explore_hits}"
+    label = "hnsw-th#{target_hits}-eh#{explore_hits}-f#{filter_percent}-at#{approximate_threshold}-aot#{acorn_one_threshold}-aoe#{acorn_one_exploration}"
     write_report([parameter_filler(TYPE, "recall"),
                   parameter_filler(LABEL, label),
                   parameter_filler(TARGET_HITS, target_hits),
                   parameter_filler(EXPLORE_HITS, explore_hits),
+                  parameter_filler(FILTER_PERCENT, filter_percent),
                   parameter_filler(APPROXIMATE_THRESHOLD, approximate_threshold),
                   parameter_filler(ACORN_ONE_THRESHOLD, acorn_one_threshold),
                   parameter_filler(ACORN_ONE_EXPLORATION, acorn_one_exploration),
@@ -100,9 +101,9 @@ class CommonAnnBaseTest < PerformanceTest
                   metric_filler(RECALL_MEDIAN, result.median)])
   end
 
-  def calc_recall_for_query_batch(target_hits, explore_hits, approximate_threshold, acorn_one_threshold, acorn_one_exploration, vectors, result, doc_type, doc_tensor, query_tensor)
+  def calc_recall_for_query_batch(target_hits, explore_hits, filter_percent, approximate_threshold, acorn_one_threshold, acorn_one_exploration, vectors, result, doc_type, doc_tensor, query_tensor)
     vectors.each do |vector|
-      raw_recall = calc_recall_in_searcher(target_hits, explore_hits, approximate_threshold, acorn_one_threshold, acorn_one_exploration, vector, doc_type, doc_tensor, query_tensor)
+      raw_recall = calc_recall_in_searcher(target_hits, explore_hits, filter_percent, approximate_threshold, acorn_one_threshold, acorn_one_exploration, vector, doc_type, doc_tensor, query_tensor)
       result.add(raw_recall)
     end
   end
@@ -113,8 +114,8 @@ class CommonAnnBaseTest < PerformanceTest
     proxy_node.copy_remote_file_to_local_file(proxy_file, local_file)
   end
 
-  def calc_recall_in_searcher(target_hits, explore_hits, approximate_threshold, acorn_one_threshold, acorn_one_exploration, query_vector, doc_type, doc_tensor, query_tensor)
-    query = get_query_for_recall_searcher(target_hits, explore_hits, approximate_threshold, acorn_one_threshold, acorn_one_exploration, query_vector, doc_type, doc_tensor, query_tensor)
+  def calc_recall_in_searcher(target_hits, explore_hits, filter_percent, approximate_threshold, acorn_one_threshold, acorn_one_exploration, query_vector, doc_type, doc_tensor, query_tensor)
+    query = get_query_for_recall_searcher(target_hits, explore_hits, filter_percent, approximate_threshold, acorn_one_threshold, acorn_one_exploration, query_vector, doc_type, doc_tensor, query_tensor)
     result = search_with_timeout(20, query)
     assert_hitcount(result, 1)
     hit = result.hit[0]
@@ -126,9 +127,9 @@ class CommonAnnBaseTest < PerformanceTest
     recall.to_i
   end
 
-  def get_query_for_recall_searcher(target_hits, explore_hits, approximate_threshold, acorn_one_threshold, acorn_one_exploration, query_vector, doc_type, doc_tensor, query_tensor)
+  def get_query_for_recall_searcher(target_hits, explore_hits, filter_percent, approximate_threshold, acorn_one_threshold, acorn_one_exploration, query_vector, doc_type, doc_tensor, query_tensor)
     "query=sddocname:#{doc_type}&summary=minimal&ranking.features.query(#{query_tensor})=#{query_vector}" +
-    "&nnr.enable=true&nnr.docTensor=#{doc_tensor}&nnr.targetHits=#{target_hits}&nnr.exploreHits=#{explore_hits}" +
+    "&nnr.enable=true&nnr.docTensor=#{doc_tensor}&nnr.targetHits=#{target_hits}&nnr.exploreHits=#{explore_hits}&nnr.filterPercent=#{filter_percent}" +
     "&nnr.approximateThreshold=#{approximate_threshold}&nnr.acornOneThreshold=#{acorn_one_threshold}&nnr.acornOneExploration=#{acorn_one_exploration}" +
     "&nnr.queryTensor=#{query_tensor}"
   end

--- a/tests/performance/nearest_neighbor/common_ann_base.rb
+++ b/tests/performance/nearest_neighbor/common_ann_base.rb
@@ -88,7 +88,10 @@ class CommonAnnBaseTest < PerformanceTest
     end
     threads.each(&:join)
     puts "recall: avg=#{result.avg}, median=#{result.median}, min=#{result.min}, max=#{result.max}, size=#{result.size}, samples_sorted=[#{result.samples.sort.join(',')}], samples=[#{result.samples.join(',')}]"
-    label = "hnsw-th#{target_hits}-eh#{explore_hits}-f#{filter_percent}-at#{approximate_threshold}-fft#{filter_first_threshold}-ffe#{filter_first_exploration}"
+    label = "th#{target_hits}-eh#{explore_hits}"
+    if filter_percent != 0
+      label = "hnsw-th#{target_hits}-eh#{explore_hits}-f#{filter_percent}-at#{approximate_threshold}-fft#{filter_first_threshold}-ffe#{filter_first_exploration}"
+    end
     write_report([parameter_filler(TYPE, "recall"),
                   parameter_filler(LABEL, label),
                   parameter_filler(TARGET_HITS, target_hits),

--- a/tests/performance/nearest_neighbor/common_mips_base.rb
+++ b/tests/performance/nearest_neighbor/common_mips_base.rb
@@ -23,7 +23,7 @@ class CommonMipsBase < CommonAnnBaseTest
 
     prepare_queries_for_recall()
     [0, 90, 190, 490].each do |explore_hits|
-      calc_recall_for_queries(10, explore_hits, doc_type, "embedding", query_tensor)
+      calc_recall_for_queries(10, explore_hits, 0.05, 0.0, 0.01, doc_type, "embedding", query_tensor)
     end
   end
 

--- a/tests/performance/nearest_neighbor/common_mips_base.rb
+++ b/tests/performance/nearest_neighbor/common_mips_base.rb
@@ -23,7 +23,7 @@ class CommonMipsBase < CommonAnnBaseTest
 
     prepare_queries_for_recall()
     [0, 90, 190, 490].each do |explore_hits|
-      calc_recall_for_queries(10, explore_hits, 0.05, 0.0, 0.01, doc_type, "embedding", query_tensor)
+      calc_recall_for_queries(10, explore_hits, 0, 0.05, 0.0, 0.01, doc_type, "embedding", query_tensor)
     end
   end
 

--- a/tests/performance/nearest_neighbor/common_sift_gist_base.rb
+++ b/tests/performance/nearest_neighbor/common_sift_gist_base.rb
@@ -41,10 +41,10 @@ class CommonSiftGistBase < CommonAnnBaseTest
     (threads_per_search > 0) ? "threads-#{threads_per_search}" : "default"
   end
 
-  def query_and_benchmark(algorithm, target_hits, explore_hits, filter_percent = 0, approximate_threshold = 0.05, acorn_one_threshold = 0.0, acorn_one_exploration = 0.01, clients = 1, threads_per_search = 0)
+  def query_and_benchmark(algorithm, target_hits, explore_hits, filter_percent = 0, approximate_threshold = 0.05, filter_first_threshold = 0.0, filter_first_exploration = 0.01, clients = 1, threads_per_search = 0)
     approximate = algorithm == HNSW ? "true" : "false"
     query_file = fetch_query_file_to_container(approximate, target_hits, explore_hits, filter_percent)
-    label = "#{algorithm}-th#{target_hits}-eh#{explore_hits}-f#{filter_percent}-at#{approximate_threshold}-aot#{acorn_one_threshold}-aoe#{acorn_one_exploration}-n#{clients}-t#{threads_per_search}"
+    label = "#{algorithm}-th#{target_hits}-eh#{explore_hits}-f#{filter_percent}-at#{approximate_threshold}-fft#{filter_first_threshold}-ffe#{filter_first_exploration}-n#{clients}-t#{threads_per_search}"
     result_file = dirs.tmpdir + "fbench_result.#{label}.txt"
     fillers = [parameter_filler(TYPE, get_type_string(filter_percent, threads_per_search)),
                parameter_filler(LABEL, label),
@@ -53,8 +53,8 @@ class CommonSiftGistBase < CommonAnnBaseTest
                parameter_filler(EXPLORE_HITS, explore_hits),
                parameter_filler(FILTER_PERCENT, filter_percent),
                parameter_filler(APPROXIMATE_THRESHOLD, approximate_threshold),
-               parameter_filler(ACORN_ONE_THRESHOLD, acorn_one_threshold),
-               parameter_filler(ACORN_ONE_EXPLORATION, acorn_one_exploration),
+               parameter_filler(FILTER_FIRST_THRESHOLD, filter_first_threshold),
+               parameter_filler(FILTER_FIRST_EXPLORATION, filter_first_exploration),
                parameter_filler(CLIENTS, clients),
                parameter_filler(THREADS_PER_SEARCH, threads_per_search)]
     profiler_start
@@ -62,7 +62,7 @@ class CommonSiftGistBase < CommonAnnBaseTest
                 query_file,
                 {:runtime => FBENCH_TIME,
                  :clients => clients,
-                 :append_str => "&summary=minimal&hits=#{target_hits}&ranking=#{get_rank_profile(threads_per_search)}&ranking.matching.approximateThreshold=#{approximate_threshold}&ranking.matching.acornOneThreshold=#{acorn_one_threshold}&ranking.matching.acornOneExploration=#{acorn_one_exploration}",
+                 :append_str => "&summary=minimal&hits=#{target_hits}&ranking=#{get_rank_profile(threads_per_search)}&ranking.matching.approximateThreshold=#{approximate_threshold}&ranking.matching.filterFirstThreshold=#{filter_first_threshold}&ranking.matching.filterFirstExploration=#{filter_first_exploration}",
                  :result_file => result_file},
                 fillers)
     profiler_report(label)

--- a/tests/performance/nearest_neighbor/gist_test/test.sd
+++ b/tests/performance/nearest_neighbor/gist_test/test.sd
@@ -21,6 +21,9 @@ search test {
     first-phase {
       expression: closeness(label,nns)
     }
+    approximate-threshold: 0.05
+    filter-first-threshold: 0.0
+    filter-first-exploration: 0.01
   }
   document-summary minimal {
     summary id {}

--- a/tests/performance/nearest_neighbor/plot.py
+++ b/tests/performance/nearest_neighbor/plot.py
@@ -1,0 +1,127 @@
+# Copyright Vespa.ai. All rights reserved.
+
+import argparse as ap
+import pandas as pd
+import matplotlib.pyplot as plt
+
+# Remove filter percentage (-f10- for example) from label
+def cleanFilter(label):
+    splitLabel = label.split("-")
+    splitLabel = map(lambda str: str if str[0] != 'f' else "", splitLabel)
+    splitLabel = filter(None, splitLabel)
+
+    return '-'.join(splitLabel)
+
+def read_filtered_queries(jsonObj):
+    response_time = {}
+
+    for row in jsonObj.itertuples():
+        row_type = row.parameters["type"]
+
+        if row_type == "query_filter":
+            label = cleanFilter(row.parameters["label"])
+            filter_percent = int(row.parameters["filter_percent"])
+
+            # Only keep filtered results
+            if filter_percent == 0:
+                continue
+
+            if label not in response_time:
+                response_time[label] = {}
+            response_time[label][filter_percent] = float(row.metrics["avgresponsetime"])
+
+    return response_time
+
+def read_recall_by_filter(jsonObj):
+    recall = {}
+
+    for row in jsonObj.itertuples():
+        row_type = row.parameters["type"]
+
+        if row_type == "recall" and "filter_percent" in row.parameters:
+            label = cleanFilter(row.parameters["label"])
+            filter_percent = int(row.parameters["filter_percent"])
+
+            # Only keep filtered results
+            if filter_percent == 0:
+                continue
+
+            if label not in recall:
+                recall[label] = {}
+            recall[label][filter_percent] = float(row.metrics["recall.avg"])
+
+    return recall
+
+def plotResponseTime(response_time):
+    labels = response_time.keys()
+    later = []
+
+    for label in labels:
+        # Hack: Draw brute_force results in the end to get colors to match in recall plot
+        if "brute_force" in label:
+            later.append(label)
+            continue
+        x = list(response_time[label].keys())
+        y = list(response_time[label].values())
+        plt.plot(x, y, label=label)
+
+    for label in later:
+        x = list(response_time[label].keys())
+        y = list(response_time[label].values())
+        plt.plot(x, y, label=label)
+
+    plt.xlabel("Fraction filtered out (%)")
+    plt.ylabel("Average response time (ms)")
+    plt.title("Response Time/Filtered")
+    plt.legend()
+    axs = plt.gca()
+    axs.set_ylim(ymin=0)
+
+def plotRecall(recall):
+    labels = recall.keys()
+
+    for label in labels:
+        x = list(recall[label].keys())
+        y = list(recall[label].values())
+        plt.plot(x, y, label=label)
+
+    plt.xlabel("Fraction filtered out (%)")
+    plt.ylabel("Average recall")
+    plt.title("Recall/Filtered")
+    plt.legend()
+
+    axs = plt.gca()
+    axs.set_ylim(ymin=0)
+
+def plot(filename, save):
+    jsonObj = pd.read_json(path_or_buf=filename, lines=True)
+
+    # Response time/filtered
+    response_time = read_filtered_queries(jsonObj)
+    if response_time:
+        plt.figure(1)
+        plotResponseTime(response_time)
+        if save:
+            plt.savefig('response_time.png', dpi=300)
+
+    # Recall/filtered
+    recall = read_recall_by_filter(jsonObj)
+    if recall:
+        plt.figure(2)
+        plotRecall(recall)
+        if save:
+            plt.savefig('recall.png', dpi=300)
+
+    plt.show()
+
+def main():
+    parser = ap.ArgumentParser(prog='Plot',
+                               description='Plot results from ANN performance test')
+    parser.add_argument('--file', nargs='?', const="result.jsonl", type=str, default="result.jsonl")
+    parser.add_argument("--save", help="save plots to file", action="store_true")
+    args = parser.parse_args()
+
+    plot(args.file, args.save)
+
+if __name__=="__main__":
+    main()

--- a/tests/performance/nearest_neighbor/plot.py
+++ b/tests/performance/nearest_neighbor/plot.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 # Remove filter percentage (-f10- for example) from label
 def clean_filter(label):
     splitLabel = label.split("-")
-    splitLabel = map(lambda str: str if str[0] != 'f' else "fX", splitLabel)
+    splitLabel = map(lambda str: str if str[0] != 'f' or (str[0] == 'f' and str[1] == 'f') else "fX", splitLabel)
     splitLabel = filter(None, splitLabel)
 
     return '-'.join(splitLabel)
@@ -126,18 +126,19 @@ def read_recall_by_response_time(jsonObj):
             else:
                 already_seen.add(original_label)
 
-            # Extended hits
-            label = clean_extended_hits(original_label)
-            if label not in recall:
-                recall[label] = []
-            recall[label].append((response_time[original_label], float(row.metrics["recall.avg"])))
-
-            # Slack
-            if "slack" in row.parameters:
-                label = clean_slack(original_label)
+            if original_label in recall:
+                # Extended hits
+                label = clean_extended_hits(original_label)
                 if label not in recall:
                     recall[label] = []
                 recall[label].append((response_time[original_label], float(row.metrics["recall.avg"])))
+
+                # Slack
+                if "slack" in row.parameters:
+                    label = clean_slack(original_label)
+                    if label not in recall:
+                        recall[label] = []
+                    recall[label].append((response_time[original_label], float(row.metrics["recall.avg"])))
 
     # Ignore single data points
     return {k: v for k, v in recall.items() if len(v) >= 2}

--- a/tests/performance/nearest_neighbor/sift_test/test.sd
+++ b/tests/performance/nearest_neighbor/sift_test/test.sd
@@ -21,6 +21,9 @@ search test {
     first-phase {
       expression: closeness(label,nns)
     }
+    approximate-threshold: 0.05
+    filter-first-threshold: 0.0
+    filter-first-exploration: 0.01
     num-threads-per-search: 1
   }
   rank-profile threads-1 inherits default {

--- a/tests/performance/nearest_neighbor/sift_test_bfloat16/test.sd
+++ b/tests/performance/nearest_neighbor/sift_test_bfloat16/test.sd
@@ -21,6 +21,9 @@ search test {
     first-phase {
       expression: closeness(label,nns)
     }
+    approximate-threshold: 0.05
+    filter-first-threshold: 0.0
+    filter-first-exploration: 0.01
   }
   document-summary minimal {
     summary id {}

--- a/tests/performance/nearest_neighbor/sift_test_mixed/test.sd
+++ b/tests/performance/nearest_neighbor/sift_test_mixed/test.sd
@@ -21,6 +21,9 @@ search test {
     first-phase {
       expression: closeness(label,nns)
     }
+    approximate-threshold: 0.05
+    filter-first-threshold: 0.0
+    filter-first-exploration: 0.01
   }
   document-summary minimal {
     summary id {}

--- a/tests/performance/nearest_neighbor/unused.gist_bfloat16/test.sd
+++ b/tests/performance/nearest_neighbor/unused.gist_bfloat16/test.sd
@@ -21,6 +21,9 @@ search test {
     first-phase {
       expression: closeness(label,nns)
     }
+    approximate-threshold: 0.05
+    filter-first-threshold: 0.0
+    filter-first-exploration: 0.01
   }
   document-summary minimal {
     summary id {}


### PR DESCRIPTION
Besides benchmarking the response time, we also compute the recall for filtered queries and compare it to the recall without the filter-first heuristic. I also include a python script that can be used to plot the results locally.