### PR TITLE
Install kernel-tools in alma9 image

### DIFF
--- a/docker/include/install-alma9.sh
+++ b/docker/include/install-alma9.sh
@@ -12,6 +12,7 @@ dnf install -y \
     git-core \
     hostname \
     jq \
+    kernel-tools \
     libxml2-devel \
     lz4 \
     make \


### PR DESCRIPTION
Add the kernel-tools package to the alma9 container image so utilities like turbostat are available. These let performance tests inspect CPU frequency, C-states and thermal/power behaviour, which is needed to diagnose and account for clock-speed variation in benchmark results.
