### PR TITLE
Add CPU diagnostics to debug bi-modal TensorMatrixMatrixProduct results

### DIFF
--- a/lib/performance_test.rb
+++ b/lib/performance_test.rb
@@ -286,6 +286,7 @@ class PerformanceTest < TestCase
     remote_node = vespa.nodeproxies.values[0]
     remote_node.execute("grep '^PRETTY_NAME' /etc/os-release")
     remote_node.execute('uname -a')
+    remote_node.execute('numactl -s')
     remote_node.execute('lscpu')
     @node_procfs_snapshot_at_setup_time = remote_node.kernel_procfs_perf_snapshot
   end

--- a/tests/performance/tensor_matrix_matrix_prod/tensor_matrix_matrix_prod.rb
+++ b/tests/performance/tensor_matrix_matrix_prod/tensor_matrix_matrix_prod.rb
@@ -26,8 +26,17 @@ class TensorMatrixMatrixProduct < PerformanceTest
     generate_feed_and_queries
     deploy_and_feed
     copy_query_file
+    t = Thread.new() { watch(@container) }
     warmup
     run_queries
+    t.kill
+  end
+
+  def watch(node)
+    while true
+      out = node.execute("turbostat sleep 10 2>&1", :noecho => true)
+      puts ">>>\n#{out}<<<"
+    end
   end
 
   def generate_feed_and_queries
@@ -165,4 +174,3 @@ class TensorMatrixMatrixProduct < PerformanceTest
   end
 
 end
-


### PR DESCRIPTION
The TensorMatrixMatrixProduct performance test sometimes "flips" between two performance levels between runs. Gather more system/CPU state to find the cause:

- performance_test.rb: log "numactl -s" for each node during setup, next to the existing os-release/uname/lscpu output, to capture CPU/memory pinning and NUMA policy.
- tensor_matrix_matrix_prod: run "turbostat sleep 10" in a loop on a background thread while warmup and queries execute, to observe CPU frequency / turbo-boost behaviour during the benchmark. The thread is killed once run_queries returns.

This is diagnostic instrumentation only; it does not change what the test measures.
