### PR TITLE
Wait for state before checking initialization status in initialization test

### DIFF
--- a/tests/search/statev1/initialization.rb
+++ b/tests/search/statev1/initialization.rb
@@ -3,7 +3,7 @@ require 'indexed_streaming_search_test'
 
 class Initialization < IndexedStreamingSearchTest
 
-  NUM_DOCUMENTS = 100000
+  NUM_DOCUMENTS = 50000
 
   def setup
     set_owner("boeker")


### PR DESCRIPTION
Instead of just waiting for a fixed amount of seconds, we wait until the expected state is reported before checking the initialization status.