### PR TITLE
Revert "Preserve custom filter_backtrace when using Test::Unit::Assertions"

### DIFF
--- a/lib/test/unit_test.rb
+++ b/lib/test/unit_test.rb
@@ -5,7 +5,6 @@ require 'test_base'
 class UnitTest
   include TestBase
   include Test::Unit::Assertions
-  include BacktraceFilter
 
   def initialize(vespamodel)
     deploy_mock(vespamodel)

--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -3,7 +3,6 @@
 require 'assertions'
 require 'vespa_assertions'
 require 'test/unit/assertion-failed-error'
-require 'test/unit/assertions'
 require 'error'
 require 'failure'
 require 'test_base'
@@ -16,35 +15,6 @@ require 'timeout'
 require 'net/http'
 require 'fileutils'
 require 'vespa_cleanup'
-
-module Test
-  module Unit
-    class AssertionMessage
-      class << self
-        include BacktraceFilter
-
-        if method_defined?(:convert)
-          alias_method :convert_without_backtrace_filter, :convert
-
-          def convert(object)
-            case object
-            when Exception
-              <<EOM.chop
-Class: <#{convert(object.class)}>
-Message: <#{convert(object.message)}>
----Backtrace---
-#{filter_backtrace(object.backtrace).join("\n")}
----------------
-EOM
-            else
-              convert_without_backtrace_filter(object)
-            end
-          end
-        end
-      end
-    end
-  end
-end
 
 class SystemTestTimeout < Interrupt
   def message
@@ -59,7 +29,6 @@ end
 class TestCase
   include DRb::DRbUndumped
   include Assertions
-  include BacktraceFilter
   include VespaAssertions
   include TestBase
 


### PR DESCRIPTION
Reverts vespa-engine/system-test#4907

Please review only, merge if this breaks something