### PR TITLE
Use Vespa Cloud mirror for multilingual-e5-large model

### DIFF
--- a/tests/search/embedding/embedding.rb
+++ b/tests/search/embedding/embedding.rb
@@ -54,8 +54,8 @@ class Embedding < SearchTest
   def huggingface_embedder_onnx_external_data_component
     Component.new('huggingface').
       type('hugging-face-embedder').
-      param('transformer-model', '', {'model-id' => 'ignored-on-selfhosted', 'url' => 'https://huggingface.co/intfloat/multilingual-e5-large/resolve/main/onnx/model.onnx'}).
-      param('tokenizer-model', '', {'model-id' => 'ignored-on-selfhosted', 'url' => 'https://huggingface.co/intfloat/multilingual-e5-large/resolve/main/onnx/tokenizer.json'})
+      param('transformer-model', '', {'model-id' => 'ignored-on-selfhosted', 'url' => 'https://data.vespa-cloud.com/onnx_models/multilingual-e5-large/model.onnx'}).
+      param('tokenizer-model', '', {'model-id' => 'ignored-on-selfhosted', 'url' => 'https://data.vespa-cloud.com/onnx_models/multilingual-e5-large/tokenizer.json'})
   end
 
   def nomic_modernbert_component


### PR DESCRIPTION
Switch the huggingface embedder test to download the multilingual-e5-large ONNX model and tokenizer from data.vespa-cloud.com instead of huggingface.co directly. This avoids rate-limiting and availability issues with the upstream HuggingFace service during CI runs.
