### PR TITLE
Extend timeout for grouping filter range test to 40

### DIFF
--- a/tests/search/grouping_adv/grouping_base.rb
+++ b/tests/search/grouping_adv/grouping_base.rb
@@ -289,9 +289,9 @@ module GroupingBase
   end
 
   def querytest_filter
-    check_query('all(group(sf) filter(range(2.9, 8.9, sf)) each(output(count())))', 'range-1', 20)
-    check_query('all(group(sf) filter(range(2.9, 8.9, sf, true, false)) each(output(count())))', 'range-1', 20) # default values for inclusion is true, false
-    check_query('all(group(sf) filter(range(2.9, 8.9, sf, false, true)) each(output(count())))', 'range-2', 20)
+    check_query('all(group(sf) filter(range(2.9, 8.9, sf)) each(output(count())))', 'range-1', 40)
+    check_query('all(group(sf) filter(range(2.9, 8.9, sf, true, false)) each(output(count())))', 'range-1', 40) # default values for inclusion is true, false
+    check_query('all(group(sf) filter(range(2.9, 8.9, sf, false, true)) each(output(count())))', 'range-2', 40)
 
     check_query('all(group(a) filter(not regex("^a1$", a)) each(output(count())))', 'predicate-1')
     check_query('all(group(a) filter(regex("^a1$", a) or regex("^a2$", a)) each(output(count())))', 'predicate-2')


### PR DESCRIPTION
Doubling the timeout.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
