### PR TITLE
Revert "Temporarily reenable Highway once more"

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -6,8 +6,7 @@
                 {
                     "value" : [
                         "VESPA_BITVECTOR_RANGE_CHECK=true",
-                        "VESPA_ENABLE_PREPARE_RESTART2=true",
-                        "VESPA_INTERNAL_VECTORIZATION_TARGET_LEVEL=HIGHWAY"
+                        "VESPA_ENABLE_PREPARE_RESTART2=true"
                     ]
                 }
             ]


### PR DESCRIPTION
@hmusum please review. Merging should be held off until we have at least one perf run with the wiring+Highway both present.

Reverts vespa-engine/system-test#4580