### PR TITLE
remove sorting of array fields

### DIFF
--- a/lib/hit.rb
+++ b/lib/hit.rb
@@ -109,10 +109,6 @@ class Hit
   end
 
   def add_field(fieldname, fieldvalue)
-    if fieldvalue.instance_of?(Array)
-      items = fieldvalue.sort {|a, b| array_sort_cmp(a, b) }
-      fieldvalue = items
-    end
     if fieldname == 'summaryfeatures' && fieldvalue.instance_of?(Hash)
       fieldvalue.delete('vespa.summaryFeatures.cached')
     end
@@ -182,4 +178,3 @@ class Hit
     end
   end
 end
-

--- a/tests/search/matched_elements_only/matched_elements_only.rb
+++ b/tests/search/matched_elements_only/matched_elements_only.rb
@@ -37,7 +37,7 @@ class MatchedElementsOnlyTest < IndexedStreamingSearchTest
     assert_summary_field("int_array contains '20'", "int_array", [20])
     assert_summary_field("str_wset contains 'bar'", "str_wset", { "bar" => 7 })
     assert_summary_field("int_wset contains '20'", "int_wset", { "20" => 7 })
-    assert_summary_field("str_array contains 'foo' or str_array contains 'bar'", "str_array", ["bar", "foo"])
+    assert_summary_field("str_array contains 'foo' or str_array contains 'bar'", "str_array", ["foo", "bar"])
     assert_summary_field("str_wset contains 'foo' or str_wset contains 'bar'", "str_wset", { "bar" => 7, "foo" => 5 })
     assert_summary_field("idx_array contains 'deux'", "idx_array", ["two 2 deux"])
     assert_summary_field("idx_array contains 'deux' or idx_array contains 'une'", "idx_array", ["one 1 une", "two 2 deux"])
@@ -45,7 +45,7 @@ class MatchedElementsOnlyTest < IndexedStreamingSearchTest
     assert_summary_field("idx_wset contains 'deux' or idx_wset contains 'une'", "idx_wset", {"one 1 une" => 5, "two 2 deux" => 7})
     assert_summary_field("weightedSet(str_array, {\"foo\":1, \"baz\":2})", "str_array", ["foo"])
     assert_summary_field("weightedSet(str_array, {\"baz\":1, \"bar\":2})", "str_array", ["bar"])
-    assert_summary_field("weightedSet(str_array, {\"foo\":1, \"bar\":2})", "str_array", ["bar", "foo"])
+    assert_summary_field("weightedSet(str_array, {\"foo\":1, \"bar\":2})", "str_array", ["foo", "bar"])
     assert_summary_field("weightedSet(int_array, {\"10\":1, \"11\":2})", "int_array", [10])
     assert_summary_field("weightedSet(int_array, {\"11\":1, \"20\":2})", "int_array", [20])
     assert_summary_field("weightedSet(int_array, {\"10\":1, \"20\":2})", "int_array", [10, 20])
@@ -55,9 +55,9 @@ class MatchedElementsOnlyTest < IndexedStreamingSearchTest
     assert_summary_field("weightedSet(int_wset, {\"10\":1, \"11\":2})", "int_wset", { "10" => 5 })
     assert_summary_field("weightedSet(int_wset, {\"11\":1, \"20\":2})", "int_wset", { "20" => 7 })
     assert_summary_field("weightedSet(int_wset, {\"10\":1, \"20\":2})", "int_wset", { "10" => 5, "20" => 7 })
-    assert_summary_field('weightedSet(idx_array, {"two":3, "deux": 5, "3":22})', "idx_array", ["three 3 trois", "two 2 deux"])
+    assert_summary_field('weightedSet(idx_array, {"two":3, "deux": 5, "3":22})', "idx_array", ["two 2 deux", "three 3 trois"])
     assert_summary_field('weightedSet(idx_wset, {"two":3, "deux": 5, "3":22})', "idx_wset", {"three 3 trois" => 16, "two 2 deux" => 7})
-    assert_summary_field('idx_array contains equiv("two", "deux", "3")', "idx_array", ["three 3 trois", "two 2 deux"])
+    assert_summary_field('idx_array contains equiv("two", "deux", "3")', "idx_array", ["two 2 deux", "three 3 trois"])
     assert_summary_field('idx_wset contains equiv("two", "deux", "3")', "idx_wset", {"three 3 trois" => 16, "two 2 deux" => 7})
 
     # Test summary fields with 'matched-elements-only' (in explicit summary class) that reference source fields.
@@ -65,14 +65,14 @@ class MatchedElementsOnlyTest < IndexedStreamingSearchTest
     assert_summary_field("int_array_src contains '20'", "int_array_filtered", [20], "filtered")
     assert_summary_field("str_wset_src contains 'bar'", "str_wset_filtered", { "bar" => 7 }, "filtered")
     assert_summary_field("int_wset_src contains '20'", "int_wset_filtered", { "20" => 7 }, "filtered")
-    assert_summary_field("str_array_src contains 'foo' or str_array_src contains 'bar'", "str_array_filtered", ["bar", "foo"], "filtered")
+    assert_summary_field("str_array_src contains 'foo' or str_array_src contains 'bar'", "str_array_filtered", ["foo", "bar"], "filtered")
     assert_summary_field("str_wset_src contains 'foo' or str_wset_src contains 'bar'", "str_wset_filtered", { "bar" => 7, "foo" => 5 }, "filtered")
     assert_summary_field("idx_array_src contains 'deux'", "idx_array_filtered", ["two 2 deux"])
     assert_summary_field("idx_array_src contains 'deux' or idx_array_src contains '1'", "idx_array_filtered", ["one 1 une", "two 2 deux"])
     assert_summary_field("idx_wset_src contains 'deux' or idx_wset_src contains '1'", "idx_wset_filtered", {"one 1 une" => 5, "two 2 deux" => 7})
 
     # The source fields are not filtered
