### PR TITLE
Adapt value of filter-first-exploration

### DIFF
--- a/tests/performance/nearest_neighbor/NearestNeighborRecallSearcher.java
+++ b/tests/performance/nearest_neighbor/NearestNeighborRecallSearcher.java
@@ -62,7 +62,7 @@ public class NearestNeighborRecallSearcher extends Searcher {
             int filterPercent = props.getInteger("nnr.filterPercent", 0);
             double approximateThreshold = Double.parseDouble(props.getString("nnr.approximateThreshold", "0.05"));
             double filterFirstThreshold = Double.parseDouble(props.getString("nnr.filterFirstThreshold", "0.00"));
-            double filterFirstExploration = Double.parseDouble(props.getString("nnr.filterFirstExploration", "0.01"));
+            double filterFirstExploration = Double.parseDouble(props.getString("nnr.filterFirstExploration", "0.3"));
             String idField = props.getString("nnr.idField", "id");
             log.log(Level.FINE, "NNRS.search(): docTensor=" + docTensor +
                     ", queryTensor=" + queryTensor + ", targetHits=" + targetHits +

--- a/tests/performance/nearest_neighbor/ann_gist_base.rb
+++ b/tests/performance/nearest_neighbor/ann_gist_base.rb
@@ -34,12 +34,12 @@ class AnnGistBase < CommonSiftGistBase
       # Standard HNSW
       query_and_benchmark(HNSW, 100, 0, filter_percent)
       # Now with filter-first heuristic enabled
-      query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.40, 0.01)
+      query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.40, 0.3)
 
       # Recall for standard HNSW
       calc_recall_for_queries(100, 0, filter_percent)
       # Recall for filter-first heuristic
-      calc_recall_for_queries(100, 0, filter_percent, 0.00, 0.40, 0.01)
+      calc_recall_for_queries(100, 0, filter_percent, 0.00, 0.40, 0.3)
     end
   end
 

--- a/tests/performance/nearest_neighbor/ann_sift_base.rb
+++ b/tests/performance/nearest_neighbor/ann_sift_base.rb
@@ -41,24 +41,24 @@ class AnnSiftBase < CommonSiftGistBase
       # Standard HNSW
       query_and_benchmark(HNSW, 100, 0, filter_percent)
       # Now with filter-first heuristic enabled
-      query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.20, 0.01)
+      query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.20, 0.3)
       # Increased exploration
-      query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.20, 0.012)
+      query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.20, 0.35)
 
       # Recall for standard HNSW
       calc_recall_for_queries(100, 0, filter_percent)
       # Recall for filter-first heuristic
-      calc_recall_for_queries(100, 0, filter_percent, 0.00, 0.20, 0.01)
+      calc_recall_for_queries(100, 0, filter_percent, 0.00, 0.20, 0.3)
       # Increased exploration
-      calc_recall_for_queries(100, 0, filter_percent, 0.00, 0.20, 0.012)
+      calc_recall_for_queries(100, 0, filter_percent, 0.00, 0.20, 0.35)
     end
 
     if test_threads_per_search
       [1, 2, 4, 8, 16].each do |threads|
         # Standard HNSW
-        query_and_benchmark(HNSW, 100, 0, 10, 0.05, 0.0, 0.0, 1, threads)
+        query_and_benchmark(HNSW, 100, 0, 10, 0.05, 0.0, 0.3, 1, threads)
         # Now with filter-first heuristic enabled
-        query_and_benchmark(HNSW, 100, 0, 10, 0.00, 0.20, 0.01, 1, threads)
+        query_and_benchmark(HNSW, 100, 0, 10, 0.00, 0.20, 0.3, 1, threads)
       end
     end
 

--- a/tests/performance/nearest_neighbor/common_ann_base.rb
+++ b/tests/performance/nearest_neighbor/common_ann_base.rb
@@ -67,7 +67,7 @@ class CommonAnnBaseTest < PerformanceTest
     fetch_file_to_localhost(@query_vectors, @local_query_vectors)
   end
 
-  def calc_recall_for_queries(target_hits, explore_hits, filter_percent = 0, approximate_threshold = 0.05, filter_first_threshold = 0.0, filter_first_exploration = 0.01, doc_type = "test", doc_tensor = "vec_m16", query_tensor = "q_vec")
+  def calc_recall_for_queries(target_hits, explore_hits, filter_percent = 0, approximate_threshold = 0.05, filter_first_threshold = 0.0, filter_first_exploration = 0.3, doc_type = "test", doc_tensor = "vec_m16", query_tensor = "q_vec")
     puts "calc_recall_for_queries: target_hits=#{target_hits}, explore_hits=#{explore_hits}, filter_percent=#{filter_percent}, approximate_threshold=#{approximate_threshold}, filter_first_threshold=#{filter_first_threshold}, filter_first_exploration=#{filter_first_exploration}, doc_type=#{doc_type}, doc_tensor=#{doc_tensor}, query_tensor=#{query_tensor}"
     result = RecallResult.new(target_hits)
     vectors = []

