### PR TITLE
Remove temporary acceleration override flag in order to return to baseline

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -5,8 +5,7 @@
             "rules" : [
                 {
                     "value" : [
-                        "VESPA_BITVECTOR_RANGE_CHECK=true",
-                        "VESPA_INTERNAL_VECTORIZATION_TARGET_LEVEL=AVX3_DL"
+                        "VESPA_BITVECTOR_RANGE_CHECK=true"
                     ]
                 }
             ]


### PR DESCRIPTION
@hmusum please review. Want to get perf tests back to the production baseline before doing any testing of Highway.