### PR TITLE
Preserve custom filter_backtrace when using Test::Unit::Assertions

### DIFF
--- a/lib/test/unit_test.rb
+++ b/lib/test/unit_test.rb
@@ -5,6 +5,7 @@ require 'test_base'
 class UnitTest
   include TestBase
   include Test::Unit::Assertions
+  include BacktraceFilter
 
   def initialize(vespamodel)
     deploy_mock(vespamodel)

--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -3,6 +3,7 @@
 require 'assertions'
 require 'vespa_assertions'
 require 'test/unit/assertion-failed-error'
+require 'test/unit/assertions'
 require 'error'
 require 'failure'
 require 'test_base'
@@ -15,6 +16,35 @@ require 'timeout'
 require 'net/http'
 require 'fileutils'
 require 'vespa_cleanup'
+
+module Test
+  module Unit
+    class AssertionMessage
+      class << self
+        include BacktraceFilter
+
+        if method_defined?(:convert)
+          alias_method :convert_without_backtrace_filter, :convert
+
+          def convert(object)
+            case object
+            when Exception
+              <<EOM.chop
+Class: <#{convert(object.class)}>
+Message: <#{convert(object.message)}>
+---Backtrace---
+#{filter_backtrace(object.backtrace).join("\n")}
+---------------
+EOM
+            else
+              convert_without_backtrace_filter(object)
+            end
+          end
+        end
+      end
+    end
+  end
+end
 
 class SystemTestTimeout < Interrupt
   def message
@@ -29,6 +59,7 @@ end
 class TestCase
   include DRb::DRbUndumped
   include Assertions
+  include BacktraceFilter
   include VespaAssertions
   include TestBase
 


### PR DESCRIPTION
## Summary
- Patches `Test::Unit::AssertionMessage.convert` to format `Exception` objects using our custom `BacktraceFilter` (class, message, filtered backtrace) instead of the gem's default pretty-print behavior
- Includes `BacktraceFilter` in `TestCase` and `UnitTest` so `filter_backtrace` is available on test instances
- Adds `require 'test/unit/assertions'` to `testcase.rb` to ensure `Test::Unit::AssertionMessage` is defined before the patch is applied

This is a preparatory step for removing `lib/assertions.rb` and migrating fully to `Test::Unit::Assertions`.