### PR TITLE
Extract VespaAssertions module from Assertions

### DIFF
--- a/lib/assertions.rb
+++ b/lib/assertions.rb
@@ -2,7 +2,6 @@
 
 require 'assertionfailederror'
 require 'backtracefilter'
-require 'tensor_result'
 
 module Assertions
 
@@ -90,19 +89,6 @@ EOT
         puts diff
     end
     assert_block(full_message) { expected == actual }
-  end
-
-  # Passes if the JSON parsed value of expected string is
-  # equal to the JSON parsed value of actual.
-  def assert_json_string_equal(expected, actual)
-      assert_equal(JSON.parse(expected), JSON.parse(actual))
-  end
-
-  # Converts parsed canonical tensors to objects and compares
-  def assert_tensors_equal(expected, actual)
-      exp = TensorResult.new(expected)
-      act = TensorResult.new(actual)
-      assert_equal(exp, act, "Tensors should be equal: Expected #{exp} != Actual #{act}")
   end
 
   private

--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -1,6 +1,7 @@
 # Copyright Vespa.ai. All rights reserved.
 # -*- coding: utf-8 -*-
 require 'assertions'
+require 'vespa_assertions'
 require 'test/unit/assertion-failed-error'
 require 'error'
 require 'failure'
@@ -28,6 +29,7 @@ end
 class TestCase
   include DRb::DRbUndumped
   include Assertions
+  include VespaAssertions
   include TestBase
 
   attr_reader :selfdir, :dirs, :testcase_file, :cmd_args, :timeout, :max_memory, :keep_tmpdir, :leave_loglevels, :tls_env, :https_client, :perf_recording

--- a/lib/vespa_assertions.rb
+++ b/lib/vespa_assertions.rb
@@ -1,0 +1,18 @@
+# Copyright Vespa.ai. All rights reserved.
+
+require 'json'
+require 'tensor_result'
+
+module VespaAssertions
+
+  def assert_json_string_equal(expected, actual)
+    assert_equal(JSON.parse(expected), JSON.parse(actual))
+  end
+
+  def assert_tensors_equal(expected, actual)
+    exp = TensorResult.new(expected)
+    act = TensorResult.new(actual)
+    assert_equal(exp, act, "Tensors should be equal: Expected #{exp} != Actual #{act}")
+  end
+
+end


### PR DESCRIPTION
## Summary
- Move `assert_json_string_equal` and `assert_tensors_equal` into a new `VespaAssertions` module in `lib/vespa_assertions.rb`
- Remove these methods from the generic `Assertions` module, along with the now-redundant `require 'tensor_result'`
- Include `VespaAssertions` in `TestCase` so all test subclasses continue to have access without changes

Part of work trying to remove lib/assertions.rb

## Test plan
- [ ] Verify tests using `assert_json_string_equal` still pass (e.g. `tests/vds/documentapi/`, `tests/search/httpgateway/documentv1.rb`)
- [ ] Verify tests using `assert_tensors_equal` still pass (e.g. `tests/search/tensor_feed/`)