### PR TITLE
Add performance test for tensorFromStructs ranking feature

### DIFF
--- a/tests/performance/tensor_from_structs/data_generator.cpp
+++ b/tests/performance/tensor_from_structs/data_generator.cpp
@@ -1,0 +1,242 @@
+// Copyright Vespa.ai. All rights reserved.
+
+#include <algorithm>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+// Compile: g++ -Wl,-rpath,$vespa_home/lib64/ -Wall -g -O3 -o data_generator data_generator.cpp
+
+inline int rand_int(int max) {
+    return std::rand() % max;
+}
+
+inline int rand_iw() {
+    return rand_int(20) - 5;
+}
+
+inline float rand_float() {
+    return static_cast<float>(rand_int(10000)) / 1000.0f - 2.0f;
+}
+
+// smap: map<string,float> — keys "0".."size-1" match imap and skv for tensorFromStructs
+std::ostream& generate_smap(std::ostream& os, int size) {
+    os << "{";
+    for (int i = 0; i < size; ++i) {
+        if (i != 0)
+            os << ",";
+        os << "\"" << i << "\":" << rand_float();
+    }
+    return os << "}";
+}
+
+// imap: map<int,int> — int keys 0..size-1 become string labels matching smap
+std::ostream& generate_imap(std::ostream& os, int size) {
+    os << "{";
+    for (int i = 0; i < size; ++i) {
+        if (i != 0)
+            os << ",";
+        os << "\"" << i << "\":" << rand_iw();
+    }
+    return os << "}";
+}
+
+// skv: array<kvs> = {k: string, v: float} — k values "0".."size-1" match smap/imap
+std::ostream& generate_skv(std::ostream& os, int size) {
+    os << "[";
+    for (int i = 0; i < size; ++i) {
+        if (i != 0)
+            os << ",";
+        os << "{\"k\":\"" << i << "\",\"v\":" << rand_float() << "}";
+    }
+    return os << "]";
+}
+
+static const std::vector<std::string> k2_labels = {"a", "b", "c", "d", "e"};
+
+// sk2v: array<k2vs> = {k1: string, k2: string, v: float} — k1 values match skv.k
+std::ostream& generate_sk2v(std::ostream& os, int size) {
+    os << "[";
+    bool first = true;
+    for (int i = 0; i < size; ++i) {
+        for (const auto& k2 : k2_labels) {
+            if (!first)
+                os << ",";
+            os << "{\"k1\":\"" << i << "\",\"k2\":\"" << k2 << "\",\"v\":" << rand_float() << "}";
+            first = false;
+        }
+    }
+    return os << "]";
+}
+
+// ik2v: array<k2vi> = {k1: int, k2: int, v: float}
+std::ostream& generate_ik2v(std::ostream& os, int size) {
+    os << "[";
+    for (int i = 0; i < size; ++i) {
+        if (i != 0)
+            os << ",";
+        os << "{\"k1\":" << i << ",\"k2\":" << rand_int(size) << ",\"v\":" << rand_float() << "}";
+    }
+    return os << "]";
+}
+
+// sk3v: array<k3vs> = {k1, k2, k4: string, v: float}
+std::ostream& generate_sk3v(std::ostream& os, int size) {
+    os << "[";
+    for (int i = 0; i < size; ++i) {
+        if (i != 0)
+            os << ",";
+        os << "{\"k1\":\"" << i << "\",\"k2\":\"" << k2_labels[rand_int(k2_labels.size())] << "\",\"k4\":\""
+           << k2_labels[rand_int(k2_labels.size())] << "\",\"v\":" << rand_float() << "}";
+    }
+    return os << "]";
+}
+
+// sk4v: array<k4vs> = {k1,k2,k3,k4: string, v: float}
+std::ostream& generate_sk4v(std::ostream& os, int size) {
+    os << "[";
+    for (int i = 0; i < size; ++i) {
+        if (i != 0)
+            os << ",";
+        os << "{\"k1\":\"" << i << "\",\"k2\":\"" << k2_labels[rand_int(k2_labels.size())] << "\",\"k3\":\""
+           << k2_labels[rand_int(k2_labels.size())] << "\",\"k4\":\"" << k2_labels[rand_int(k2_labels.size())]
+           << "\",\"v\":" << rand_float() << "}";
+    }
+    return os << "]";
+}
+
+// sk5v: array<k5vs> = {k1-k5: string, v: float}
+std::ostream& generate_sk5v(std::ostream& os, int size) {
+    os << "[";
+    for (int i = 0; i < size; ++i) {
+        if (i != 0)
+            os << ",";
+        os << "{\"k1\":\"" << i << "\",\"k2\":\"" << k2_labels[rand_int(k2_labels.size())] << "\",\"k3\":\""
+           << k2_labels[rand_int(k2_labels.size())] << "\",\"k4\":\"" << k2_labels[rand_int(k2_labels.size())]
+           << "\",\"k5\":\"" << k2_labels[rand_int(k2_labels.size())] << "\",\"v\":" << rand_float() << "}";
+    }
+    return os << "]";
+}
+
+// ik5v: array<k5vi> = {k1-k5: int, v: float}
+std::ostream& generate_ik5v(std::ostream& os, int size) {
+    os << "[";
+    for (int i = 0; i < size; ++i) {
+        if (i != 0)
+            os << ",";
+        os << "{\"k1\":\"" << i << "\",\"k2\":\"" << rand_int(1000) << "\",\"k3\":\""
+           << rand_int(1000) << "\",\"k4\":\"" << rand_int(1000)
+           << "\",\"k5\":\"" << rand_int(1000) << "\",\"v\":" << rand_float() << "}";
+    }
+    return os << "]";
+}
+
+// mix5: array<k5vmix> = {k1: string, k2: int, k3: string, k4: int, k5: string, v: int}
+std::ostream& generate_mix5(std::ostream& os, int size) {
+    os << "[";
+    for (int i = 0; i < size; ++i) {
+        if (i != 0)
+            os << ",";
+        os << "{\"k1\":\"" << i << "\",\"k2\":" << rand_int(size) << ",\"k3\":\""
+           << k2_labels[rand_int(k2_labels.size())] << "\",\"k4\":" << rand_int(size) << ",\"k5\":\""
+           << k2_labels[rand_int(k2_labels.size())] << "\",\"v\":" << rand_iw() << "}";
+    }
+    return os << "]";
+}
+
+void generate_put(std::ostream& os, int doc_id, int size) {
+    os << "{\"put\":\"id:test:test::" << doc_id << "\",\"fields\":{" << std::endl;
+    os << "\"title\":\"doc " << doc_id << "\"," << std::endl;
+    os << "\"smap\":";
+    generate_smap(os, size);
+    os << "," << std::endl;
+    os << "\"imap\":";
+    generate_imap(os, size);
+    os << "," << std::endl;
+    os << "\"skv\":";
+    generate_skv(os, size);
+    os << "," << std::endl;
+    os << "\"sk2v\":";
+    generate_sk2v(os, size);
+    os << "," << std::endl;
+    os << "\"ik2v\":";
+    generate_ik2v(os, size);
+    os << "," << std::endl;
+    os << "\"sk3v\":";
+    generate_sk3v(os, size);
+    os << "," << std::endl;
+    os << "\"sk4v\":";
+    generate_sk4v(os, size);
+    os << "," << std::endl;
+    os << "\"sk5v\":";
+    generate_sk5v(os, size);
+    os << "," << std::endl;
+    os << "\"ik5v\":";
+    generate_ik5v(os, size);
+    os << "," << std::endl;
+    os << "\"mix5\":";
+    generate_mix5(os, size) << std::endl;
+    os << "}}";
+}
+
+std::vector<int> generate_doc_ids(int num_docs, bool shuffle) {
+    std::vector<int> result(num_docs);
+    std::iota(result.begin(), result.end(), 0);
+    if (shuffle) {
+        std::mt19937 rng(std::rand());
+        std::shuffle(result.begin(), result.end(), rng);
+    }
+    return result;
+}
+
+template <typename Func>
+void generate_ops(std::ostream& os, const std::vector<int>& doc_ids, int num_runs, Func& op_func) {
+    os << "[" << std::endl;
+    bool first = true;
+    for (int i = 0; i < num_runs; ++i) {
+        for (int doc_id : doc_ids) {
+            if (!first) {
+                os << "," << std::endl;
+            }
+            op_func(os, doc_id);
+            first = false;
+        }
+    }
+    os << std::endl << "]" << std::endl;
+}
+
+void generate_puts(std::ostream& os, int num_docs, int size) {
+    auto op_func = [=](std::ostream& os, int doc_id) { generate_put(os, doc_id, size); };
+    generate_ops(os, generate_doc_ids(num_docs, false), 1, op_func);
+}
+
+void usage(char* argv[]) {
+    std::cerr << argv[0] << " put <num-docs> [<size>]" << std::endl;
+}
+
+bool verify_usage(int argc, char* argv[]) {
+    if (argc != 3 && argc != 4 && argc != 5) {
+        usage(argv);
+        return false;
+    }
+    return true;
+}
+
+int main(int argc, char* argv[]) {
+    if (!verify_usage(argc, argv)) {
+        return 1;
+    }
+    std::srand(123);
+    std::string operation = argv[1];
+    int         num_docs = std::stoi(argv[2]);
+    if (operation == "put") {
+        int size = (argc >= 4) ? std::stoi(argv[3]) : 100;
+        generate_puts(std::cout, num_docs, size);
+    } else {
+        usage(argv);
+        return 1;
+    }
+    return 0;
+}

