### PR TITLE
Use Maven 3.9.15 [MERGEOK]

### DIFF
--- a/docker/Dockerfile.alma8
+++ b/docker/Dockerfile.alma8
@@ -24,7 +24,7 @@ RUN dnf install -y gcc-c++ python3-devel && \
 FROM $VESPA_BASE_IMAGE AS systemtest
 
 ARG JAVA_VERSION=17
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 ENV LANG=en_US.UTF-8
 
 USER root


### PR DESCRIPTION
3.9.14 has been removed from https://dlcdn.apache.org/maven/maven-3/
