### PR TITLE
Migrate system test Java projects from JUnit 4 to JUnit 5 (Jupiter)

### DIFF
--- a/tests/config/integrationtests/config_test/pom.xml
+++ b/tests/config/integrationtests/config_test/pom.xml
@@ -23,8 +23,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tests/config/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/BasicSubscriptionTest.java
+++ b/tests/config/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/BasicSubscriptionTest.java
@@ -7,8 +7,8 @@ import com.yahoo.config.FooConfig;
 import com.yahoo.foo.BarConfig;
 import com.yahoo.myproject.config.NamespaceConfig;
 import com.yahoo.vespa.config.testutil.TestConfigServer;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.logging.Logger;
 
@@ -17,10 +17,10 @@ import static com.yahoo.config.subscription.ConfigTester.assertNextConfigHasNotC
 import static com.yahoo.config.subscription.ConfigTester.timingValues;
 import static com.yahoo.config.subscription.ConfigTester.waitWhenExpectedFailure;
 import static com.yahoo.config.subscription.ConfigTester.waitWhenExpectedSuccess;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BasicSubscriptionTest {
 
@@ -284,7 +284,7 @@ public class BasicSubscriptionTest {
       handle that the payload then is empty, i.e. empty is not propagated to subscriber
      */
     @Test
-    @Ignore
+    @Disabled
     public void testEmptyPayloadWhenUnHandledReqPreviously() throws InterruptedException {
         try (ConfigTester tester = new ConfigTester()) {
             ConfigSubscriber subscriber = tester.getSubscriber();

--- a/tests/config/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/ConfigTester.java
+++ b/tests/config/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/ConfigTester.java
@@ -26,9 +26,9 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Helper class for unit tests to make it easier to start and stop config server(s)

--- a/tests/config/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/FailoverTest.java
+++ b/tests/config/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/FailoverTest.java
@@ -8,8 +8,8 @@ import com.yahoo.foo.BarConfig;
 import com.yahoo.vespa.config.Connection;
 import com.yahoo.vespa.config.ConnectionPool;
 import com.yahoo.vespa.config.testutil.TestConfigServer;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -17,18 +17,18 @@ import java.util.logging.Logger;
 import static com.yahoo.config.subscription.ConfigTester.assertNextConfigHasChanged;
 import static com.yahoo.config.subscription.ConfigTester.assertNextConfigHasNotChanged;
 import static com.yahoo.config.subscription.ConfigTester.waitWhenExpectedSuccess;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class FailoverTest {
     private final java.util.logging.Logger log = Logger.getLogger(FailoverTest.class.getName());
 
     private ConfigSubscriber subscriber;
 
-    @After
+    @AfterEach
     public void closeSubscriber() {
         if (subscriber != null) subscriber.close();
     }

--- a/tests/config/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/GenericSubscriptionTest.java
+++ b/tests/config/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/GenericSubscriptionTest.java
@@ -12,8 +12,8 @@ import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.JRTConnectionPool;
 import com.yahoo.vespa.config.RawConfig;
 import com.yahoo.vespa.config.testutil.TestConfigServer;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.regex.Pattern;
@@ -22,15 +22,15 @@ import static com.yahoo.config.subscription.ConfigTester.assertNextConfigHasChan
 import static com.yahoo.config.subscription.ConfigTester.assertNextConfigHasNotChanged;
 import static com.yahoo.config.subscription.ConfigTester.timingValues;
 import static com.yahoo.config.subscription.ConfigTester.waitWhenExpectedSuccess;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GenericSubscriptionTest {
 
     private GenericConfigSubscriber subscriber;
 
-    @After
+    @AfterEach
     public void closeSubscriber() {
         if (subscriber != null) subscriber.close();
     }

--- a/tests/config/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/RawDirFileJarSubscriptionTest.java
+++ b/tests/config/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/RawDirFileJarSubscriptionTest.java
@@ -5,16 +5,17 @@ import com.yahoo.config.AppConfig;
 import com.yahoo.config.StringConfig;
 import com.yahoo.foo.BarConfig;
 import com.yahoo.io.IOUtils;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.jar.JarFile;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test cases for raw:, dir:, jar: and file: subscriptions
@@ -207,23 +208,27 @@ public class RawDirFileJarSubscriptionTest {
     /**
      * Tests subscribing with non-existing jar
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNonExistingJar() {
-        ConfigSubscriber subscriber = new ConfigSubscriber();
-        subscriber.subscribe(AppConfig.class, "jar:configs/nonexisting.jar");
-        subscriber.nextConfig(300, false);
-        subscriber.close();
+        assertThrows(IllegalArgumentException.class, () -> {
+            ConfigSubscriber subscriber = new ConfigSubscriber();
+            subscriber.subscribe(AppConfig.class, "jar:configs/nonexisting.jar");
+            subscriber.nextConfig(300, false);
+            subscriber.close();
+        });
     }
 
     /**
      * Tests subscribing with config that is not in jar
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testJarWrongConfig() {
-        ConfigSubscriber subscriber = new ConfigSubscriber();
-        subscriber.subscribe(BarConfig.class, "jar:configs/app.jar");
-        subscriber.nextConfig(300, false);
-        subscriber.close();
+        assertThrows(IllegalArgumentException.class, () -> {
+            ConfigSubscriber subscriber = new ConfigSubscriber();
+            subscriber.subscribe(BarConfig.class, "jar:configs/app.jar");
+            subscriber.nextConfig(300, false);
+            subscriber.close();
+        });
     }
 
     @Test
@@ -251,7 +256,7 @@ public class RawDirFileJarSubscriptionTest {
 
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    @After
+    @AfterEach
     public void tearDown() {
         if (tmpFile1 != null) tmpFile1.delete();
         if (tmpFile2 != null) tmpFile2.delete();

--- a/tests/config/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/StressTest.java
+++ b/tests/config/integrationtests/config_test/src/test/java/com/yahoo/config/subscription/StressTest.java
@@ -3,14 +3,14 @@ package com.yahoo.config.subscription;
 
 import com.yahoo.config.FooConfig;
 import com.yahoo.foo.BarConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static com.yahoo.config.subscription.ConfigTester.waitWhenExpectedFailure;
 import static com.yahoo.config.subscription.ConfigTester.waitWhenExpectedSuccess;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StressTest {
 

--- a/tests/config/integrationtests/config_test/src/test/java/com/yahoo/vespa/config/ConfigClientTest.java
+++ b/tests/config/integrationtests/config_test/src/test/java/com/yahoo/vespa/config/ConfigClientTest.java
@@ -13,7 +13,7 @@ import com.yahoo.vespa.config.protocol.JRTClientConfigRequest;
 import com.yahoo.vespa.config.protocol.JRTClientConfigRequestV3;
 import com.yahoo.vespa.config.protocol.Trace;
 import com.yahoo.vespa.config.testutil.TestConfigServer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -21,10 +21,10 @@ import java.util.Optional;
 import static com.yahoo.vespa.config.ErrorCode.ILLEGAL_CONFIG_MD5;
 import static com.yahoo.vespa.config.PayloadChecksum.Type.MD5;
 import static com.yahoo.vespa.config.PayloadChecksum.Type.XXHASH64;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for different client requests to config server.
@@ -46,8 +46,8 @@ public class ConfigClientTest {
             Request req = new Request("frt.rpc.ping");
             tester.invokeSync(req);
             System.out.println("Got ping response at " + System.currentTimeMillis());
-            assertFalse("Invocation failed: " + req.errorCode() + ": " + req.errorMessage(),
-                        req.isError());
+            assertFalse(req.isError(),
+                        "Invocation failed: " + req.errorCode() + ": " + req.errorMessage());
             assertEquals(0, req.returnValues().size());
         }
     }
@@ -152,16 +152,16 @@ public class ConfigClientTest {
             JRTClientConfigRequest newReq = createRequest(payloadChecksums, generation);
 
             tester.invokeSync(newReq.getRequest());
-            assertTrue("Valid return values", newReq.validateResponse());
-            assertTrue("More recent generation", newReq.getNewGeneration() > generation);
-            assertFalse("Updated flag in response is false", newReq.hasUpdatedConfig());
+            assertTrue(newReq.validateResponse(), "Valid return values");
+            assertTrue(newReq.getNewGeneration() > generation, "More recent generation");
+            assertFalse(newReq.hasUpdatedConfig(), "Updated flag in response is false");
             PayloadChecksums payloadChecksums2 = newReq.getNewChecksums();
-            assertEquals("Equal config md5 as previous response",
-                         payloadChecksums2.getForType(MD5),
-                         payloadChecksums.getForType(MD5));
-            assertEquals("Equal config xxhash64 as previous response",
-                         payloadChecksums2.getForType(XXHASH64),
-                         payloadChecksums.getForType(XXHASH64));
+            assertEquals(payloadChecksums2.getForType(MD5),
+                         payloadChecksums.getForType(MD5),
+                         "Equal config md5 as previous response");
+            assertEquals(payloadChecksums2.getForType(XXHASH64),
+                         payloadChecksums.getForType(XXHASH64),
+                         "Equal config xxhash64 as previous response");
             verifyConfigUnchanged(newReq);
         }
     }
@@ -181,16 +181,16 @@ public class ConfigClientTest {
     void verifyOkResponse(JRTClientConfigRequest req) {
         //System.out.println("Got config response at " + System.currentTimeMillis());
         assertNull(req.errorMessage(), req.errorMessage());
-        assertTrue(req.getRequest().errorMessage(), req.validateResponse());
+        assertTrue(req.validateResponse(), req.getRequest().errorMessage());
     }
 
     void verifyConfigChanged(JRTClientConfigRequest req) {
-        assertTrue(req.errorMessage(), (req.errorCode() == 0));
-        assertTrue(req.toString(), req.hasUpdatedConfig());
+        assertTrue((req.errorCode() == 0), req.errorMessage());
+        assertTrue(req.hasUpdatedConfig(), req.toString());
     }
 
     void verifyConfigUnchanged(JRTClientConfigRequest req) {
-        assertTrue(req.errorMessage(), (req.errorCode() == 0));
+        assertTrue((req.errorCode() == 0), req.errorMessage());
         assertFalse(req.hasUpdatedConfig());
     }
 

--- a/tests/container/assemble_container_plugin/project1/pom.xml
+++ b/tests/container/assemble_container_plugin/project1/pom.xml
@@ -40,8 +40,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/tests/container/assemble_container_plugin/project2/pom.xml
+++ b/tests/container/assemble_container_plugin/project2/pom.xml
@@ -47,8 +47,8 @@
     </dependency>
  
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/tests/container/zk_reconfig/zookeeper_test/pom.xml
+++ b/tests/container/zk_reconfig/zookeeper_test/pom.xml
@@ -76,8 +76,9 @@
             <version>${zookeeper.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/tests/container/zk_reconfig/zookeeper_test/src/test/java/test/VespaZooKeeperTest.java
+++ b/tests/container/zk_reconfig/zookeeper_test/src/test/java/test/VespaZooKeeperTest.java
@@ -14,7 +14,8 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.admin.ZooKeeperAdmin;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -40,8 +41,8 @@ import java.util.stream.IntStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Jon Marius Venstad
@@ -63,7 +64,8 @@ public class VespaZooKeeperTest {
      * <p>
      * Throughout all of this, quorum should remain, and the data should remain the same.
      */
-    @Test(timeout = 300_000)
+    @Test
+    @Timeout(value = 300_000, unit = TimeUnit.MILLISECONDS)
     public void testReconfiguration() throws ExecutionException, InterruptedException, IOException, KeeperException, TimeoutException {
         List<ZooKeeper> keepers = new ArrayList<>();
         for (int i = 0; i < 8; i++) keepers.add(new ZooKeeper());

--- a/tests/performance/configserver/defbundle/pom.xml
+++ b/tests/performance/configserver/defbundle/pom.xml
@@ -25,8 +25,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   

--- a/tests/performance/container/query_profile_compilation/project/pom.xml
+++ b/tests/performance/container/query_profile_compilation/project/pom.xml
@@ -15,8 +15,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.yahoo.vespa</groupId>

--- a/tests/performance/container/query_profile_compilation/project/src/test/java/com/yahoo/search/query/profile/QueryProfileCompilerTestCase.java
+++ b/tests/performance/container/query_profile_compilation/project/src/test/java/com/yahoo/search/query/profile/QueryProfileCompilerTestCase.java
@@ -4,7 +4,7 @@ package com.yahoo.search.query.profile;
 import com.yahoo.config.subscription.ConfigGetter;
 import com.yahoo.search.query.profile.config.QueryProfileConfigurer;
 import com.yahoo.search.query.profile.config.QueryProfilesConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;

--- a/tests/search/concretedocs/concretedocs/pom.xml
+++ b/tests/search/concretedocs/concretedocs/pom.xml
@@ -55,8 +55,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -66,7 +66,7 @@
       <version>${vespa.version}</version>
       <scope>provided</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>concretedocs2</groupId>
       <artifactId>concretedocs2</artifactId>

--- a/tests/search/concretedocs/concretedocs2/pom.xml
+++ b/tests/search/concretedocs/concretedocs2/pom.xml
@@ -55,8 +55,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/tests/search/documentapi/project/pom.xml
+++ b/tests/search/documentapi/project/pom.xml
@@ -15,8 +15,9 @@
 
   <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/tests/search/documentapi/project/src/test/java/test/AssertQuery.java
+++ b/tests/search/documentapi/project/src/test/java/test/AssertQuery.java
@@ -11,9 +11,9 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.net.URL;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author Simon Thoresen Hult

--- a/tests/search/documentapi/project/src/test/java/test/AsyncSessionTest.java
+++ b/tests/search/documentapi/project/src/test/java/test/AsyncSessionTest.java
@@ -12,17 +12,17 @@ import com.yahoo.documentapi.DocumentAccess;
 import com.yahoo.documentapi.DocumentResponse;
 import com.yahoo.documentapi.Response;
 import com.yahoo.documentapi.Result;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static test.AssertQuery.assertQuery;
 import static test.Documents.newDocument;
 import static test.Documents.newUpdate;
@@ -49,7 +49,7 @@ public class AsyncSessionTest {
         assertGet("id:tenant:test::foo", null);
     }
 
-    @After
+    @AfterEach
     public void after() {
         session.destroy();
         access.shutdown();
@@ -65,7 +65,7 @@ public class AsyncSessionTest {
             }
         });
         Response response = session.getNext(TIMEOUT_MILLIS);
-        assertTrue(response.getTextMessage(), response.isSuccess());
+        assertTrue(response.isSuccess(), response.getTextMessage());
     }
 
     private void assertUpdate(final DocumentUpdate upd) throws Exception {
@@ -78,7 +78,7 @@ public class AsyncSessionTest {
             }
         });
         Response response = session.getNext(TIMEOUT_MILLIS);
-        assertTrue(response.getTextMessage(), response.isSuccess());
+        assertTrue(response.isSuccess(), response.getTextMessage());
     }
 
     private void assertRemove(final String docId) throws Exception {
@@ -91,7 +91,7 @@ public class AsyncSessionTest {
             }
         });
         Response response = session.getNext(TIMEOUT_MILLIS);
-        assertTrue(response.getTextMessage(), response.isSuccess());
+        assertTrue(response.isSuccess(), response.getTextMessage());
     }
 
     private void assertGet(final String docId, String expectedFieldValue) throws Exception {
@@ -104,7 +104,7 @@ public class AsyncSessionTest {
             }
         });
         Response response = session.getNext(TIMEOUT_MILLIS);
-        assertTrue(response.getTextMessage(), response.isSuccess());
+        assertTrue(response.isSuccess(), response.getTextMessage());
         assertTrue(response instanceof DocumentResponse);
         Document doc = ((DocumentResponse)response).getDocument();
         System.out.println(doc);

--- a/tests/search/documentapi/project/src/test/java/test/SyncSessionTest.java
+++ b/tests/search/documentapi/project/src/test/java/test/SyncSessionTest.java
@@ -11,13 +11,13 @@ import com.yahoo.document.datatypes.StringFieldValue;
 import com.yahoo.documentapi.DocumentAccess;
 import com.yahoo.documentapi.SyncParameters;
 import com.yahoo.documentapi.SyncSession;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static test.AssertQuery.assertQuery;
 import static test.Documents.newDocument;
 import static test.Documents.newUpdate;
@@ -43,7 +43,7 @@ public class SyncSessionTest {
         assertGet("id:tenant:test::foo", null);
     }
 
-    @After
+    @AfterEach
     public void after() {
         session.destroy();
         access.shutdown();

--- a/tests/search/documentapi/project/src/test/java/test/VisitorSessionTest.java
+++ b/tests/search/documentapi/project/src/test/java/test/VisitorSessionTest.java
@@ -12,15 +12,15 @@ import com.yahoo.documentapi.SyncSession;
 import com.yahoo.documentapi.VisitorControlHandler;
 import com.yahoo.documentapi.VisitorParameters;
 import com.yahoo.documentapi.VisitorSession;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static test.Documents.newDocument;
 
 /**
@@ -28,7 +28,7 @@ import static test.Documents.newDocument;
  */
 public class VisitorSessionTest {
 
-    @Before
+    @BeforeEach
     public void requireElasticSetup() {
         assumeTrue("INDEXED".equals(System.getProperty("searchType")));
     }

--- a/tests/search/event-loggging/project/pom.xml
+++ b/tests/search/event-loggging/project/pom.xml
@@ -16,8 +16,9 @@
 
   <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/tests/search/struct_and_map_types/inherited_struct/concretedocs/pom.xml
+++ b/tests/search/struct_and_map_types/inherited_struct/concretedocs/pom.xml
@@ -56,8 +56,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/tests/search/wasfound/project/pom.xml
+++ b/tests/search/wasfound/project/pom.xml
@@ -24,8 +24,8 @@
         <version>${vespa.version}</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tests/search/wasfound/project/src/test/java/WasFoundTest.java
+++ b/tests/search/wasfound/project/src/test/java/WasFoundTest.java
@@ -11,12 +11,12 @@ import com.yahoo.document.update.ValueUpdate;
 import com.yahoo.documentapi.DocumentAccess;
 import com.yahoo.documentapi.SyncParameters;
 import com.yahoo.documentapi.SyncSession;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * System test accessing the wasFound flag of update and remove replies.
@@ -30,7 +30,7 @@ public class WasFoundTest {
     private DocumentType type;
     private Document doc;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         access = DocumentAccess.createForNonContainer();
         session = access.createSyncSession(new SyncParameters.Builder().build());
@@ -40,7 +40,7 @@ public class WasFoundTest {
         session.remove(new DocumentRemove(docId));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         access.shutdown();
     }


### PR DESCRIPTION
JUnit 4 (junit:junit) is being phased out in favor of JUnit 5 (org.junit.jupiter:junit-jupiter), consistent with the rest of the Vespa codebase. This updates 26 files across config, container, performance, and search test projects:

- pom.xml: switch dependency from junit:junit to org.junit.jupiter:junit-jupiter; add explicit <scope>test</scope> where missing
- Imports: org.junit.* → org.junit.jupiter.api.*, org.junit.Assert.* → org.junit.jupiter.api.Assertions.*, org.junit.Assume.* → org.junit.jupiter.api.Assumptions.*
- Annotations: @After → @AfterEach, @Before → @BeforeEach, @Ignore → @Disabled, @Test(timeout=N) → @Test + @Timeout, @Test(expected=E.class) → @Test + assertThrows(E.class, () -> ...)
- Assertion argument order: message moved to last parameter position as required by JUnit 5 API

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