-    assert_summary_field("str_array_src contains 'bar'", "str_array_src", ["bar", "foo"])
+    assert_summary_field("str_array_src contains 'bar'", "str_array_src", ["foo", "bar"])
     assert_summary_field("str_wset_src contains 'bar'", "str_wset_src", { "bar" => 7, "foo" => 5 })
 
     # No elements matches in other fields

--- a/tests/search/streamingmatcher/fieldtypetest_teststring2.result
+++ b/tests/search/streamingmatcher/fieldtypetest_teststring2.result
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result total-hit-count="1" coverage-docs="2" coverage-nodes="1" coverage-full="true" coverage="100" results-full="1" results="1">
-  <hit relevancy="0.38186238359951247" source="search.fieldtypetest">
+  <hit relevancy="0.38186238359951247" source="search">
     <field name="relevancy">0.38186238359951247</field>
     <field name="sddocname">fieldtypetest</field>
     <field name="teststring">teststring2</field>
@@ -69,19 +69,19 @@
       <item weight="1">item2</item>
     </field>
     <field name="testwsetbyte">
+      <item weight="1">4</item>
       <item weight="2">5</item>
       <item weight="3">6</item>
-      <item weight="1">4</item>
     </field>
     <field name="testwsetint">
+      <item weight="1">4</item>
       <item weight="2">5</item>
       <item weight="3">6</item>
-      <item weight="1">4</item>
     </field>
     <field name="testwsetlong">
+      <item weight="1">4</item>
       <item weight="2">5</item>
       <item weight="3">6</item>
-      <item weight="1">4</item>
     </field>
     <field name="testweightedset">
       <item weight="4">item3</item>

--- a/tests/search/streamingmatcher/fieldtypetest_teststring2.result.json
+++ b/tests/search/streamingmatcher/fieldtypetest_teststring2.result.json
@@ -1,0 +1,116 @@
+{
+  "root": {
+    "id": "toplevel",
+    "relevance": 1.0,
+    "fields": {
+      "totalCount": 1
+    },
+    "coverage": {
+      "coverage": 100,
+      "documents": 2,
+      "full": true,
+      "nodes": 1,
+      "results": 1,
+      "resultsFull": 1
+    },
+    "children": [
+      {
+        "id": "id:fieldtypetest:fieldtypetest:n=1:1",
+        "relevance": 0.38186238359951247,
+        "source": "search",
+        "fields": {
+          "sddocname": "fieldtypetest",
+          "documentid": "id:fieldtypetest:fieldtypetest:n=1:1",
+          "teststring": "teststring2",
+          "testexactmatch": "testexactmatch2",
+          "testint": 2147483647,
+          "testlong": 2147483647,
+          "testbyte": 127,
+          "testbool": false,
+          "testfloat": 5.678,
+          "testdouble": 12345.6789,
+          "testraw": "testraw2",
+          "testuri": "http://www0.testuri2.se:8080/path/p?arg1=1&arg2=2#frag1",
+          "testtermboost": {
+            "term1": 1
+          },
+          "testcontent": "testcontent2",
+          "testlatlong": {
+            "lat": -4.62325,
+            "lng": 55.452306
+          },
+          "testarraystring": [
+            "item2",
+            "item3"
+          ],
+          "testarraybyte": [
+            4,
+            5,
+            6
+          ],
+          "testarrayint": [
+            4,
+            5,
+            6
+          ],
+          "testarraylong": [
+            4,
+            5,
+            6
+          ],
+          "testarrayfloat": [
+            4.0,
+            5.0,
+            6.0
+          ],
+          "testarraydouble": [
+            4.0,
+            5.0,
+            6.0
+          ],
+          "testarraylatlong": [
+            {
+              "lat": -4.444004,
+              "lng": 55.404004
+            },
+            {
+              "lat": -4.555005,
+              "lng": 55.505005
+            },
+            {
+              "lat": -4.666006,
+              "lng": 55.606006
+            }
+          ],
+          "testwsetstring": {
+            "item3": 2,
+            "item2": 1
+          },
+          "testwsetbyte": {
+            "4": 1,
+            "5": 2,
+            "6": 3
+          },
+          "testwsetint": {
+            "4": 1,
+            "5": 2,
+            "6": 3
+          },
+          "testwsetlong": {
+            "4": 1,
+            "5": 2,
+            "6": 3
+          },
+          "testweightedset": {
+            "item3": 4,
+            "item2": 3
+          },
+          "testtag": {
+            "item3": 4,
+            "item2": 3
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/search/streamingmatcher/streamingmatcher_part1.rb
+++ b/tests/search/streamingmatcher/streamingmatcher_part1.rb
@@ -486,8 +486,8 @@ class StreamingMatcherPart1 < StreamingMatcher
     assert_hitcount("query=testbool:true&streaming.userid=1", 1)
     assert_hitcount("query=testbool:false&streaming.userid=1", 1)
 
-    # save_result("query=teststring:teststring2&streaming.userid=1&format=xml", selfdir + "fieldtypetest_teststring2.result")
-    assert_result("query=teststring:teststring2&streaming.userid=1&format=xml", selfdir + "fieldtypetest_teststring2.result")
+    # save_result("query=teststring:teststring2&streaming.userid=1", selfdir + "fieldtypetest_teststring2.result.json")
+    assert_result("query=teststring:teststring2&streaming.userid=1", selfdir + "fieldtypetest_teststring2.result.json")
 
     # TODO: Should maybe test more features from indexed search?
 


### PR DESCRIPTION
@toregge please review
@hmusum FYI

may still break some tests, but I've tried running most test that use arrays.
