### PR TITLE
Drop Maven Wrapper from m2 repo population script [MERGEOK]

### DIFF
--- a/docker/include/populate-m2-repo.sh
+++ b/docker/include/populate-m2-repo.sh
@@ -17,24 +17,13 @@ if [[ -n $(find /opt/rh -mindepth 1 -maxdepth 1 -type d -name "rh-ruby*") ]]; th
   source /opt/rh/rh-ruby*/enable
 fi
 
-if [[ -n $(find /opt/rh -mindepth 1 -maxdepth 1 -type d -name "rh-maven*") ]]; then
-  source /opt/rh/rh-maven*/enable
-fi
-
-readonly MVNW=/tmp/mvnw
-readonly MVN_VERSION=3.9.4 # 3.9.x required for faster dependency resolver
 readonly TESTS_ROOT=/opt/vespa-systemtests
 # Use '-Daether.dependencyCollector.impl=bf' for parallel dependency downloading https://issues.apache.org/jira/browse/MRESOLVER-324
 readonly SHARED_MVN_OPTS="-Daether.dependencyCollector.impl=bf --threads 1 -Dvespa.version=${VESPA_VERSION} -Dmaven.repo.local=${LOCAL_M2_REPO} --batch-mode --file ${TESTS_ROOT}/tests/pom.xml"
-# Install Maven Wrapper
-cp $TESTS_ROOT/tests/pom.xml /tmp/pom.parent.xml
-mvn --file /tmp/pom.parent.xml $SHARED_MVN_OPTS --show-version --non-recursive -Dmaven=$MVN_VERSION wrapper:wrapper
 # Install parent pom
-$MVNW $SHARED_MVN_OPTS --show-version --non-recursive install
+mvn $SHARED_MVN_OPTS --show-version --non-recursive install
 # Resolve all dependencies recursively
-$MVNW $SHARED_MVN_OPTS dependency:go-offline
-# Cleanup
-rm -rf $MVNW /tmp/mvnw.cmd /tmp/.mvn/ /tmp/pom.parent.xml
+mvn $SHARED_MVN_OPTS dependency:go-offline
 # Remove these files to avoid Maven verifying the the source locations
 find $LOCAL_M2_REPO -name "_remote.repositories" -delete
 


### PR DESCRIPTION
populate-m2-repo.sh used to bootstrap Maven Wrapper 3.9.4.

The Docker base image now installs vespa-maven (see install-alma8.sh and install-alma9.sh), which already provides a newer Maven version. The wrapper bootstrap is therefore redundant: invoke mvn directly.
