### PR TITLE
Revert "Enable Highway vectorization kernels for system/performance tests"

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -6,8 +6,7 @@
                 {
                     "value" : [
                         "VESPA_BITVECTOR_RANGE_CHECK=true",
-                        "VESPA_ENABLE_PREPARE_RESTART2=true",
-                        "VESPA_INTERNAL_VECTORIZATION_TARGET_LEVEL=HIGHWAY"
+                        "VESPA_ENABLE_PREPARE_RESTART2=true"
                     ]
                 }
             ]


### PR DESCRIPTION
Preemptive revert PR in case of exciting breakages 🫣

Reverts vespa-engine/system-test#4550