### PR TITLE
Add test for coverage computation when a node is down

### DIFF
--- a/lib/app_generator/content.rb
+++ b/lib/app_generator/content.rb
@@ -92,6 +92,7 @@ class Content
     def needs_cluster_tuning_tag?
       @distribution_type != nil ||
       @search.get_dispatch_policy != nil ||
+      @search.get_min_active_docs_coverage != nil ||
       @search.get_min_node_ratio_per_group != nil ||
       @search.get_resource_limits != nil
     end
@@ -106,9 +107,14 @@ class Content
           if (@distribution_type != nil)
             tuningTag.tag("distribution", :type => @distribution_type).close_tag
           end
-          if (@search.get_dispatch_policy)
+          if @search.get_dispatch_policy || @search.get_min_active_docs_coverage
             dispatch = tuningTag.tag("dispatch")
-            dispatch.tag("dispatch-policy").content(@search.get_dispatch_policy).close_tag
+            if @search.get_dispatch_policy
+              dispatch.tag("dispatch-policy").content(@search.get_dispatch_policy).close_tag
+            end
+            if @search.get_min_active_docs_coverage
+              dispatch.tag("min-active-docs-coverage").content(@search.get_min_active_docs_coverage).close_tag
+            end
             dispatch.close_tag
           end
           if @search.get_min_node_ratio_per_group != nil

--- a/lib/app_generator/search_cluster.rb
+++ b/lib/app_generator/search_cluster.rb
@@ -26,6 +26,7 @@ class SearchCluster
   chained_setter :hwinfo_disk_shared
   chained_setter :search_coverage
   chained_setter :dispatch_policy
+  chained_setter :min_active_docs_coverage
   chained_setter :min_node_ratio_per_group
   chained_setter :persistence_threads
   chained_setter :resource_limits
@@ -49,6 +50,7 @@ class SearchCluster
     @flush_on_shutdown = nil
     @documents_selection = nil
     @dispatch_policy= nil
+    @min_active_docs_coverage = nil
     @min_node_ratio_per_group = nil
     @num_parts = 1
     @redundancy = 1
@@ -90,6 +92,10 @@ class SearchCluster
 
   def get_dispatch_policy
     return @dispatch_policy
+  end
+
+  def get_min_active_docs_coverage
+    return @min_active_docs_coverage
   end
 
   def get_min_node_ratio_per_group

