### PR TITLE
Reduce number of values to test for range_search and in_operator tests

### DIFF
--- a/tests/performance/in_operator/in_operator.rb
+++ b/tests/performance/in_operator/in_operator.rb
@@ -25,8 +25,8 @@ class InOperatorPerfTest < PerformanceTest
     compile_create_docs
     start
 
-    @op_hits_ratios = [1, 5, 10, 50, 100, 200]
-    @filter_hits_ratios = [1, 5, 10, 50, 100, 150, 200]
+    @op_hits_ratios = [1, 10, 50, 200]
+    @filter_hits_ratios = [1, 10, 50, 200]
     @tokens_in_op = [1, 10, 100, 1000, 10000, 100000]
     @num_docs = 10000000
     feed_docs

--- a/tests/performance/range_search/range_search.rb
+++ b/tests/performance/range_search/range_search.rb
@@ -22,8 +22,8 @@ class RangeSearchPerfTest < PerformanceTest
     start
 
     # This matches the documents created by create_docs.cpp
-    @range_hits_ratios = [1, 5, 10, 50, 100, 200]
-    @filter_hits_ratios = [1, 5, 10, 50, 100, 150, 200]
+    @range_hits_ratios = [1, 10, 50, 200]
+    @filter_hits_ratios = [1, 10, 50, 200]
     @values_in_range = [1, 100, 10000]
     @large_values_in_range = [100000, 1000000]
     @num_docs = 10000000


### PR DESCRIPTION
Similar performance characteristics for these values, seems unnecessary to use time on this,
this will also reduce total runtime for tests.