### PR TITLE
Add system test of pseudo row-column mode for down/retired node states

### DIFF
--- a/lib/app_generator/storage_cluster.rb
+++ b/lib/app_generator/storage_cluster.rb
@@ -17,6 +17,7 @@ class StorageCluster
   chained_setter :garbagecollectioninterval
   chained_setter :selection, :documentselection
   chained_setter :num_distributor_stripes
+  chained_setter :pseudo_row_column_mode
   chained_forward :fleet_controllers,
                   :min_storage_up_ratio => :min_storage_up_ratio,
                   :min_distributor_up_ratio => :min_distributor_up_ratio,
@@ -45,6 +46,7 @@ class StorageCluster
     @streaming = false
     @max_nodes_per_merge = 16
     @num_distributor_stripes = nil
+    @pseudo_row_column_mode = false
   end
 
   def sd(file_name, params = {})
@@ -135,8 +137,11 @@ class StorageCluster
                               :"minimum-bits" => @distribution_bits).close_tag.
       tag("max-document-size").content(@max_document_size).close_tag
 
-    if (@max_nodes_per_merge != 16)
+    if @max_nodes_per_merge != 16
       xml = xml.tag("merges", :"max-nodes-per-merge" => @max_nodes_per_merge).close_tag
+    end
+    if @pseudo_row_column_mode
+      xml = xml.tag("distribution").tag("pseudo-row-column-mode").content("true").close_tag.close_tag
     end
     xml.to_xml(@persistence_threads).
       to_xml(@fleet_controllers, :tuning_xml).

--- a/tests/vds/hierarchdistr/hierarchdistr.rb
+++ b/tests/vds/hierarchdistr/hierarchdistr.rb
@@ -5,6 +5,7 @@ require 'securerandom'
 class HierarchDistr < VdsMultiModelTest
 
   def setup
+    @distribution_bits = 12
     set_owner("vekterli")
   end
 
@@ -20,6 +21,7 @@ class HierarchDistr < VdsMultiModelTest
                StorageApp.new.enable_document_api.storage_cluster(
                  StorageCluster.new("storage").
                    redundancy(2).
+                   distribution_bits(@distribution_bits).
                    group(NodeGroup.new(0, "mycluster").
                      distribution("1|*").
                      group(
@@ -32,13 +34,14 @@ class HierarchDistr < VdsMultiModelTest
                            node(NodeSpec.new("node1", 3))))).
                sd(VDS + "/schemas/music.sd").
                transition_time(0).
-               validation_override("redundancy-increase");
+               validation_override("redundancy-increase")
   end
 
   def app3
                StorageApp.new.enable_document_api.storage_cluster(
                  StorageCluster.new("storage").
                    redundancy(2).
+                   distribution_bits(@distribution_bits).
                    group(NodeGroup.new(0, "mycluster").
                      distribution("*").
                      group(
@@ -52,13 +55,14 @@ class HierarchDistr < VdsMultiModelTest
                            node(NodeSpec.new("node1", 4))))).
                sd(VDS + "/schemas/music.sd").
                transition_time(0).
-               validation_override("redundancy-increase");
+               validation_override("redundancy-increase")
   end
 
   def app4
                StorageApp.new.enable_document_api.storage_cluster(
                  StorageCluster.new("storage").
                    redundancy(2).
+                   distribution_bits(@distribution_bits).
                    group(NodeGroup.new(0, "mycluster").
                      distribution("*|*").
                      group(
@@ -81,7 +85,7 @@ class HierarchDistr < VdsMultiModelTest
                                  node(NodeSpec.new("node1", 3)))))).
                sd(VDS + "/schemas/music.sd").
                transition_time(0).
-               validation_override("redundancy-increase");
+               validation_override("redundancy-increase")
  end
 
   def deploy_and_wait(app, start_services=nil)
@@ -101,6 +105,7 @@ class HierarchDistr < VdsMultiModelTest
                StorageApp.new.enable_document_api.storage_cluster(
                  StorageCluster.new("storage").
                    redundancy(2).
+                   distribution_bits(@distribution_bits).
                    group(NodeGroup.new(0, "mycluster").
                       node(NodeSpec.new("node1", 0)).
                       node(NodeSpec.new("node1", 1)).
@@ -108,40 +113,28 @@ class HierarchDistr < VdsMultiModelTest
                       node(NodeSpec.new("node1", 3)))).
                sd(VDS + "/schemas/music.sd").
                transition_time(0).
