### PR TITLE
Reapply "Set searchnode-reserved-memory-factor to 0.5"

### DIFF
--- a/docker/include/feature-flags.json
+++ b/docker/include/feature-flags.json
@@ -53,7 +53,7 @@
         { "id" : "unknown-config-definition", "rules" : [ { "value" : "fail" } ] },
         { "id" : "search-core-transaction-log-replay-soft-memory-limit", "rules" : [ { "value" : -5 } ] },
         { "id" : "zookeeper-pre-alloc-size", "rules" : [ { "value" : 16384 } ] },
-        { "id" : "searchnode-reserved-memory-factor", "rules" : [ { "value" : 0.0 } ] },
+        { "id" : "searchnode-reserved-memory-factor", "rules" : [ { "value" : 0.5 } ] },
         { "id" : "sort-blueprints-by-cost", "rules" : [ { "value" : true } ] },
         { "id" : "require-explicit-docproc-cluster", "rules" : [ { "value" : true } ] }
     ]


### PR DESCRIPTION
Should be OK now that we limit flushing for proton flush target in tests.

@toregge please review