### PR TITLE
Use custom labels in ANN removal test

### DIFF
--- a/tests/performance/nearest_neighbor/ann_gist_base.rb
+++ b/tests/performance/nearest_neighbor/ann_gist_base.rb
@@ -30,16 +30,16 @@ class AnnGistBase < CommonSiftGistBase
     run_target_hits_10_tests
 
     [1, 10, 50, 90, 95, 99].each do |filter_percent|
-      query_and_benchmark(BRUTE_FORCE, 100, 0, filter_percent)
+      query_and_benchmark(BRUTE_FORCE, 100, 0, {:filter_percent => filter_percent})
       # Standard HNSW
-      query_and_benchmark(HNSW, 100, 0, filter_percent)
+      query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent})
       # Now with filter-first heuristic enabled
-      query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.40, 0.3)
+      query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.40, :filter_first_exploration => 0.3})
 
       # Recall for standard HNSW
-      calc_recall_for_queries(100, 0, filter_percent)
+      calc_recall_for_queries(100, 0, {:filter_percent => filter_percent})
       # Recall for filter-first heuristic
-      calc_recall_for_queries(100, 0, filter_percent, 0.00, 0.40, 0.3)
+      calc_recall_for_queries(100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.40, :filter_first_exploration => 0.3})
     end
   end
 

--- a/tests/performance/nearest_neighbor/ann_sift_base.rb
+++ b/tests/performance/nearest_neighbor/ann_sift_base.rb
@@ -39,28 +39,28 @@ class AnnSiftBase < CommonSiftGistBase
     run_target_hits_100_tests
 
     [1, 10, 50, 90, 95, 99].each do |filter_percent|
-      query_and_benchmark(BRUTE_FORCE, 100, 0, filter_percent)
+      query_and_benchmark(BRUTE_FORCE, 100, 0, {:filter_percent => filter_percent})
       # Standard HNSW
-      query_and_benchmark(HNSW, 100, 0, filter_percent)
+      query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent})
       # Now with filter-first heuristic enabled
-      query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.20, 0.3)
+      query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.20, :filter_first_exploration => 0.3})
       # Increased exploration
-      query_and_benchmark(HNSW, 100, 0, filter_percent, 0.00, 0.20, 0.35)
+      query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.20, :filter_first_exploration => 0.35})
 
       # Recall for standard HNSW
-      calc_recall_for_queries(100, 0, filter_percent)
+      calc_recall_for_queries(100, 0, {:filter_percent => filter_percent})
       # Recall for filter-first heuristic
-      calc_recall_for_queries(100, 0, filter_percent, 0.00, 0.20, 0.3)
+      calc_recall_for_queries(100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.20, :filter_first_exploration => 0.3})
       # Increased exploration
-      calc_recall_for_queries(100, 0, filter_percent, 0.00, 0.20, 0.35)
+      calc_recall_for_queries(100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.20, :filter_first_exploration => 0.35})
     end
 
     if test_threads_per_search
       [1, 2, 4, 8, 16].each do |threads|
         # Standard HNSW
-        query_and_benchmark(HNSW, 100, 0, 10, 0.05, 0.0, 0.3, 0.0, 1, threads)
+        query_and_benchmark(HNSW, 100, 0, {:filter_percent => 10, :threads => threads})
         # Now with filter-first heuristic enabled
-        query_and_benchmark(HNSW, 100, 0, 10, 0.00, 0.20, 0.3, 0.0, 1, threads)
+        query_and_benchmark(HNSW, 100, 0, {:filter_percent => 10, :approximate_threshold => 0.00, :filter_first_threshold => 0.20, :filter_first_exploration => 0.3, :threads => threads})
       end
     end
 

--- a/tests/performance/nearest_neighbor/common_ann_base.rb
+++ b/tests/performance/nearest_neighbor/common_ann_base.rb
@@ -108,7 +108,16 @@ class CommonAnnBaseTest < PerformanceTest
     fetch_file_to_localhost(@query_vectors, @local_query_vectors)
   end
 