--- a/tests/performance/nearest_neighbor/common_mips_base.rb
+++ b/tests/performance/nearest_neighbor/common_mips_base.rb
@@ -23,7 +23,7 @@ class CommonMipsBase < CommonAnnBaseTest
 
     prepare_queries_for_recall()
     [0, 90, 190, 490].each do |explore_hits|
-      calc_recall_for_queries(10, explore_hits, 0, 0.05, 0.0, 0.01, doc_type, "embedding", query_tensor)
+      calc_recall_for_queries(10, explore_hits, 0, 0.05, 0.0, 0.3, doc_type, "embedding", query_tensor)
     end
   end
 

--- a/tests/performance/nearest_neighbor/common_sift_gist_base.rb
+++ b/tests/performance/nearest_neighbor/common_sift_gist_base.rb
@@ -41,7 +41,7 @@ class CommonSiftGistBase < CommonAnnBaseTest
     (threads_per_search > 0) ? "threads-#{threads_per_search}" : "default"
   end
 
-  def query_and_benchmark(algorithm, target_hits, explore_hits, filter_percent = 0, approximate_threshold = 0.05, filter_first_threshold = 0.0, filter_first_exploration = 0.01, clients = 1, threads_per_search = 0)
+  def query_and_benchmark(algorithm, target_hits, explore_hits, filter_percent = 0, approximate_threshold = 0.05, filter_first_threshold = 0.0, filter_first_exploration = 0.3, clients = 1, threads_per_search = 0)
     approximate = algorithm == HNSW ? "true" : "false"
     query_file = fetch_query_file_to_container(approximate, target_hits, explore_hits, filter_percent)
     label = "#{algorithm}-th#{target_hits}-eh#{explore_hits}-f#{filter_percent}-at#{approximate_threshold}-fft#{filter_first_threshold}-ffe#{filter_first_exploration}-n#{clients}-t#{threads_per_search}"

--- a/tests/performance/nearest_neighbor/gist_test/test.sd
+++ b/tests/performance/nearest_neighbor/gist_test/test.sd
@@ -23,7 +23,7 @@ search test {
     }
     approximate-threshold: 0.05
     filter-first-threshold: 0.0
-    filter-first-exploration: 0.01
+    filter-first-exploration: 0.3
   }
   document-summary minimal {
     summary id {}

--- a/tests/performance/nearest_neighbor/sift_test/test.sd
+++ b/tests/performance/nearest_neighbor/sift_test/test.sd
@@ -23,7 +23,7 @@ search test {
     }
     approximate-threshold: 0.05
     filter-first-threshold: 0.0
-    filter-first-exploration: 0.01
+    filter-first-exploration: 0.3
     num-threads-per-search: 1
   }
   rank-profile threads-1 inherits default {

--- a/tests/performance/nearest_neighbor/sift_test_bfloat16/test.sd
+++ b/tests/performance/nearest_neighbor/sift_test_bfloat16/test.sd
@@ -23,7 +23,7 @@ search test {
     }
     approximate-threshold: 0.05
     filter-first-threshold: 0.0
-    filter-first-exploration: 0.01
+    filter-first-exploration: 0.3
   }
   document-summary minimal {
     summary id {}

--- a/tests/performance/nearest_neighbor/sift_test_mixed/test.sd
+++ b/tests/performance/nearest_neighbor/sift_test_mixed/test.sd
@@ -23,7 +23,7 @@ search test {
     }
     approximate-threshold: 0.05
     filter-first-threshold: 0.0
-    filter-first-exploration: 0.01
+    filter-first-exploration: 0.3
   }
   document-summary minimal {
     summary id {}

--- a/tests/performance/nearest_neighbor/unused.gist_bfloat16/test.sd
+++ b/tests/performance/nearest_neighbor/unused.gist_bfloat16/test.sd
@@ -23,7 +23,7 @@ search test {
     }
     approximate-threshold: 0.05
     filter-first-threshold: 0.0
-    filter-first-exploration: 0.01
+    filter-first-exploration: 0.3
   }
   document-summary minimal {
     summary id {}


### PR DESCRIPTION
This adapts the value of `filter-first-exploration` in the ANN performance tests to the changes in Vespa (https://github.com/vespa-engine/vespa/pull/34524).