### PR TITLE
Use just one container cluster

### DIFF
--- a/tests/vds/capacity.rb
+++ b/tests/vds/capacity.rb
@@ -11,7 +11,6 @@ class Capacity < VdsTest
   def test_capacity
     deploy_app(
                StorageApp.new.
-               enable_document_api.
                storage_cluster(
                  StorageCluster.new("storage").
                    group(NodeGroup.new(0, "mygroup").
@@ -41,7 +40,6 @@ class Capacity < VdsTest
     # Change config: .0.c:1.0 and .1.c:3.0
     deploy_app(
                StorageApp.new.
-               enable_document_api.
                storage_cluster(
                  StorageCluster.new("storage").
                    group(NodeGroup.new(0, "mygroup").

--- a/tests/vds/cluster_name_specified.rb
+++ b/tests/vds/cluster_name_specified.rb
@@ -8,7 +8,7 @@ class Cluster_Name_Specified < VdsTest
     set_owner("vekterli")
 
     deploy_app(
-               StorageApp.new.enable_document_api.storage_cluster(
+               StorageApp.new.storage_cluster(
                  StorageCluster.new("nonstandard").default_group).sd(VDS + "/schemas/music.sd").
                transition_time(0));
     start

--- a/tests/vds/documentapi/document_api_v1_base.rb
+++ b/tests/vds/documentapi/document_api_v1_base.rb
@@ -38,7 +38,6 @@ class DocumentApiV1Base < SearchTest
 
   def store_only_app
     StorageApp.new.default_cluster.sd(selfdir + 'music.sd').
-      enable_document_api(FeederOptions.new.timeout(120)).
       transition_time(0).
       distribution_bits(8)
   end


### PR DESCRIPTION
enable_document_api is unnecessary, both container clusters have document api enabled