-               validation_override("redundancy-increase");
+               validation_override("redundancy-increase")
   end
 
   def test_app_change
     @valgrind = false
     deploy_and_wait(app2, true)
-    
-    feed_file = tempfile_name("1000_buckets_app2.json")
-    make_feed_file(feed_file, "music", 0, 999, 1)
-    feedfile(feed_file, :route => "storage")
-
-    get_all_docs(true)
+    feed_and_get_all_documents
 
     deploy_and_wait(app4)
     vespa.storage["storage"].wait_until_ready(300)
 
-    get_all_docs(true)
+    get_all_docs
 
     deploy_and_wait(nohierarchy)
     vespa.storage["storage"].wait_until_ready(300)
 
-    get_all_docs(true)
-
-    File.delete(feed_file)
+    get_all_docs
   end
 
   def test_app2
     deploy_and_wait(app2, true)
-
-    feed_file = tempfile_name("1000_buckets_app2.json")
-    make_feed_file(feed_file, "music", 0, 999, 1)
-    feedfile(feed_file, :route => "storage")
-
-    get_all_docs(true)
+    feed_and_get_all_documents
 
     set0 = get_buckets(0)
     set1 = get_buckets(1)
@@ -165,26 +158,19 @@ class HierarchDistr < VdsMultiModelTest
     vespa.stop_content_node('storage', 0)
     vespa.stop_content_node('storage', 1)
 
-    get_all_docs(false)
+    get_all_docs
     vespa.storage["storage"].storage["0"].wait_for_current_node_state('d')
     vespa.storage["storage"].storage["1"].wait_for_current_node_state('d')
     vespa.storage["storage"].wait_until_ready(300)
 
     # all data should still be available
-    get_all_docs(true)
-
-    File.delete(feed_file)
+    get_all_docs
   end
 
 
   def test_app3
     deploy_and_wait(app3, true)
-
-    feed_file = tempfile_name("1000_buckets_app3.json")
-    make_feed_file(feed_file, "music", 0, 999, 1)
-    feedfile(feed_file, :route => "storage")
-
-    get_all_docs(true)
+    feed_and_get_all_documents
 
     set0 = get_buckets(0)
     set1 = get_buckets(1)
@@ -207,7 +193,7 @@ class HierarchDistr < VdsMultiModelTest
 
     # take down node 0 in switch 0
     vespa.stop_content_node('storage', 0)
-    get_all_docs(false)
+    get_all_docs
     vespa.storage["storage"].storage["0"].wait_for_current_node_state('d')
     vespa.storage["storage"].wait_until_ready(300)
 
@@ -227,20 +213,13 @@ class HierarchDistr < VdsMultiModelTest
     assert set12new == set012
 
     # all data should still be available
-    get_all_docs(true)
-
-    File.delete(feed_file)
+    get_all_docs
   end
 
 
   def test_app4
     deploy_and_wait(app4, true)
-
-    feed_file = tempfile_name("1000_buckets_app4.json")
-    make_feed_file(feed_file, "music", 0, 999, 1)
-    feedfile(feed_file, :route => "storage")
-
-    get_all_docs(true)
+    feed_and_get_all_documents
 
     set0 = get_buckets(0)
     set1 = get_buckets(1)
@@ -264,7 +243,7 @@ class HierarchDistr < VdsMultiModelTest
 
     # take down node 0 in switch 0 rack 0
     vespa.stop_content_node('storage', 0)
-    get_all_docs(false)
+    get_all_docs
     vespa.storage["storage"].storage["0"].wait_for_current_node_state('d')
     vespa.storage["storage"].wait_until_ready(300)
 
@@ -278,35 +257,178 @@ class HierarchDistr < VdsMultiModelTest
     assert set3new == set3
 
     # all data should still be available
-    get_all_docs(true)
+    get_all_docs
+  end
 
