### PR TITLE
Adapt document-ids-in-memory test to change in file format

### DIFF
--- a/tests/search/docids/docids_in_memory.rb
+++ b/tests/search/docids/docids_in_memory.rb
@@ -11,7 +11,7 @@ class DocIdsInMemoryTest < IndexedOnlySearchTest
   def setup
     set_owner("boeker")
     @doc1 = Document.new("id:storage_test:test:n=1234:1").add_field("some_field", 42)
-    @docid_file_size = 0x1000 + 8 + 29 # Header + bytes for length of string + bytes for actual string
+    @docid_file_size = 0x1000 + 4 + 29 # Header + bytes for length of string + bytes for actual string
   end
 
   def feed_and_assert_visiting_docids()


### PR DESCRIPTION
Only four instead of eight bytes used with https://github.com/vespa-engine/vespa/pull/36816.