--- a/tests/performance/tensor_from_structs/qf.1
+++ b/tests/performance/tensor_from_structs/qf.1
@@ -1,0 +1,1 @@
+/search/?query=title:doc&hits=42

--- a/tests/performance/tensor_from_structs/tensor_from_structs.rb
+++ b/tests/performance/tensor_from_structs/tensor_from_structs.rb
@@ -1,0 +1,64 @@
+# coding: utf-8
+# Copyright Vespa.ai. All rights reserved.
+require 'performance_test'
+require 'performance/fbench'
+require 'app_generator/search_app'
+require 'environment'
+
+class TensorFromStructsPerfTest < PerformanceTest
+
+  def initialize(*args)
+    super(*args)
+  end
+
+  def setup
+    super
+    set_owner('arnej')
+    @perf_recording = 'some'
+  end
+
+  def create_app
+    SearchApp.new.sd(selfdir + 'test.sd').disable_flush_tuning.
+      container(Container.new.search(Searching.new).
+                  jvmoptions('-Xms8g -Xmx8g'))
+  end
+
+  def test_make_tensor_from_struct
+    set_description('Test query performance while making tensors from structs')
+    deploy_app(create_app)
+    start
+    @container = vespa.container.values.first
+    compile_data_generator
+    @num_docs = 100
+    feed_docs(@num_docs)
+    run_queries('default')
+    run_queries('combine2keys')
+  end
+
+  def feeder_numthreads
+      3
+  end
+
+  def compile_data_generator
+    tmp_bin_dir = vespa.adminserver.create_tmp_bin_dir
+    @data_generator = "#{tmp_bin_dir}/data_generator"
+    vespa.adminserver.execute("g++ -Wl,-rpath,#{Environment.instance.vespa_home}/lib64/ -Wall -g -O3 -o #{@data_generator} #{selfdir}/data_generator.cpp")
+  end
+
+  def feed_docs(num_docs)
+    feed_stream("#{@data_generator} put #{num_docs}")
+  end
+
+  def run_queries(rank_profile)
+    @container.copy(selfdir + 'qf.1', dirs.tmpdir)
+    fillers = [ parameter_filler('ranking', rank_profile) ]
+    profiler_start
+    run_fbench2(@container,
+                dirs.tmpdir + 'qf.1',
+                {:runtime => 30, :clients => 30,
+                 :append_str => "&ranking=#{rank_profile}&timeout=10"},
+                fillers)
+    profiler_report(rank_profile)
+  end
+
+end

