### PR TITLE
Fix assert() (use assert_equal)

### DIFF
--- a/tests/vds/redundancy.rb
+++ b/tests/vds/redundancy.rb
@@ -119,9 +119,11 @@ class Redundancy < PersistentProviderTest
     assert(statinfo.has_key?("0"))
     assert(statinfo.has_key?("1"))
 
-    # Check that document B is on neither node
+    # Check that document B is on both nodes with status DELETED
     statinfo = vespa.storage["storage"].storage["0"].stat("id:crawler:music::http://yahoo.com/B", include_owner: false)
-    assert_equal(0, statinfo.size)
+    assert_equal(2, statinfo.size)
+    assert_equal("DELETED", statinfo["0"]["status"])
+    assert_equal("DELETED", statinfo["1"]["status"])
   end
 
 

--- a/tests/vds/redundancy.rb
+++ b/tests/vds/redundancy.rb
@@ -121,7 +121,7 @@ class Redundancy < PersistentProviderTest
 
     # Check that document B is on neither node
     statinfo = vespa.storage["storage"].storage["0"].stat("id:crawler:music::http://yahoo.com/B", include_owner: false)
-    assert(0, statinfo.size)
+    assert_equal(0, statinfo.size)
   end
 
 


### PR DESCRIPTION
Fixed to use assert_equal, but now test fails with:

  1) ERROR IN 'Redundancy::test_kill_node__PROTON()': AssertionFailedError: <0> expected but was
<2>.

     at /yahoo-systemtests/system-test/tests/vds/redundancy.rb:124:in `test_kill_node'

Help! 🙃 