### PR TITLE
Add separate filter-first sift/gist ANN test cases

### DIFF
--- a/tests/performance/nearest_neighbor/ann_gist_base.rb
+++ b/tests/performance/nearest_neighbor/ann_gist_base.rb
@@ -49,6 +49,38 @@ class AnnGistBase < CommonSiftGistBase
     end
   end
 
+  def run_gist_filter_first_test(sd_dir)
+    deploy_app(create_app(sd_dir, 0.3))
+    start
+
+    num_queries_for_recall = 100
+    num_documents = 300_000
+    filter_values = [1, 70, 90, 95, 97, 99]
+
+    # Smaller values that can be used for development and testing
+    #num_queries_for_recall = 10
+    #num_documents = 1_000
+
+    compile_generators
+    generate_vectors_for_recall(num_queries_for_recall)
+    feed_and_benchmark(num_documents, "300k-docs", {:filter_values => filter_values})
+
+    query_and_benchmark(BRUTE_FORCE, 10, 0)
+
+    run_target_hits_10_filter_first_tests
+    run_target_hits_100_filter_first_tests
+
+    filter_values.each do |filter_percent|
+      query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.40, :filter_first_exploration => 0.3})
+      # Increased exploration
+      query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.40, :filter_first_exploration => 0.4})
+
+      calc_recall_for_queries(100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.40, :filter_first_exploration => 0.3})
+      # Increased exploration
+      calc_recall_for_queries(100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.40, :filter_first_exploration => 0.4})
+    end
+  end
+
   def run_gist_removal_test(sd_dir)
     deploy_app(create_app(sd_dir, 0.3))
     start

--- a/tests/performance/nearest_neighbor/ann_sift_base.rb
+++ b/tests/performance/nearest_neighbor/ann_sift_base.rb
@@ -70,6 +70,36 @@ class AnnSiftBase < CommonSiftGistBase
     feed_and_benchmark(num_updates, "1M-updates", {:start_with_docid => num_documents / 2, :operation => "update", :mixed_tensor => mixed_tensor})
   end
 
+  def run_sift_filter_first_test(sd_dir, mixed_tensor = false)
+    deploy_app(create_app(sd_dir, 0.3, 1))
+    start
+
+    num_queries_for_recall = 100
+    num_documents = 1_000_000
+    filter_values = [1, 70, 90, 95, 99]
+
+    compile_generators
+    generate_vectors_for_recall(num_queries_for_recall)
+    feed_and_benchmark(num_documents, "1M-docs", {:filter_values => filter_values, :mixed_tensor => mixed_tensor})
+
+    # Warm-up
+    query_and_benchmark(BRUTE_FORCE, 10, 0)
+
+    run_target_hits_100_filter_first_tests
+
+    filter_values.each do |filter_percent|
+      # Now with filter-first heuristic enabled
+      query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.20, :filter_first_exploration => 0.3})
+      # Increased exploration
+      query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.20, :filter_first_exploration => 0.35})
+
+      # Recall for filter-first heuristic
+      calc_recall_for_queries(100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.20, :filter_first_exploration => 0.3})
+      # Increased exploration
+      calc_recall_for_queries(100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.20, :filter_first_exploration => 0.35})
+    end
+  end
+
   def run_sift_geolocation_test(sd_dir)
     deploy_app(create_app(sd_dir, 0.3, 1))
     start

--- a/tests/performance/nearest_neighbor/ann_sift_base.rb
+++ b/tests/performance/nearest_neighbor/ann_sift_base.rb
@@ -76,7 +76,7 @@ class AnnSiftBase < CommonSiftGistBase
 
     num_queries_for_recall = 100
     num_documents = 1_000_000
-    filter_values = [1, 70, 90, 95, 99]
+    filter_values = [1, 70, 90, 95, 97, 99]
 
     compile_generators
     generate_vectors_for_recall(num_queries_for_recall)
@@ -85,6 +85,7 @@ class AnnSiftBase < CommonSiftGistBase
     # Warm-up
     query_and_benchmark(BRUTE_FORCE, 10, 0)
 
+    run_target_hits_10_filter_first_tests
     run_target_hits_100_filter_first_tests
 
     filter_values.each do |filter_percent|