--- a/tests/performance/tensor_from_structs/test.sd
+++ b/tests/performance/tensor_from_structs/test.sd
@@ -1,0 +1,132 @@
+# Copyright Vespa.ai. All rights reserved.
+schema test {
+    struct kvs {
+        field k type string {}
+        field v type float {}
+    }
+    struct k2vs {
+        field k1 type string {}
+        field k2 type string {}
+        field v type float {}
+    }
+    struct k2vi {
+        field k1 type int {}
+        field k2 type int {}
+        field v type float {}
+    }
+    struct k3vs {
+        field k1 type string {}
+        field k2 type string {}
+        field k4 type string {}
+        field v type float {}
+    }
+    struct k4vs {
+        field k1 type string {}
+        field k2 type string {}
+        field k3 type string {}
+        field k4 type string {}
+        field v type float {}
+    }
+    struct k5vs {
+        field k1 type string {}
+        field k2 type string {}
+        field k3 type string {}
+        field k4 type string {}
+        field k5 type string {}
+        field v type float {}
+    }
+    struct k5vi {
+        field k1 type int {}
+        field k2 type int {}
+        field k3 type int {}
+        field k4 type int {}
+        field k5 type int {}
+        field v type float {}
+    }
+    struct k5vmix {
+        field k1 type string {}
+        field k2 type int {}
+        field k3 type string {}
+        field k4 type int {}
+        field k5 type string {}
+        field v type int {}
+    }
+    document test {
+        field title type string {
+            indexing: summary | index
+        }
+        field smap type map<string,float> {
+            struct-field key { indexing: attribute }
+            struct-field value { indexing: attribute }
+        }
+        field imap type map<int,int> {
+            struct-field key { indexing: attribute }
+            struct-field value { indexing: attribute }
+        }
+        field skv type array<kvs> {
+            struct-field k { indexing: attribute }
+            struct-field v { indexing: attribute }
+        }
+        field sk2v type array<k2vs> {
+            struct-field k1 { indexing: attribute }
+            struct-field k2 { indexing: attribute }
+            struct-field v { indexing: attribute }
+        }
+        field ik2v type array<k2vi> {
+        }
+        field sk3v type array<k3vs> {
+        }
+        field sk4v type array<k4vs> {
+        }
+        field sk5v type array<k5vs> {
+            struct-field k1 { indexing: attribute }
+            struct-field k2 { indexing: attribute }
+            struct-field k3 { indexing: attribute }
+            struct-field k4 { indexing: attribute }
+            struct-field k5 { indexing: attribute }
+            struct-field v { indexing: attribute }
+        }
+        field ik5v type array<k5vi> {
+        }
+        field mix5 type array<k5vmix> {
+        }
+    }
+    rank-profile default {
+        function tk5vs() {
+            expression: tensorFromStructs(attribute(sk5v), k1, k2, k3, k4, k5, v, float)
+        }
+        first-phase {
+            expression: nativeRank(title)
+        }
+        match-features {
+            tk5vs
+        }
+    }
+    rank-profile combine2keys {
+        function tsm() {
+            expression: tensorFromStructs(attribute(smap), key, value, float)
+        }
+        function tim() {
+            expression: tensorFromStructs(attribute(imap), key, value, float)
+        }
+        function tkvs() {
+            expression: tensorFromStructs(attribute(skv), k, v, float)
+        }
+        function tk2vs() {
+            expression: tensorFromStructs(attribute(sk2v), k1, k2, v, float)
+        }
+        function c1() {
+            expression: rename(tsm*tim, key, k)
+        }
+        function c2() {
+            expression: rename(c1*tkvs, k, k1)
+        }
+        function c3() {
+            expression: reduce(c2*tk2vs, max, k1)
+        }
+        first-phase {
+            expression: reduce(c3, sum, k2)
+        }
+    }
+
+}


### PR DESCRIPTION
Measures query throughput when building tensors at query time from struct arrays and maps stored as document attributes. Covers a range of configurations: single-key maps (string->float, int->int), 1-5 key struct arrays with string and mixed int/string key types.

Two rank profiles are tested:
- default: 5-key string tensor from sk5v returned as a match-feature
- combine2keys: chains multiple tensorFromStructs calls with rename and reduce to produce a scalar first-phase score

Goal is to detect regressions and characterize performance as the number of struct keys grows. The C++ data generator is compiled on the server at test time and feeds 100 documents; fbench runs 30s at 30 clients.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
