### PR TITLE
Fix crash when subtracting metrics with drifting array length

### DIFF
--- a/lib/performance/stat.rb
+++ b/lib/performance/stat.rb
@@ -255,6 +255,13 @@ module Perf
       end
 
       def entry_delta(this, that, path = [])
+        # One side missing (not both) happens when array_delta zips two arrays of
+        # different lengths (Array#zip pads the shorter side with nil) -- e.g.
+        # /proc/stat's 'intr'/'softirq' per-IRQ arrays, whose length can drift
+        # between two snapshots as the kernel adds/removes IRQ vectors at runtime.
+        # Skip such entries instead of raising, mirroring map_delta's existing
+        # skip of a hash key missing on one side.
+        return nil if this.nil? || that.nil?
         if this.class != that.class
           path_str = path.empty? ? "(root)" : path.join(" -> ")
           raise "Class mismatch when subtracting metrics at #{path_str}: " \
@@ -281,7 +288,7 @@ module Perf
       def array_delta(this, that, path = [])
         this.zip(that).each_with_index.map do |(a, b), i|
           entry_delta(a, b, path + ["[#{i}]"])
-        end
+        end.compact # drop entries entry_delta skipped (nil) due to length drift
       end
 
       def subtract(other, params={})

--- a/lib/performance/test/stat_test.rb
+++ b/lib/performance/test/stat_test.rb
@@ -1,0 +1,102 @@
+# Copyright Vespa.ai. All rights reserved.
+require 'test/unit'
+require '../stat'
+
+class StatTest < Test::Unit::TestCase
+  include Perf
+
+  # Build a Snapshot without going through RealProcFs/system_snapshot, and
+  # without triggering host_to_internal metric building (which requires a
+  # full field tree with :net, :vm, etc.) -- we only want to exercise the
+  # delta logic in isolation here.
+  def snapshot(fields)
+    Stat::Snapshot.new(fields, :disable_metric_building => true)
+  end
+
+  # Regression test for the crash seen in ProgrammaticFeedClientTest::test_throughput:
+  # "Class mismatch when subtracting metrics at cpu -> intr -> [301]:
+  #  Integer (21) != NilClass (nil)"
+  #
+  # /proc/stat's 'intr' line length depends on the number of IRQ vectors the
+  # kernel currently exposes, which can differ between two snapshots taken
+  # seconds apart. This is the direction that actually reproduces the crash:
+  # the end snapshot's array is longer than the start snapshot's, so
+  # Array#zip pads the missing start-side elements with nil, and entry_delta
+  # used to treat Integer vs NilClass as an unexpected type mismatch.
+  def test_array_grew_is_skipped_not_raised
+    start_snapshot = snapshot(:cpu => { 'intr' => [100, 1, 2] })
+    end_snapshot   = snapshot(:cpu => { 'intr' => [140, 5, 9, 21] }) # one more IRQ vector
+
+    result = nil
+    assert_nothing_raised do
+      result = end_snapshot.subtract(start_snapshot, :disable_metric_building => true)
+    end
+
+    # The index only present on the longer side is dropped rather than raising.
+    assert_equal([40, 4, 7], result.fields[:cpu]['intr'])
+  end
+
+  # The reverse direction: the end snapshot's array is shorter than the start
+  # snapshot's. Array#zip's result length always matches the receiver, so
+  # this never actually raised even before the fix (the extra start-side
+  # element is simply dropped, no nil is produced). Kept as a test to
+  # document that this direction remains safe after the fix too.
+  def test_array_shrunk_was_already_safe
+    start_snapshot = snapshot(:cpu => { 'intr' => [100, 1, 2, 3] })
+    end_snapshot   = snapshot(:cpu => { 'intr' => [140, 5, 9] }) # one fewer IRQ vector
+
+    result = nil
+    assert_nothing_raised do
+      result = end_snapshot.subtract(start_snapshot, :disable_metric_building => true)
+    end
+
+    assert_equal([40, 4, 7], result.fields[:cpu]['intr'])
+  end
+
+  # A genuine type mismatch (not caused by array-length drift) must still
+  # raise loudly -- we don't want to silently hide real bugs.
+  def test_genuine_type_mismatch_still_raises
+    start_snapshot = snapshot(:cpu => { 'foo' => { :bar => 1 } })
+    end_snapshot   = snapshot(:cpu => { 'foo' => 5 })
+
+    error = assert_raise RuntimeError do
+      end_snapshot.subtract(start_snapshot, :disable_metric_building => true)
+    end
+    assert_match(/Class mismatch when subtracting metrics at cpu -> foo/, error.message)
+  end
+
+  # Regression test built closer to the real /proc/stat shape produced by
+  # Stat::system_snapshot / CpuInfo, rather than only a synthetic minimal
+  # Hash. Constructs the 'cpu' sub-hash the way CpuInfo actually would
+  # (assoc_array for the 'cpu' aggregate line, plus a raw array for 'intr'),
+  # without touching a live /proc filesystem.
+  def test_realistic_cpu_fields_with_growing_intr_length
+    make_cpu_fields = lambda do |intr_len|
+      {
+        :cpu => {
+          'cpu'  => Stat::assoc_array([:user, :nice, :system, :idle, :iowait, :irq, :softirq],
+                                       [100, 0, 50, 900, 0, 0, 0]),
+          'intr' => (0...intr_len).to_a,
+          'ctxt' => [12345],
+          'processes' => [42]
+        }
+      }
+    end
+
+    start_snapshot = snapshot(make_cpu_fields.call(301))
+    end_snapshot   = snapshot(make_cpu_fields.call(302)) # one more IRQ vector appeared
+
+    result = nil
+    assert_nothing_raised do
+      result = end_snapshot.subtract(start_snapshot, :disable_metric_building => true)
+    end
+
+    # The 'intr' delta drops the dangling index rather than raising, and the
+    # metrics actually consumed downstream (ctxt, processes, the cpu
+    # aggregate) are unaffected and still computed correctly.
+    assert_equal(301, result.fields[:cpu]['intr'].size)
+    assert_equal([0], result.fields[:cpu]['ctxt'])
+    assert_equal([0], result.fields[:cpu]['processes'])
+    assert_equal(0, result.fields[:cpu]['cpu'][:user])
+  end
+end


### PR DESCRIPTION
## Summary
- `ProgrammaticFeedClientTest::test_throughput` (and any performance test using `Perf::System`) intermittently crashed with `Class mismatch when subtracting metrics at cpu -> intr -> [301]: Integer (21) != NilClass (nil)`.
- Root cause: `/proc/stat`'s `intr` (per-IRQ) array length can drift between two snapshots as the kernel adds/removes IRQ vectors at runtime. `array_delta` used `Array#zip`, which pads a shorter array with `nil`, and `entry_delta` treated `Integer` vs `NilClass` as a fatal type mismatch — even though this field isn't used by any reported metric.
- Fix: `entry_delta` now skips an entry when either side is missing (mirroring the existing behavior for hash keys in `map_delta`), and `array_delta` compacts those skipped entries out. Genuine type mismatches (e.g. `Hash` vs `Array`) still raise.
- Added `lib/performance/test/stat_test.rb`, verified it reproduces the original crash message when run against the pre-fix code and passes with the fix.


Generated by Claude.