### PR TITLE
Reduce number of values to test

### DIFF
--- a/tests/performance/cli_feed_client/cli_feed_client.rb
+++ b/tests/performance/cli_feed_client/cli_feed_client.rb
@@ -9,7 +9,6 @@ class CliFeedClientTest < PerformanceTest
 
   DOCUMENTS = 2000000
   TINY = 10
-  MEDIUM = 1000
   LARGE = 10000
 
   DUMMY_ROUTE = 'null/default'
@@ -28,10 +27,8 @@ class CliFeedClientTest < PerformanceTest
     vespa_destination_start
 
     run_benchmark(container_node, "vespa-cli-feed",    TINY)
-    run_benchmark(container_node, "vespa-cli-feed",    MEDIUM)
     run_benchmark(container_node, "vespa-cli-feed",    LARGE)
     run_benchmark(container_node, "vespa-feed-client", TINY)
-    run_benchmark(container_node, "vespa-feed-client", MEDIUM)
     run_benchmark(container_node, "vespa-feed-client", LARGE)
   end
 


### PR DESCRIPTION
Using MEDIUM gives performance with so high variance that we cannot set any meaningful limits, so just stop testing with that.