### PR TITLE
Add test cases for measuring recall after removal of documents

### DIFF
--- a/tests/performance/nearest_neighbor/ann_gist_base.rb
+++ b/tests/performance/nearest_neighbor/ann_gist_base.rb
@@ -43,4 +43,14 @@ class AnnGistBase < CommonSiftGistBase
     end
   end
 
+  def run_gist_removal_test(sd_dir)
+    deploy_app(create_app(sd_dir, 0.3))
+    start
+    @container = vespa.container.values.first
+
+    prepare_queries_for_recall
+
+    run_removal_test(@docs_300k, "300k-docs", 150000, 300000)
+  end
+
 end

--- a/tests/performance/nearest_neighbor/ann_sift_base.rb
+++ b/tests/performance/nearest_neighbor/ann_sift_base.rb
@@ -67,4 +67,14 @@ class AnnSiftBase < CommonSiftGistBase
     feed_and_benchmark((mixed_tensor ? @updates_mixed_200k : @updates_200k), "1M-updates")
   end
 
+  def run_sift_removal_test(sd_dir)
+    deploy_app(create_app(sd_dir, 0.3, 1))
+    start
+    @container = vespa.container.values.first
+
+    prepare_queries_for_recall
+
+    run_removal_test(@docs_1M, "1M-docs", 500000, 1000000)
+  end
+
 end

--- a/tests/performance/nearest_neighbor/case_gist_float.rb
+++ b/tests/performance/nearest_neighbor/case_gist_float.rb
@@ -14,5 +14,9 @@ class AnnGistPerfTest < AnnGistBase
     run_gist_test("gist_test")
   end
 
+  def test_removal_gist_data_set
+    set_description("Test recall using nearestNeighbor operator (hnsw) over the 1M (300k fed) GIST (960 dim) dataset before and after removal of many documents")
+    run_gist_removal_test("gist_test")
+  end
 
 end

--- a/tests/performance/nearest_neighbor/case_sift_float.rb
+++ b/tests/performance/nearest_neighbor/case_sift_float.rb
@@ -14,5 +14,9 @@ class AnnSiftPerfTest < AnnSiftBase
     run_sift_test("sift_test", true)
   end
 
+  def test_removal_sift_data_set
+    set_description("Test recall using nearestNeighbor operator (hnsw) over the 1M SIFT (128 dim) dataset before and after removal of many documents")
+    run_sift_removal_test("sift_test")
+  end
 
 end

--- a/tests/performance/nearest_neighbor/common_ann_base.rb
+++ b/tests/performance/nearest_neighbor/common_ann_base.rb
@@ -38,6 +38,39 @@ class CommonAnnBaseTest < PerformanceTest
     print_nni_stats(doc_type, tensor)
   end
 
+  def feed_and_benchmark_range(feed_file, label, from, to, doc_type = "test", tensor = "vec_m16")
+    #profiler_start
+    node_file = nn_download_file(feed_file, vespa.adminserver)
+    # Name of the file containing the specified range
+    range_file = "#{node_file}_#{from}_#{to}"
+
+    # Since jq uses too much memory and the streaming mode is too slow, we do some text editing
+    # Add '[' to mark beginning of array
+    vespa.adminserver.execute("echo -e '[' > #{range_file}", :exceptiononfailure => true)
+    # The following places every put in its own line and selects the desired range:
+    # Remove whitespace
+    # Remove leading [
+    # Replace trailing ] by , and newline
+    # Add newline before every put
+    # Choose puts with ids "from" to "to" (not including "to")
+    # Every line now ends with a comma and a newline: Select range
+    vespa.adminserver.execute("cat #{node_file} | tr -d '[:space:]' \
+                                                | sed 's/\\[//' \
+                                                | sed 's/]$/,\\n/' \
+                                                | sed 's/{\\\"put\\\"/\\n{\\\"put\\\"/g' \
+                                                | sed -n #{from+2},#{to+1}p\
+                                                >> #{range_file}", :exceptiononfailure => true)
+    # Remove trailing newline and comma
+    vespa.adminserver.execute("truncate -s -2 #{range_file}", :exceptiononfailure => true)
+    # Add ']' to mark end of array
+    vespa.adminserver.execute("echo -e '\n]\n' >> #{range_file}", :exceptiononfailure => true)
+
+    run_feeder(range_file, [parameter_filler(TYPE, "feed"), parameter_filler(LABEL, label)], :localfile => true)
+    vespa.adminserver.execute("ls -ld #{range_file} #{selfdir}", :exceptiononfailure => false)
+    profiler_report("feed")
+    print_nni_stats(doc_type, tensor)
+  end
+
   def print_nni_stats(doc_type, tensor)
     stats = get_nni_stats(doc_type, tensor)
     write_report([parameter_filler(TYPE, "nni"),


### PR DESCRIPTION
These test cases take the sift/gist data set and measure how deleting a lot of documents affects the recall.

First, the first half of the documents is fed and the recall is measured. Then, after the remaining half is fed and immediately removed again, the recall is measured a second time.

The test case uses (mainly) `sed` to extract a subset of documents from the benchmark feed files. The reason for this is that `jq` uses too much memory in normal mode and is too slow in streaming mode. Suggestions for simpler alternatives are appreciated. :)