### PR TITLE
Test `time` in grouping with timezones

### DIFF
--- a/tests/search/grouping_adv/answers/time.hour.timezone.json
+++ b/tests/search/grouping_adv/answers/time.hour.timezone.json
@@ -1,0 +1,115 @@
+{
+  "root": {
+    "id": "toplevel",
+    "relevance": 1.0,
+    "fields": {
+      "totalCount": 28
+    },
+    "coverage": {
+      "coverage": 100,
+      "documents": 28,
+      "full": true,
+      "nodes": 1,
+      "results": 1,
+      "resultsFull": 1
+    },
+    "children": [
+      {
+        "id": "group:root:0",
+        "relevance": 1.0,
+        "continuation": {
+          "this": ""
+        },
+        "children": [
+          {
+            "id": "grouplist:time.hourofday(from)",
+            "relevance": 1.0,
+            "label": "time.hourofday(from)",
+            "children": [
+              {
+                "id": "group:long:12",
+                "relevance": 12111.719438207627,
+                "value": "12",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:9",
+                "relevance": 11111.709477840308,
+                "value": "9",
+                "fields": {
+                  "count()": 2
+                }
+              },
+              {
+                "id": "group:long:5",
+                "relevance": 10977.31338339293,
+                "value": "5",
+                "fields": {
+                  "count()": 6
+                }
+              },
+              {
+                "id": "group:long:23",
+                "relevance": 9998.214537458838,
+                "value": "23",
+                "fields": {
+                  "count()": 2
+                }
+              },
+              {
+                "id": "group:long:19",
+                "relevance": 9751.807920622134,
+                "value": "19",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:22",
+                "relevance": 9009.325691944365,
+                "value": "22",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:2",
+                "relevance": 8875.610133144828,
+                "value": "2",
+                "fields": {
+                  "count()": 12
+                }
+              },
+              {
+                "id": "group:long:1",
+                "relevance": 7751.494193136243,
+                "value": "1",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:15",
+                "relevance": 2113.5503594784377,
+                "value": "15",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:0",
+                "relevance": 357.87755966891814,
+                "value": "0",
+                "fields": {
+                  "count()": 1
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/search/grouping_adv/answers/time.mday.timezone.json
+++ b/tests/search/grouping_adv/answers/time.mday.timezone.json
@@ -1,0 +1,123 @@
+{
+  "root": {
+    "id": "toplevel",
+    "relevance": 1.0,
+    "fields": {
+      "totalCount": 28
+    },
+    "coverage": {
+      "coverage": 100,
+      "documents": 28,
+      "full": true,
+      "nodes": 1,
+      "results": 1,
+      "resultsFull": 1
+    },
+    "children": [
+      {
+        "id": "group:root:0",
+        "relevance": 1.0,
+        "continuation": {
+          "this": ""
+        },
+        "children": [
+          {
+            "id": "grouplist:time.dayofmonth(from)",
+            "relevance": 1.0,
+            "label": "time.dayofmonth(from)",
+            "children": [
+              {
+                "id": "group:long:8",
+                "relevance": 12111.719438207627,
+                "value": "8",
+                "fields": {
+                  "count()": 2
+                }
+              },
+              {
+                "id": "group:long:27",
+                "relevance": 11111.709477840308,
+                "value": "27",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:1",
+                "relevance": 10977.31338339293,
+                "value": "1",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:18",
+                "relevance": 10011.709521325834,
+                "value": "18",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:7",
+                "relevance": 9998.214537458838,
+                "value": "7",
+                "fields": {
+                  "count()": 6
+                }
+              },
+              {
+                "id": "group:long:12",
+                "relevance": 9751.807920622134,
+                "value": "12",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:29",
+                "relevance": 9009.325691944365,
+                "value": "29",
+                "fields": {
+                  "count()": 2
+                }
+              },
+              {
+                "id": "group:long:13",
+                "relevance": 8518.091869631671,
+                "value": "13",
+                "fields": {
+                  "count()": 7
+                }
+              },
+              {
+                "id": "group:long:30",
+                "relevance": 7997.832345648446,
+                "value": "30",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:31",
+                "relevance": 6985.517516649399,
+                "value": "31",
+                "fields": {
+                  "count()": 5
+                }
+              },
+              {
+                "id": "group:long:2",
+                "relevance": 2113.5503594784377,
+                "value": "2",
+                "fields": {
+                  "count()": 1
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/search/grouping_adv/answers/time.minute.timezone.json
+++ b/tests/search/grouping_adv/answers/time.minute.timezone.json
@@ -1,0 +1,203 @@
+{
+  "root": {
+    "id": "toplevel",
+    "relevance": 1.0,
+    "fields": {
+      "totalCount": 28
+    },
+    "coverage": {
+      "coverage": 100,
+      "documents": 28,
+      "full": true,
+      "nodes": 1,
+      "results": 1,
+      "resultsFull": 1
+    },
+    "children": [
+      {
+        "id": "group:root:0",
+        "relevance": 1.0,
+        "continuation": {
+          "this": ""
+        },
+        "children": [
+          {
+            "id": "grouplist:time.minuteofhour(from)",
+            "relevance": 1.0,
+            "label": "time.minuteofhour(from)",
+            "children": [
+              {
+                "id": "group:long:30",
+                "relevance": 12111.719438207627,
+                "value": "30",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:52",
+                "relevance": 11111.709477840308,
+                "value": "52",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:17",
+                "relevance": 10977.31338339293,
+                "value": "17",
+                "fields": {
+                  "count()": 2
+                }
+              },
+              {
+                "id": "group:long:40",
+                "relevance": 10011.709521325834,
+                "value": "40",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:39",
+                "relevance": 9998.214537458838,
+                "value": "39",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:4",
+                "relevance": 9751.807920622134,
+                "value": "4",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:27",
+                "relevance": 9009.325691944365,
+                "value": "27",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:25",
+                "relevance": 8875.610133144828,
+                "value": "25",
+                "fields": {
+                  "count()": 2
+                }
+              },
+              {
+                "id": "group:long:50",
+                "relevance": 8518.091869631671,
+                "value": "50",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:13",
+                "relevance": 7997.832345648446,
+                "value": "13",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:37",
+                "relevance": 7283.644818632625,
+                "value": "37",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:0",
+                "relevance": 6985.517516649399,
+                "value": "0",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:42",
+                "relevance": 6628.09515313634,
+                "value": "42",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:54",
+                "relevance": 6049.133667632721,
+                "value": "54",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:44",
+                "relevance": 5504.689703136349,
+                "value": "44",
+                "fields": {
+                  "count()": 3
+                }
+              },
+              {
+                "id": "group:long:18",
+                "relevance": 4960.735248649505,
+                "value": "18",
+                "fields": {
+                  "count()": 2
+                }
+              },
+              {
+                "id": "group:long:55",
+                "relevance": 4814.61700663273,
+                "value": "55",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:56",
+                "relevance": 3580.099884632731,
+                "value": "56",
+                "fields": {
+                  "count()": 3
+                }
+              },
+              {
+                "id": "group:long:19",
+                "relevance": 2935.945422549505,
+                "value": "19",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:5",
+                "relevance": 2113.5503594784377,
+                "value": "5",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:57",
+                "relevance": 357.87755966891814,
+                "value": "57",
+                "fields": {
+                  "count()": 1
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/search/grouping_adv/answers/time.wday.timezone.json
+++ b/tests/search/grouping_adv/answers/time.wday.timezone.json
@@ -1,0 +1,91 @@
+{
+  "root": {
+    "id": "toplevel",
+    "relevance": 1.0,
+    "fields": {
+      "totalCount": 28
+    },
+    "coverage": {
+      "coverage": 100,
+      "documents": 28,
+      "full": true,
+      "nodes": 1,
+      "results": 1,
+      "resultsFull": 1
+    },
+    "children": [
+      {
+        "id": "group:root:0",
+        "relevance": 1.0,
+        "continuation": {
+          "this": ""
+        },
+        "children": [
+          {
+            "id": "grouplist:time.dayofweek(from)",
+            "relevance": 1.0,
+            "label": "time.dayofweek(from)",
+            "children": [
+              {
+                "id": "group:long:2",
+                "relevance": 12111.719438207627,
+                "value": "2",
+                "fields": {
+                  "count()": 3
+                }
+              },
+              {
+                "id": "group:long:6",
+                "relevance": 10977.31338339293,
+                "value": "6",
+                "fields": {
+                  "count()": 2
+                }
+              },
+              {
+                "id": "group:long:4",
+                "relevance": 10011.709521325834,
+                "value": "4",
+                "fields": {
+                  "count()": 3
+                }
+              },
+              {
+                "id": "group:long:0",
+                "relevance": 9998.214537458838,
+                "value": "0",
+                "fields": {
+                  "count()": 6
+                }
+              },
+              {
+                "id": "group:long:1",
+                "relevance": 8875.610133144828,
+                "value": "1",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:5",
+                "relevance": 8518.091869631671,
+                "value": "5",
+                "fields": {
+                  "count()": 7
+                }
+              },
+              {
+                "id": "group:long:3",
+                "relevance": 7997.832345648446,
+                "value": "3",
+                "fields": {
+                  "count()": 6
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/search/grouping_adv/answers/time.yday.timezone.json
+++ b/tests/search/grouping_adv/answers/time.yday.timezone.json
@@ -1,0 +1,147 @@
+{
+  "root": {
+    "id": "toplevel",
+    "relevance": 1.0,
+    "fields": {
+      "totalCount": 28
+    },
+    "coverage": {
+      "coverage": 100,
+      "documents": 28,
+      "full": true,
+      "nodes": 1,
+      "results": 1,
+      "resultsFull": 1
+    },
+    "children": [
+      {
+        "id": "group:root:0",
+        "relevance": 1.0,
+        "continuation": {
+          "this": ""
+        },
+        "children": [
+          {
+            "id": "grouplist:time.dayofyear(from)",
+            "relevance": 1.0,
+            "label": "time.dayofyear(from)",
+            "children": [
+              {
+                "id": "group:long:280",
+                "relevance": 12111.719438207627,
+                "value": "280",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:206",
+                "relevance": 11111.709477840308,
+                "value": "206",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:30",
+                "relevance": 10977.31338339293,
+                "value": "30",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:16",
+                "relevance": 10011.709521325834,
+                "value": "16",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:217",
+                "relevance": 9998.214537458838,
+                "value": "217",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:41",
+                "relevance": 9751.807920622134,
+                "value": "41",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:27",
+                "relevance": 9009.325691944365,
+                "value": "27",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:219",
+                "relevance": 8875.610133144828,
+                "value": "219",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:42",
+                "relevance": 8518.091869631671,
+                "value": "42",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:29",
+                "relevance": 7997.832345648446,
+                "value": "29",
+                "fields": {
+                  "count()": 6
+                }
+              },
+              {
+                "id": "group:long:218",
+                "relevance": 7751.494193136243,
+                "value": "218",
+                "fields": {
+                  "count()": 5
+                }
+              },
+              {
+                "id": "group:long:43",
+                "relevance": 7283.644818632625,
+                "value": "43",
+                "fields": {
+                  "count()": 6
+                }
+              },
+              {
+                "id": "group:long:90",
+                "relevance": 2113.5503594784377,
+                "value": "90",
+                "fields": {
+                  "count()": 1
+                }
+              },
+              {
+                "id": "group:long:332",
+                "relevance": 357.87755966891814,
+                "value": "332",
+                "fields": {
+                  "count()": 1
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/search/grouping_adv/grouping_base.rb
+++ b/tests/search/grouping_adv/grouping_base.rb
@@ -94,6 +94,24 @@ module GroupingBase
     check_query('all(group(time.dayofweek(from)) each(output(count()) ))',
                 'time.wday')
 
+    # Test time with timezone
+    check_query('all(group(time.year(from)) each(output(count()) ))',
+                'time.year', DEFAULT_TIMEOUT, true, "default", "America/Los_Angeles")
+    check_query('all(group(time.monthofyear(from)) each(output(count()) ))',
+                'time.month', DEFAULT_TIMEOUT, true, "default", "America/Los_Angeles")
+    check_query('all(group(time.hourofday(from)) each(output(count()) ))',
+                'time.hour.timezone', DEFAULT_TIMEOUT, true, "default", "America/Los_Angeles")
+    check_query('all(group(time.secondofminute(from)) each(output(count()) ))',
+                'time.second', DEFAULT_TIMEOUT, true, "default", "America/Los_Angeles")
+    check_query('all(group(time.minuteofhour(from)) each(output(count()) ))',
+                'time.minute.timezone', DEFAULT_TIMEOUT, true, "default", "Australia/Adelaide")
+    check_query('all(group(time.dayofmonth(from)) each(output(count()) ))',
+                'time.mday.timezone', DEFAULT_TIMEOUT, true, "default", "Pacific/Kiritimati")
+    check_query('all(group(time.dayofyear(from)) each(output(count()) ))',
+                'time.yday.timezone', DEFAULT_TIMEOUT, true, "default", "America/Los_Angeles")
+    check_query('all(group(time.dayofweek(from)) each(output(count()) ))',
+                'time.wday.timezone', DEFAULT_TIMEOUT, true, "default", "Europe/Oslo")
+
     # Test relevance
     check_query('all(group(a) each(output(count(),sum(mod(relevance(),100000))) ))',
                 'relevance')
@@ -335,10 +353,9 @@ module GroupingBase
     check_fullquery(full_query, file)
   end
 
-
-  def check_query(select, file, timeout=DEFAULT_TIMEOUT, session_cache=true, rank_profile="default")
+  def check_query(select, file, timeout=DEFAULT_TIMEOUT, session_cache=true, rank_profile="default", timezone="utc")
     full_query = "/?query=sddocname:test&select=#{select}&streaming.selection=true&hits=0&timeout=#{timeout}" +
-      "&groupingSessionCache=#{session_cache}&ranking.profile=#{rank_profile}"
+      "&groupingSessionCache=#{session_cache}&ranking.profile=#{rank_profile}&timezone=#{timezone}"
     check_fullquery(full_query, file)
   end
 

--- a/tests/search/grouping_adv/grouping_base.rb
+++ b/tests/search/grouping_adv/grouping_base.rb
@@ -95,16 +95,21 @@ module GroupingBase
                 'time.wday')
 
     # Test time with timezone
+    # - timezone should offset the value in from field into a local time with these queries
     check_query('all(group(time.year(from)) each(output(count()) ))',
                 'time.year', DEFAULT_TIMEOUT, true, "default", "America/Los_Angeles")
     check_query('all(group(time.monthofyear(from)) each(output(count()) ))',
                 'time.month', DEFAULT_TIMEOUT, true, "default", "America/Los_Angeles")
+    # - hour should change with timezone
     check_query('all(group(time.hourofday(from)) each(output(count()) ))',
                 'time.hour.timezone', DEFAULT_TIMEOUT, true, "default", "America/Los_Angeles")
+    # - seconds should not change with timezones
     check_query('all(group(time.secondofminute(from)) each(output(count()) ))',
                 'time.second', DEFAULT_TIMEOUT, true, "default", "America/Los_Angeles")
+    # - Australia/Adelaide does not offset the time by whole hours, but with additional 30 minutes
     check_query('all(group(time.minuteofhour(from)) each(output(count()) ))',
                 'time.minute.timezone', DEFAULT_TIMEOUT, true, "default", "Australia/Adelaide")
+    # - Pacific/Kiritimati offsets by 14 hours
     check_query('all(group(time.dayofmonth(from)) each(output(count()) ))',
                 'time.mday.timezone', DEFAULT_TIMEOUT, true, "default", "Pacific/Kiritimati")
     check_query('all(group(time.dayofyear(from)) each(output(count()) ))',


### PR DESCRIPTION
Extend `check_query` to include a timezone field and add it to the query.

Add interesting time zones when applicable.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