--- a/tests/search/coverage/coverage.rb
+++ b/tests/search/coverage/coverage.rb
@@ -1,0 +1,165 @@
+# Copyright Vespa.ai. All rights reserved.
+require 'indexed_only_search_test'
+
+class Coverage < IndexedOnlySearchTest
+
+  def setup
+    set_owner("boeker")
+    add_ignorable_messages([/group \d has reduced coverage/])
+    @num_documents = 10_000
+    @simple_query = {"query" => "sddocname:coverage"}
+  end
+
+  def doc_template
+    '{ "put": "id:coverage:coverage::$seq()", "fields": { "int_field": $seq() } }'
+  end
+
+  def feed_and_wait
+    feed_stream(DataGenerator.new.feed_command(template: doc_template, count: @num_documents), {})
+    wait_for_hitcount(@simple_query, @num_documents)
+  end
+
+  def feed_and_wait_and_stop
+    feed_and_wait
+    vespa.stop_content_node("mycluster", 0, 120, "d")
+  end
+
+  def create_app(schema_file, num_groups, num_nodes_per_group, redundancy, ready_copies, distribution)
+    SearchApp.new.sd(selfdir + "coverage.sd")
+
+    topgroup = NodeGroup.new(0, "mytopgroup").distribution(distribution)
+    distkey = 0
+    for g in 1..num_groups do
+      nodegroup = NodeGroup.new(g-1, "mygroup#{g-1}")
+      for n in 1..num_nodes_per_group do
+        nodegroup.node(NodeSpec.new("node1", distkey))
+        distkey = distkey + 1
+      end
+      topgroup.group(nodegroup)
+    end
+
+    SearchApp.new.cluster(SearchCluster.new("mycluster")
+                                       .sd(schema_file)
+                                       .redundancy(redundancy)
+                                       .ready_copies(ready_copies)
+                                       .min_active_docs_coverage(100.0) # Should make no difference for the test. For toying around with
+                                       .group(topgroup))
+  end
+
+  def test_coverage_when_stopping_node_with_one_group_with_redundancy
+    set_description("Check reported coverage when a node in a group is stopped with one groups and redundant documents on the other node")
+    deploy_app(create_app(selfdir + "coverage.sd", 1, 2, 2, 1, "*"))
+    start
+
+    feed_and_wait_and_stop
+
+    wait_for_hitcount_from_group(@simple_query, nil, @num_documents)
+    wait_for_coverage_from_group(@simple_query, nil, 100)
+  end
+
+  def test_coverage_when_stopping_node_with_one_group_without_redundancy
+    set_description("Check reported coverage when a node in a group is stopped with one groups and no redundant documents on the other node")
+    deploy_app(create_app(selfdir + "coverage.sd", 1, 2, 1, 1, "*"))
+    start
+
+    feed_and_wait_and_stop
+
+    # No need to wait for hitcount. Will be around @num_documents / 2 and not change since there is no redundancy.
+    wait_for_coverage_from_group(@simple_query, nil, 50)
+  end
+
+  def test_coverage_when_stopping_node_with_two_groups_without_redundancy
+    set_description("Check reported coverage when a node in a group is stopped with two groups in total and no inner-group redundancy")
+    deploy_app(create_app(selfdir + "coverage.sd", 2, 2, 2, 2, "1|*"))
+    start
+
+    feed_and_wait_and_stop
+
+    wait_for_hitcount_from_group(@simple_query, 0, @num_documents)
+    wait_for_hitcount_from_group(@simple_query, 1, @num_documents)
+    wait_for_coverage_from_group(@simple_query, 0, 100)
+    wait_for_coverage_from_group(@simple_query, 1, 100)
+  end
+
+  def test_coverage_when_stopping_node_with_two_groups_with_redundancy
+    set_description("Check reported coverage when a node in a group is stopped with two groups in total and inner-group redundancy")
+    deploy_app(create_app(selfdir + "coverage.sd", 2, 2, 4, 2, "2|*"))
+    start
+
+    feed_and_wait_and_stop
+
+    wait_for_hitcount_from_group(@simple_query, 0, @num_documents)
+    wait_for_hitcount_from_group(@simple_query, 1, @num_documents)
+    wait_for_coverage_from_group(@simple_query, 0, 100)
+    wait_for_coverage_from_group(@simple_query, 1, 100)
+  end
+
+  def wait_for_hitcount_from_group(query, wanted_group, wanted_hitcount, timeout_in=60, qrserver_id=0, params={})
+    query = query.merge({"hits" => "1", "model.searchGroup" => "#{wanted_group}"})
+
+    hitcount = -1
+    group = -1
+    timeout = timeout_in
+    timeout = calculateQueryTimeout(timeout)
+
+    puts "Waiting for #{wanted_hitcount} hits from group #{wanted_group}, timeout: #{timeout}"
+    trynum = 0
+    start = Time.now.to_i
+
+    while Time.now.to_i < start + timeout
+      begin
+        trynum += 1
+        result = search_with_timeout(timeout_in, query, qrserver_id, {}, false, params)
+        hitcount = result.hitcount
+        group = result.json['root']['fields']['searchGroup']
+        if hitcount == wanted_hitcount && (wanted_group == nil || group == wanted_group)
+          puts "Success on try #{trynum}: Got #{wanted_hitcount} hits from group #{wanted_group}"
+          return true
+        else
+          puts "Failure on try #{trynum}: Expected #{wanted_hitcount} hits from group #{wanted_group}, got #{hitcount} hits from group #{group}"
+        end
+      rescue StandardError => e
+        puts "error #{e}: #{e.backtrace}"
+      rescue Interrupt
+        puts "low-level timeout, retry"
+      end
+      sleep 1
+    end
+    fail("Timeout after #{trynum} tries: Expected #{wanted_hitcount} hits from group #{wanted_group}, got #{hitcount} hits from group #{group}")
+  end
+
+  def wait_for_coverage_from_group(query, wanted_group, wanted_coverage, timeout_in=60, qrserver_id=0, params={})
+    query = query.merge({"hits" => "1", "model.searchGroup" => "#{wanted_group}"})
+
+    coverage = -1
+    group = -1
+    timeout = timeout_in
+    timeout = calculateQueryTimeout(timeout)
+
+    puts "Waiting for #{wanted_coverage} coverage from group #{wanted_group}, timeout: #{timeout}"
+    trynum = 0
+    start = Time.now.to_i
+
+    while Time.now.to_i < start + timeout
+      begin
+        trynum += 1
+        result = search_with_timeout(timeout_in, query, qrserver_id, {}, false, params)
+        coverage = result.json['root']['coverage']['coverage']
+        group = result.json['root']['fields']['searchGroup']
+        if coverage == wanted_coverage && (wanted_group == nil || group == wanted_group)
+          puts "Success on try #{trynum}: Got #{wanted_coverage} coverage from group #{wanted_group}"
+          return true
+        else
+          puts "Failure on try #{trynum}: Expected #{wanted_coverage} coverage from group #{wanted_group}, got #{coverage} coverage from group #{group}"
+        end
+      rescue StandardError => e
+        puts "error #{e}: #{e.backtrace}"
+      rescue Interrupt
+        puts "low-level timeout, retry"
+      end
+      sleep 1
+    end
+    fail("Timeout after #{trynum} tries: Expected #{wanted_coverage} coverage from group #{wanted_group}, got #{coverage} coverage from group #{group}")
+  end
+
+end

--- a/tests/search/coverage/coverage.sd
+++ b/tests/search/coverage/coverage.sd
@@ -1,0 +1,11 @@
+# Copyright Vespa.ai. All rights reserved.
+schema coverage {
+  document coverage {
+    field int_field type int {
+      indexing: summary | attribute
+    }
+  }
+  document-summary minimal {
+    summary int_field {}
+  }
+}


### PR DESCRIPTION
Adds a system test that verifies the reported coverage when a node is down, both with a single group and two groups. Depends on https://github.com/vespa-engine/vespa/pull/37380.