### PR TITLE
Add system test for first phase max

### DIFF
--- a/tests/search/first-phase-max/docs.json
+++ b/tests/search/first-phase-max/docs.json
@@ -1,0 +1,32 @@
+[
+    {
+        "put": "id:test:test::1",
+        "fields": {
+            "order": 100
+        }
+    },
+    {
+        "put": "id:test:test::2",
+        "fields": {
+            "order": 150
+        }
+    },
+    {
+        "put": "id:test:test::3",
+        "fields": {
+            "order": 200
+        }
+    },
+    {
+        "put": "id:test:test::4",
+        "fields": {
+            "order": 250
+        }
+    },
+    {
+        "put": "id:test:test::5",
+        "fields": {
+            "order": 300
+        }
+    }
+]

--- a/tests/search/first-phase-max/first_phase_max.rb
+++ b/tests/search/first-phase-max/first_phase_max.rb
@@ -1,0 +1,51 @@
+# Copyright Vespa.ai. All rights reserved.
+
+require 'indexed_only_search_test'
+
+class FirstPhaseMax < IndexedOnlySearchTest
+
+  def setup
+    set_owner('johsol')
+    deploy_app(SearchApp.new.sd(selfdir + 'test.sd'))
+    start
+    feed_and_wait_for_docs('test', 5, :file => selfdir + 'docs.json')
+  end
+
+  def test_first_phase_max
+    # firstPhaseMax exposes the largest first-phase rank score computed on the node.
+    # max(order) = 300, second-phase = order + firstPhaseMax = order + 300.
+    result = search({'query' => 'sddocname:test', 'ranking' => 'default'})
+    assert_equal(5, result.hitcount)
+    assert_equal([600.0, 550.0, 500.0, 450.0, 400.0], extract_scores(result))
+    assert_equal([300.0, 300.0, 300.0, 300.0, 300.0], extract_features(result, 'matchfeatures', 'firstPhaseMax'))
+  end
+
+  def test_dynamic_relative_threshold
+    # Simulates a relative drop threshold: keep hits where first-phase score
+    # is at least 70% of the per-node first-phase max, otherwise emit -1 so
+    # rank-score-drop-limit drops them.
+    # max(order) = 300, threshold = 0.7 * 300 = 210.
+    # Only order >= 210 (i.e. 250, 300) survives. Score = order * 2.
+    result = search({'query' => 'sddocname:test', 'ranking' => 'dynamic_threshold'})
+    assert_equal(2, result.hitcount)
+    assert_equal([600.0, 500.0], extract_scores(result))
+    assert_equal([300.0, 300.0], extract_features(result, 'matchfeatures', 'firstPhaseMax'))
+  end
+
+  def extract_features(result, field, feature)
+    features = []
+    result.hit.each do |h|
+      features.push(h.field[field][feature])
+    end
+    features
+  end
+
+  def extract_scores(result)
+    scores = []
+    result.hit.each do |h|
+      scores.push(h.field['relevancy'])
+    end
+    scores
+  end
+
+end

--- a/tests/search/first-phase-max/test.sd
+++ b/tests/search/first-phase-max/test.sd
@@ -1,0 +1,48 @@
+# Copyright Vespa.ai. All rights reserved.
+
+schema test {
+
+  document test {
+    field order type int {
+      indexing: attribute | summary
+    }
+  }
+
+  rank-profile default {
+    first-phase {
+      expression: attribute(order)
+    }
+    second-phase {
+      expression: attribute(order) + firstPhaseMax
+    }
+    match-features {
+      attribute(order)
+      firstPhaseMax
+    }
+  }
+
+  rank-profile dynamic_threshold {
+    function raw_second_phase() {
+      expression: attribute(order) * 2
+    }
+    function relative_threshold() {
+      expression: 0.7 * firstPhaseMax
+    }
+    function gated() {
+      expression: if (attribute(order) >= relative_threshold, raw_second_phase, -1)
+    }
+    first-phase {
+      expression: attribute(order)
+    }
+    second-phase {
+      expression: gated
+      rerank-count: 100
+      rank-score-drop-limit: 0.0
+    }
+    match-features {
+      attribute(order)
+      firstPhaseMax
+    }
+  }
+
+}


### PR DESCRIPTION
Use `firstPhaseMax` in the second phase to use the highest first-phase rank score in rank expressions.

Added `test_dynamic_relative_threshold`, which is the use-case related to the feature request.

