### PR TITLE
chore: bump test perf deps to latest (sweeps VESPANG-3350 Mend HIGH CVEs)

### DIFF
--- a/tests/performance/ecommerce_hybrid_search/common/requirements.txt
+++ b/tests/performance/ecommerce_hybrid_search/common/requirements.txt
@@ -1,7 +1,8 @@
-docker
-elasticsearch
-pyvespa
-vespacli
-tqdm
-requests
-zstandard
+docker>=7.1.0
+elasticsearch>=9.4.0
+pyvespa>=1.2.0
+vespacli>=8.687.75
+tqdm>=4.67.3
+requests>=2.34.0
+zstandard>=0.25.0
+urllib3>=2.7.0


### PR DESCRIPTION
## Summary
Sweep the unpinned `tests/performance/ecommerce_hybrid_search/common/requirements.txt` to current latest-stable versions and add an explicit `urllib3>=2.7.0` floor to cover the Mend HIGH CVEs (`CVE-2026-44432`, `CVE-2026-44431`) tracked in [VESPANG-3350](https://vespa.atlassian.net/browse/VESPANG-3350). `urllib3` is pulled transitively by `docker`, `requests`, and `elasticsearch` — pinning a direct floor in the same manifest guarantees the perf-test environment resolves to a fixed `urllib3`.

`urllib3==2.7.0` is the current latest stable on PyPI and is above the affected ranges for both CVEs.

Resolver coherence sanity-checked with `uv pip compile` — resolves to `urllib3==2.7.0`, no conflicts.

## Changes
`tests/performance/ecommerce_hybrid_search/common/requirements.txt` — all direct deps moved from unpinned to `>=` floor at latest stable:

| Package | New floor |
|---|---|
| docker | >=7.1.0 |
| elasticsearch | >=9.4.0 |
| pyvespa | >=1.2.0 |
| vespacli | >=8.687.75 |
| tqdm | >=4.67.3 |
| requests | >=2.34.0 |
| zstandard | >=0.25.0 |
| urllib3 (new, explicit) | >=2.7.0 |

## Test plan
- [ ] CI green
- [ ] Perf-test environment installs cleanly from the manifest

---
This PR was generated automatically by [Claude Code](https://claude.com/claude-code) (Opus 4.7) following the Vespa security-workflow skill. Human review is still expected before merge.