-  def calc_recall_for_queries(target_hits, explore_hits, filter_percent = 0, approximate_threshold = 0.05, filter_first_threshold = 0.0, filter_first_exploration = 0.3, slack = 0.0, doc_type = "test", doc_tensor = "vec_m16", query_tensor = "q_vec")
+  def calc_recall_for_queries(target_hits, explore_hits, params = {})
+    filter_percent = params[:filter_percent] || 0
+    approximate_threshold = params[:approximate_threshold] || 0.05
+    filter_first_threshold = params[:filter_first_threshold] || 0.0
+    filter_first_exploration = params[:filter_first_exploration] || 0.3
+    slack = params[:slack] || 0.0
+    doc_type = params[:doc_type] || "test"
+    doc_tensor = params[:doc_tensor] || "vec_m16"
+    query_tensor = params[:query_tensor] || "q_vec"
+
     puts "calc_recall_for_queries: target_hits=#{target_hits}, explore_hits=#{explore_hits}, filter_percent=#{filter_percent}, approximate_threshold=#{approximate_threshold}, filter_first_threshold=#{filter_first_threshold}, filter_first_exploration=#{filter_first_exploration}, slack=#{slack}, doc_type=#{doc_type}, doc_tensor=#{doc_tensor}, query_tensor=#{query_tensor}"
     result = RecallResult.new(target_hits)
     vectors = []
@@ -129,7 +138,7 @@ class CommonAnnBaseTest < PerformanceTest
     end
     threads.each(&:join)
     puts "recall: avg=#{result.avg}, median=#{result.median}, min=#{result.min}, max=#{result.max}, size=#{result.size}, samples_sorted=[#{result.samples.sort.join(',')}], samples=[#{result.samples.join(',')}]"