--- a/tests/performance/nearest_neighbor/case_gist_float.rb
+++ b/tests/performance/nearest_neighbor/case_gist_float.rb
@@ -14,6 +14,11 @@ class AnnGistPerfTest < AnnGistBase
     run_gist_test("gist_test")
   end
 
+  def test_filter_first_gist_data_set
+    set_description("Test performance and recall using nearestNeighbor operator (filter-first heuristic) over the 1M (300k fed) GIST (960 dim) dataset")
+    run_gist_filter_first_test("gist_test")
+  end
+
   def test_removal_gist_data_set
     set_description("Test recall using nearestNeighbor operator (hnsw) over the 1M (300k fed) GIST (960 dim) dataset before and after removal of many documents")
     run_gist_removal_test("gist_test")

--- a/tests/performance/nearest_neighbor/case_sift_float.rb
+++ b/tests/performance/nearest_neighbor/case_sift_float.rb
@@ -14,6 +14,11 @@ class AnnSiftPerfTest < AnnSiftBase
     run_sift_test("sift_test", true)
   end
 
+  def test_filter_first_sift_data_set
+    set_description("Test performance and recall using nearestNeighbor operator (filter-first heuristic) over the 1M SIFT (128 dim) dataset")
+    run_sift_filter_first_test("sift_test")
+  end
+
   def test_geolocation_sift_data_set
     set_description("Test performance and recall using nearestNeighbor combined with geoLocation operator (hnsw vs brute force) over the 1M SIFT (128 dim) dataset")
     run_sift_geolocation_test("sift_test")

--- a/tests/performance/nearest_neighbor/case_sift_mixed.rb
+++ b/tests/performance/nearest_neighbor/case_sift_mixed.rb
@@ -14,5 +14,9 @@ class AnnSiftMixedPerfTest < AnnSiftBase
     run_sift_test("sift_test_mixed", false, true)
   end
 
+  def test_filter_first_sift_data_set_mixed
+    set_description("Test performance and recall using nearestNeighbor operator (filter-first heuristic) over the 1M SIFT (128 dim) dataset using a mixed tensor")
+    run_sift_filter_first_test("sift_test", true)
+  end
 
 end

--- a/tests/performance/nearest_neighbor/common_sift_gist_base.rb
+++ b/tests/performance/nearest_neighbor/common_sift_gist_base.rb
@@ -228,6 +228,18 @@ class CommonSiftGistBase < CommonAnnBaseTest
     end
   end
 
+  def run_target_hits_10_filter_first_tests
+    [0, 50, 100].each do |explore_hits|
+      query_and_benchmark(HNSW, 10, explore_hits, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3})
+      calc_recall_for_queries(10, explore_hits, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3})
+    end
+
+    [0.0, 0.1, 0.2].each do |slack|
+      query_and_benchmark(HNSW, 100, 0, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
+      calc_recall_for_queries(100, 0, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
+    end
+  end
+
   def run_target_hits_100_filter_first_tests
     [0, 100, 200].each do |explore_hits|
       query_and_benchmark(HNSW, 100, explore_hits, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3})

--- a/tests/performance/nearest_neighbor/common_sift_gist_base.rb
+++ b/tests/performance/nearest_neighbor/common_sift_gist_base.rb
@@ -228,6 +228,18 @@ class CommonSiftGistBase < CommonAnnBaseTest
     end
   end
 
+  def run_target_hits_100_filter_first_tests
+    [0, 100, 200].each do |explore_hits|
+      query_and_benchmark(HNSW, 100, explore_hits, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3})
+      calc_recall_for_queries(100, explore_hits, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3})
+    end
+
+    [0.0, 0.1, 0.2].each do |slack|
+      query_and_benchmark(HNSW, 100, 0, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
+      calc_recall_for_queries(100, 0, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
+    end
+  end
+
   def run_removal_test(documents_to_benchmark, documents_in_total, label)
     filter_values = [1, 10, 50, 90, 95, 99]
 


### PR DESCRIPTION
The existing sift/gist performance test cases test a lot of things and take a long time to run.

Add new test cases that test only the filter-first heuristic. I plan to later remove the filter-first testing from the existing test cases.