### PR TITLE
Revert "Set max-distributor-document-operation-size-mib to 200 MiB"

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -54,8 +54,7 @@
         { "id" : "content-layer-metadata-feature-level", "rules" : [ { "value" : 1 } ] },
         { "id" : "search-core-transaction-log-replay-soft-memory-limit", "rules" : [ { "value" : -5 } ] },
         { "id" : "zookeeper-pre-alloc-size", "rules" : [ { "value" : 16384 } ] },
-        { "id" : "resource-limit-address-space", "rules" : [ { "value" : 0.8 } ] },
-        { "id" : "max-distributor-document-operation-size-mib", "rules" : [ { "value" : 200 } ] }
+        { "id" : "resource-limit-address-space", "rules" : [ { "value" : 0.8 } ] }
     ]
 
 }


### PR DESCRIPTION
Reverts vespa-engine/system-test#4509

No need for this anymore, as default is now 128 MiB