### PR TITLE
Set searchnode-reserved-memory-factor to 0.0

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -53,7 +53,7 @@
         { "id" : "unknown-config-definition", "rules" : [ { "value" : "fail" } ] },
         { "id" : "search-core-transaction-log-replay-soft-memory-limit", "rules" : [ { "value" : -5 } ] },
         { "id" : "zookeeper-pre-alloc-size", "rules" : [ { "value" : 16384 } ] },
-        { "id" : "searchnode-reserved-memory-factor", "rules" : [ { "value" : 0.5 } ] },
+        { "id" : "searchnode-reserved-memory-factor", "rules" : [ { "value" : 0.0 } ] },
         { "id" : "sort-blueprints-by-cost", "rules" : [ { "value" : true } ] },
         { "id" : "require-explicit-docproc-cluster", "rules" : [ { "value" : true } ] }
     ]


### PR DESCRIPTION
@toregge please review

Going back to 0.0 until we think we are ready to try increasing this again