+  def app_3x3_with_pseudo_row_column
+    StorageApp.new.enable_document_api.storage_cluster(
+      StorageCluster.new("storage").
+        redundancy(3).
+        distribution_bits(@distribution_bits).
+        pseudo_row_column_mode(true).
+        group(NodeGroup.new(0, "mycluster").
+          distribution("*|*|*").
+          group(
+            NodeGroup.new(0, "g0").
+              node(NodeSpec.new("node1", 0)).
+              node(NodeSpec.new("node1", 1)).
+              node(NodeSpec.new("node1", 2))).
+          group(
+            NodeGroup.new(1, "g1").
+              node(NodeSpec.new("node1", 3)).
+              node(NodeSpec.new("node1", 4)).
+              node(NodeSpec.new("node1", 5))).
+          group(
+            NodeGroup.new(2, "g3").
+              node(NodeSpec.new("node1", 6)).
+              node(NodeSpec.new("node1", 7)).
+              node(NodeSpec.new("node1", 8))))).
+      sd(VDS + "/schemas/music.sd").
+      transition_time(0)
+  end
+
+  def test_node_order_relative_replica_placement
+    deploy_app(app_3x3_with_pseudo_row_column)
+    start
+    feed_and_get_all_documents
+    buckets = get_3x3_bucket_matrix
+    puts 'Verifying that distinct columns have the same buckets across all rows'
+    assert_equal(buckets[0][0], buckets[1][0])
+    assert_equal(buckets[2][0], buckets[1][0])
+
+    assert_equal(buckets[0][1], buckets[1][1])
+    assert_equal(buckets[2][1], buckets[1][1])
+
+    assert_equal(buckets[0][2], buckets[1][2])
+    assert_equal(buckets[2][2], buckets[1][2])
+
+    3.times {|n| puts "Node #{n} has #{buckets[0][n].size} buckets" }
+
+    puts 'Verifying that there is no overlap of buckets between columns in a row'
+    # Since we've already checked column equivalence, this property
+    # shall transitively hold across rows (groups).
+    # Quick Ruby Set operator reminder; | is union, & is intersection, - is difference
+    assert_equal(buckets[0][0] & buckets[0][1], Set.new)
+    assert_equal(buckets[0][1] & buckets[0][2], Set.new)
+
+    puts '-------'
+    puts 'Testing that content node down has expected data movement'
+    puts '-------'
+    # Take down relative node 0 in group 1 (absolute distribution key 3).
+    # Just set node states instead of actually taking processes down/up
+    # since it's quite a bit faster.
+    set_content_node_state(3, 'd')
+
+    down_buckets = get_3x3_bucket_matrix(ignore: [3])
+    [1, 2].each do |i|
+      puts node_bucket_diff(3 + i, buckets[1][i], down_buckets[1][i])
+    end
+    puts 'Verifying no changes to buckets in groups without nodes down'
+    assert_equal(down_buckets[0], buckets[0])
+    assert_equal(down_buckets[2], buckets[2])
+    puts 'Verifying that remaining nodes in group 1 have taken over data ownership from downed node'
+    all_buckets = buckets[0][0] | buckets[0][1] | buckets[0][2]
+    assert_equal(down_buckets[1][1] | down_buckets[1][2], all_buckets)
+    puts 'Verifying minimal data movement'
+    # Should only have gotten _new_ buckets from node 0, should not have moved its own away
+    assert_equal(down_buckets[1][1] - buckets[1][0], buckets[1][1])
+    assert_equal(down_buckets[1][2] - buckets[1][0], buckets[1][2])
+
+    puts 'Verifying that clients send to correct distributors'
+    feed_and_get_all_documents
+    set_content_node_state(3, 'u')
+
+    puts 'Verifying that buckets are back in their original locations'
+    up_buckets = get_3x3_bucket_matrix
+    assert_equal(up_buckets, buckets)
+
+    puts '-------'
+    puts 'Testing that node retirement shifts bucket placement away'
+    puts '-------'
+    # Retirement working "as if" a node has been removed from the config is a
+    # double-edged sword, since it allows for functionally replacing a node
+    # verbatim without moving data to other nodes. But if no replacement node
+    # is added at the same time as retiring and old node, bucket ownership is
+    # "shifted" by one.
+    # Relative node 1 in group 2 (absolute distribution key 7).
+    set_content_node_state(7, 'r')
+    retired_buckets = get_3x3_bucket_matrix
+    [0, 1, 2].each do |i|
+      puts node_bucket_diff(6 + i, buckets[2][i], retired_buckets[2][i])
+    end
+    puts 'Verifying no bucket movement in unrelated groups'
+    assert_equal(retired_buckets[0], buckets[0])
+    assert_equal(retired_buckets[1], buckets[1])
+    puts 'Verifying buckets have shifted away from the retired node'
+    assert_equal(retired_buckets[2][1], Set.new)
+    puts 'Verifying retired buckets have found a new home on the other nodes'
+    union_buckets = retired_buckets[2][0] | retired_buckets[2][2]
+    assert_equal(union_buckets & buckets[2][1], buckets[2][1])
+    puts 'Verifying all other buckets are still present'
+    assert_equal(union_buckets & buckets[2][0], buckets[2][0])
+    assert_equal(union_buckets & buckets[2][2], buckets[2][2])
+
+    puts 'Verifying that clients send to correct distributors'
+    feed_and_get_all_documents
+  end
+
+  def feed_and_get_all_documents
+    # Any of these should fail if the container client is unable to send to the correct distributor
+    feed_n_buckets(1000)
+    get_all_docs
+  end
+
+  # Returns a groups*nodes row (group) major matrix
+  def get_bucket_matrix(n_groups, n_nodes, ignore)
+    buckets = []
+    n_groups.times { |group|
+      buckets << []
+      n_nodes.times { |node|
+        node_key = n_groups*group + node
+        b = ignore.include?(node_key) ? 0 : get_buckets(node_key)
+        buckets[group] << b
+      }
+    }
+    buckets
+  end
+
+  def get_3x3_bucket_matrix(ignore: [])
+    get_bucket_matrix(3, 3, ignore)
+  end
+
+  # Feed n docs so that each fed document is placed into its own distinct bucket.
+  # Note that this requires that n < 2^@distribution_bits to avoid super bucket overlap.
+  def feed_n_buckets(n)
+    assert n > 0
+    feed_file = tempfile_name("buckets_feed.json")
+    make_feed_file(feed_file, 'music', 0, n - 1, 1)
+    feedfile(feed_file, :route => 'storage')
     File.delete(feed_file)
   end
 
