### PR TITLE
map_search perf test: turn off fast-search for map value struct-fields

### DIFF
--- a/tests/performance/map_search/test.sd
+++ b/tests/performance/map_search/test.sd
@@ -11,7 +11,7 @@ schema test {
       }
       struct-field value {
         indexing: attribute
-        attribute: fast-search
+        #attribute: fast-search
         rank: filter
       }
     }
@@ -28,7 +28,7 @@ schema test {
       }
       struct-field value {
         indexing: attribute
-        attribute: fast-search
+        #attribute: fast-search
         rank: filter
       }
     }
@@ -43,8 +43,9 @@ schema test {
         indexing: attribute
         attribute: fast-search
       }
-      struct-field value { indexing: attribute
-        attribute: fast-search
+      struct-field value {
+        indexing: attribute
+        #attribute: fast-search
         rank: filter
       }
     }


### PR DESCRIPTION
Comment out 'attribute: fast-search' on the value struct-field of the kv_5/kv_25/kv_125 map attributes, so searching by value must fall back to filtering.  This lets the performance graphs show the difference between posting list versus filtering, to check our assumptions.
