### PR TITLE
Revert "Reapply "Use mimalloc in system tests""

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -55,8 +55,7 @@
         { "id" : "content-layer-metadata-feature-level", "rules" : [ { "value" : 1 } ] },
         { "id" : "search-core-transaction-log-replay-soft-memory-limit", "rules" : [ { "value" : -5 } ] },
         { "id" : "zookeeper-pre-alloc-size", "rules" : [ { "value" : 16384 } ] },
-        { "id" : "resource-limit-address-space", "rules" : [ { "value" : 0.8 } ] },
-        { "id" : "vespa-use-malloc-impl", "rules" : [ { "value" : "mimalloc" } ] }
+        { "id" : "resource-limit-address-space", "rules" : [ { "value" : 0.8 } ] }
     ]
 
 }


### PR DESCRIPTION
Reverts vespa-engine/system-test#4609

Seeing some issues with mimalloc, will merge when we have had some runs