-
-  def get_all_docs(do_assert)
-    if do_assert
-      puts "Get all docs..."
-    end
-    begin
-      1000.times {|i|
-        doc = Document.new("id:music:music:n=#{i}:0:system_test")
-        doc2 = vespa.document_api_v1.get("id:music:music:n=#{i}:0:system_test", :brief => true)
-        if do_assert
-          assert_equal(doc, doc2)
-        end
-      }
-    rescue RuntimeError
-      # Ignored
-    end
-    if do_assert
-      puts "Ok. Got all docs."
-    end
+  def get_all_docs
+    puts "Getting all docs..."
+    1000.times {|i|
+      doc = Document.new("id:music:music:n=#{i}:0:system_test")
+      doc2 = vespa.document_api_v1.get("id:music:music:n=#{i}:0:system_test", :brief => true)
+      assert_equal(doc, doc2)
+    }
+    puts "Ok. Got all docs."
   end
 
   def get_buckets(node)
     vespa.storage['storage'].storage[node.to_s].get_buckets['default'].keys.to_set
   end
 
+  def set_content_node_state(idx, state)
+    cc = vespa.storage['storage'].get_master_cluster_controller
+    cc.set_node_state('storage', 'storage', idx, "s:#{state}")
+    vespa.storage['storage'].wait_until_ready(300)
+  end
+
+  def node_bucket_diff(node_idx, buckets_before, buckets_after)
+    "Node #{node_idx} got #{(buckets_after - buckets_before).size} new buckets, " +
+      "removed #{(buckets_before - buckets_after).size} buckets (now has #{buckets_after.size})"
+  end
 
 end


### PR DESCRIPTION
@toregge please review

This tests that fundamental properties of the ideal state algorithm also hold in pseudo row-column mode for nodes in down/retired states.

For both states, other nodes within a group (row) must take over buckets. For down state, the minimal data movement properties of the algorithm shall hold. This is however not the case for retired states.

Also ensure that we run hierarchical distribution tests with a distribution bit level that is high enough that all fed documents end up in their own logical bucket (this seems to have been lost when tests were moved to 8 distribution bits many moons ago to speed up visiting and maintenance ops). Doesn't affect correctness, but for all things pseudo-random, more sample points == better...!
