### PR TITLE
Reduce turbostat noise in TensorMatrixMatrixProduct log

### DIFF
--- a/tests/performance/tensor_matrix_matrix_prod/tensor_matrix_matrix_prod.rb
+++ b/tests/performance/tensor_matrix_matrix_prod/tensor_matrix_matrix_prod.rb
@@ -26,15 +26,15 @@ class TensorMatrixMatrixProduct < PerformanceTest
     generate_feed_and_queries
     deploy_and_feed
     copy_query_file
-    t = Thread.new() { watch(@container) }
     warmup
+    t = Thread.new() { watch(@container) }
     run_queries
     t.kill
   end
 
   def watch(node)
     while true
-      out = node.execute("turbostat sleep 10 2>&1", :noecho => true)
+      out = node.execute("turbostat sleep 10 2>&1 | grep -v not.effective", :noecho => true)
       puts ">>>\n#{out}<<<"
     end
   end


### PR DESCRIPTION
- Start the watch thread only after warmup
- Filter out turbostat's repeated "not effective" warning lines with grep -v, which otherwise clutter every sample.
