### PR TITLE
Add tests for grouping filter predicates `or()`, `and()` and `not()`

### DIFF
--- a/tests/search/grouping_adv/answers/predicate-1.json
+++ b/tests/search/grouping_adv/answers/predicate-1.json
@@ -1,0 +1,51 @@
+{
+  "root": {
+    "id": "toplevel",
+    "relevance": 1.0,
+    "fields": {
+      "totalCount": 28
+    },
+    "coverage": {
+      "coverage": 100,
+      "documents": 28,
+      "full": true,
+      "nodes": 2,
+      "results": 1,
+      "resultsFull": 1
+    },
+    "children": [
+      {
+        "id": "group:root:0",
+        "relevance": 1.0,
+        "continuation": {
+          "this": ""
+        },
+        "children": [
+          {
+            "id": "grouplist:a",
+            "relevance": 1.0,
+            "label": "a",
+            "children": [
+              {
+                "id": "group:string:a2",
+                "relevance": 11111.709477840308,
+                "value": "a2",
+                "fields": {
+                  "count()": 9
+                }
+              },
+              {
+                "id": "group:string:a3",
+                "relevance": 10011.709521325834,
+                "value": "a3",
+                "fields": {
+                  "count()": 9
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/search/grouping_adv/answers/predicate-2.json
+++ b/tests/search/grouping_adv/answers/predicate-2.json
@@ -1,0 +1,51 @@
+{
+  "root": {
+    "id": "toplevel",
+    "relevance": 1.0,
+    "fields": {
+      "totalCount": 28
+    },
+    "coverage": {
+      "coverage": 100,
+      "documents": 28,
+      "full": true,
+      "nodes": 2,
+      "results": 1,
+      "resultsFull": 1
+    },
+    "children": [
+      {
+        "id": "group:root:0",
+        "relevance": 1.0,
+        "continuation": {
+          "this": ""
+        },
+        "children": [
+          {
+            "id": "grouplist:a",
+            "relevance": 1.0,
+            "label": "a",
+            "children": [
+              {
+                "id": "group:string:a1",
+                "relevance": 12111.719438207627,
+                "value": "a1",
+                "fields": {
+                  "count()": 10
+                }
+              },
+              {
+                "id": "group:string:a2",
+                "relevance": 11111.709477840308,
+                "value": "a2",
+                "fields": {
+                  "count()": 9
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/search/grouping_adv/answers/predicate-3.json
+++ b/tests/search/grouping_adv/answers/predicate-3.json
@@ -1,0 +1,43 @@
+{
+  "root": {
+    "id": "toplevel",
+    "relevance": 1.0,
+    "fields": {
+      "totalCount": 28
+    },
+    "coverage": {
+      "coverage": 100,
+      "documents": 28,
+      "full": true,
+      "nodes": 2,
+      "results": 1,
+      "resultsFull": 1
+    },
+    "children": [
+      {
+        "id": "group:root:0",
+        "relevance": 1.0,
+        "continuation": {
+          "this": ""
+        },
+        "children": [
+          {
+            "id": "grouplist:a",
+            "relevance": 1.0,
+            "label": "a",
+            "children": [
+              {
+                "id": "group:string:a1",
+                "relevance": 4814.61700663273,
+                "value": "a1",
+                "fields": {
+                  "count()": 3
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/search/grouping_adv/grouping_base.rb
+++ b/tests/search/grouping_adv/grouping_base.rb
@@ -257,6 +257,10 @@ module GroupingBase
   end
 
   def querytest_filter
+    check_query('all(group(a) filter(not(regex("^a1$", a))) each(output(count())))', 'predicate-1')
+    check_query('all(group(a) filter(or(regex("^a1$", a),regex("^a2$", a))) each(output(count())))', 'predicate-2')
+    check_query('all(group(a) filter(and(regex("^a*$", s),regex("^b1$", b))) each(output(count())))', 'predicate-3')
+
     check_query('all(group(a) filter(regex("^a1$", a)) each(output(count())))', 'filter-1')
     check_query('all(group(a) filter(regex("^b1$", b)) each(output(count())))', 'filter-2')
     check_query('all(group(a) filter(regex("5\.9", tostring(f))) each(output(count())))', 'filter-3')


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
