### PR TITLE
newest version of libxml-ruby does not load

### DIFF
--- a/docker/Dockerfile.alma8
+++ b/docker/Dockerfile.alma8
@@ -62,7 +62,8 @@ RUN --mount=type=bind,target=/context-root,source=.,ro \
         wget \
         zstd && \
     dnf install -y gcc && \
-    gem install ffi libxml-ruby parallel && \
+    gem install ffi parallel && \
+    gem install libxml-ruby -v 5.0.5 && \
     curl -sSLf "https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.zip" -o maven.zip && \
     curl -sSLf "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2-$(uname -m).zip" && \
     unzip -q maven.zip && \

--- a/docker/include/install-alma9.sh
+++ b/docker/include/install-alma9.sh
@@ -46,7 +46,8 @@ dnf -y install \
     rubygem-rexml \
     rubygem-test-unit
 
-gem install ffi libxml-ruby parallel
+gem install ffi parallel
+gem install libxml-ruby -v 5.0.5
 dnf remove -y gcc
 
 dnf -y install \


### PR DESCRIPTION
the newly released 5.0.6 version of libxml-ruby gem does not load, try forcing previous version.