-    label = "hnsw-th#{target_hits}-eh#{explore_hits}-f#{filter_percent}-at#{approximate_threshold}-fft#{filter_first_threshold}-ffe#{filter_first_exploration}-sl#{slack}"
+    label = params[:label] || "hnsw-th#{target_hits}-eh#{explore_hits}-f#{filter_percent}-at#{approximate_threshold}-fft#{filter_first_threshold}-ffe#{filter_first_exploration}-sl#{slack}"
     write_report([parameter_filler(TYPE, "recall"),
                   parameter_filler(LABEL, label),
                   parameter_filler(TARGET_HITS, target_hits),

--- a/tests/performance/nearest_neighbor/common_mips_base.rb
+++ b/tests/performance/nearest_neighbor/common_mips_base.rb
@@ -23,7 +23,7 @@ class CommonMipsBase < CommonAnnBaseTest
 
     prepare_queries_for_recall()
     [0, 90, 190, 490].each do |explore_hits|
-      calc_recall_for_queries(10, explore_hits, 0, 0.05, 0.0, 0.3, 0.0, doc_type, "embedding", query_tensor)
+      calc_recall_for_queries(10, explore_hits, {:doc_type => doc_type, :doc_tensor => "embedding", :query_tensor => query_tensor})
     end
   end
 

--- a/tests/performance/nearest_neighbor/common_sift_gist_base.rb
+++ b/tests/performance/nearest_neighbor/common_sift_gist_base.rb
@@ -41,10 +41,18 @@ class CommonSiftGistBase < CommonAnnBaseTest
     (threads_per_search > 0) ? "threads-#{threads_per_search}" : "default"
   end
 
-  def query_and_benchmark(algorithm, target_hits, explore_hits, filter_percent = 0, approximate_threshold = 0.05, filter_first_threshold = 0.0, filter_first_exploration = 0.3, slack = 0.0, clients = 1, threads_per_search = 0)
+  def query_and_benchmark(algorithm, target_hits, explore_hits, params = {})
+    filter_percent = params[:filter_percent] || 0
+    approximate_threshold = params[:approximate_threshold] || 0.05
+    filter_first_threshold = params[:filter_first_threshold] || 0.0
+    filter_first_exploration = params[:filter_first_exploration] || 0.3
+    slack = params[:slack] || 0.0
+    clients = params[:clients] || 1
+    threads_per_search = params[:threads_per_search] || 0
+
     approximate = algorithm == HNSW ? "true" : "false"
     query_file = fetch_query_file_to_container(approximate, target_hits, explore_hits, filter_percent)
-    label = "#{algorithm}-th#{target_hits}-eh#{explore_hits}-f#{filter_percent}-at#{approximate_threshold}-fft#{filter_first_threshold}-ffe#{filter_first_exploration}-sl#{slack}-n#{clients}-t#{threads_per_search}"
+    label = params[:label] || "#{algorithm}-th#{target_hits}-eh#{explore_hits}-f#{filter_percent}-at#{approximate_threshold}-fft#{filter_first_threshold}-ffe#{filter_first_exploration}-sl#{slack}-n#{clients}-t#{threads_per_search}"
     result_file = dirs.tmpdir + "fbench_result.#{label}.txt"
     fillers = [parameter_filler(TYPE, get_type_string(filter_percent, threads_per_search)),
                parameter_filler(LABEL, label),
@@ -85,8 +93,8 @@ class CommonSiftGistBase < CommonAnnBaseTest
     end
 
     [0.00, 0.05, 0.10, 0.15, 0.2, 0.3, 0.4, 0.5].each do |slack|
-      query_and_benchmark(HNSW, 10, 0, 0, 0.05, 0.0, 0.3, slack)
-      calc_recall_for_queries(10, 0, 0, 0.05, 0.0, 0.3, slack)
+      query_and_benchmark(HNSW, 10, 0, {:slack => slack})
+      calc_recall_for_queries(10, 0, {:slack => slack})
     end
   end
 
@@ -97,14 +105,14 @@ class CommonSiftGistBase < CommonAnnBaseTest
     end
 
     [0.00, 0.05, 0.10, 0.15, 0.2, 0.3, 0.4, 0.5].each do |slack|
-      query_and_benchmark(HNSW, 100, 0, 0, 0.05, 0.0, 0.3, slack)
-      calc_recall_for_queries(100, 0, 0, 0.05, 0.0, 0.3, slack)
+      query_and_benchmark(HNSW, 100, 0, {:slack => slack})
+      calc_recall_for_queries(100, 0, {:slack => slack})
     end
 
     # Now with filtering and filter first
     [0.00, 0.05, 0.10, 0.15, 0.2, 0.3, 0.4, 0.5].each do |slack|
-      query_and_benchmark(HNSW, 100, 0, 95, 0.00, 0.4, 0.3, slack)
-      calc_recall_for_queries(100, 0, 95, 0.00, 0.4, 0.3, slack)
+      query_and_benchmark(HNSW, 100, 0, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
+      calc_recall_for_queries(100, 0, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
     end
   end
 

--- a/tests/performance/nearest_neighbor/common_sift_gist_base.rb
+++ b/tests/performance/nearest_neighbor/common_sift_gist_base.rb
@@ -122,8 +122,8 @@ class CommonSiftGistBase < CommonAnnBaseTest
     assert_hitcount("query=sddocname:test", documents_to_benchmark)
 
     puts "Benchmarking before deletion"
-    query_and_benchmark(HNSW, 100, 0)
-    calc_recall_for_queries(100, 0)
+    query_and_benchmark(HNSW, 100, 0, {:label => "hnsw-th100-before-removal"})
+    calc_recall_for_queries(100, 0, {:label => "hnsw-th100-before-removal"})
 
     puts "Feeding the remaining documents..."
     feed_and_benchmark_range(file, "#{label}-#{documents_to_benchmark}-#{documents_in_total}", documents_to_benchmark, documents_in_total)
@@ -133,8 +133,8 @@ class CommonSiftGistBase < CommonAnnBaseTest
     assert_hitcount("query=sddocname:test", documents_to_benchmark)
 
     puts "Benchmarking after deletion"
-    query_and_benchmark(HNSW, 100, 0)
-    calc_recall_for_queries(100, 0)
+    query_and_benchmark(HNSW, 100, 0, {:label => "hnsw-th100-after-removal"})
+    calc_recall_for_queries(100, 0, {:label => "hnsw-th100-after-removal"})
   end
 
   def fetch_query_file_to_container(approximate, target_hits, explore_hits, filter_percent)


### PR DESCRIPTION
Add custom labels for before and after removal so that the data points can be distinguished. Use a hash for all optional parameters to also make the tests more readable.

@arnej27959 please review and merge