### PR TITLE
Disable SIFT BF16 performance test `perf` recording

### DIFF
--- a/tests/performance/nearest_neighbor/case_sift_bfloat16.rb
+++ b/tests/performance/nearest_neighbor/case_sift_bfloat16.rb
@@ -10,7 +10,6 @@ class AnnSiftBFloat16PerfTest < AnnSiftBase
   end
 
   def test_sift_data_set_bfloat16
-    @perf_recording = 'some'
     set_description("Test performance and recall using nearestNeighbor operator (hnsw vs brute force) over the 1M SIFT (128 dim) dataset using bfloat16")
     run_sift_test("sift_test_bfloat16")
   end


### PR DESCRIPTION
@arnej27959 please review

`perf` adds some overhead, so disable it (at least for now) to get an apples-to-apples comparison with the old performance numbers.

