### PR TITLE
Revert "Use assertions from rubygem assertions class in more places, part 5"

### DIFF
--- a/lib/testcase.rb
+++ b/lib/testcase.rb
@@ -1,5 +1,6 @@
 # Copyright Vespa.ai. All rights reserved.
 # -*- coding: utf-8 -*-
+require 'assertions'
 require 'vespa_assertions'
 require 'test/unit/assertion-failed-error'
 require 'test/unit/assertions'
@@ -57,7 +58,7 @@ end
 # In addition, subclasses must implement the zero-argument "modulename" method to return a category name for the test case.
 class TestCase
   include DRb::DRbUndumped
-  include Test::Unit::Assertions
+  include Assertions
   include BacktraceFilter
   include VespaAssertions
   include TestBase


### PR DESCRIPTION
Reverts vespa-engine/system-test#4928

Seems like this broke 2 tests, need to figure out what went wrong.
Please review only, might be that the tests should be updated instead