### PR TITLE
Revert "Enable VESPA_ENABLE_PREPARE_RESTART2"

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -6,8 +6,7 @@
                 {
                     "value" : [
                         "VESPA_BITVECTOR_RANGE_CHECK=true",
-                        "VESPA_INTERNAL_VECTORIZATION_TARGET_LEVEL=AVX3_DL",
-                        "VESPA_ENABLE_PREPARE_RESTART2=true"
+                        "VESPA_INTERNAL_VECTORIZATION_TARGET_LEVEL=AVX3_DL"
                     ]
                 }
             ]


### PR DESCRIPTION
Reverts vespa-engine/system-test#4538

Some system tests failed due to this change, probably due to differences in vespa log output.

