### PR TITLE
Allow to specify custom denominator for filter values in ANN performance tests

### DIFF
--- a/tests/performance/nearest_neighbor/ann_gist_base.rb
+++ b/tests/performance/nearest_neighbor/ann_gist_base.rb
@@ -68,8 +68,7 @@ class AnnGistBase < CommonSiftGistBase
 
     query_and_benchmark(BRUTE_FORCE, 10, 0)
 
-    run_target_hits_10_filter_first_tests
-    run_target_hits_100_filter_first_tests
+    run_target_hits_10_filter_first_tests(95_00)
 
     filter_values.each do |filter_percent|
       query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.40, :filter_first_exploration => 0.3})

--- a/tests/performance/nearest_neighbor/ann_gist_base.rb
+++ b/tests/performance/nearest_neighbor/ann_gist_base.rb
@@ -55,7 +55,8 @@ class AnnGistBase < CommonSiftGistBase
 
     num_queries_for_recall = 100
     num_documents = 300_000
-    filter_values = [1, 70, 90, 95, 97, 99]
+    filter_values_denominator = 10_000 # filter_values below are per myriad
+    filter_values = [1_00, 70_00, 90_00, 95_00, 97_00, 99_00, 99_50]
 
     # Smaller values that can be used for development and testing
     #num_queries_for_recall = 10
@@ -63,7 +64,7 @@ class AnnGistBase < CommonSiftGistBase
 
     compile_generators
     generate_vectors_for_recall(num_queries_for_recall)
-    feed_and_benchmark(num_documents, "300k-docs", {:filter_values => filter_values})
+    feed_and_benchmark(num_documents, "300k-docs", {:filter_values => filter_values, :filter_values_denominator => filter_values_denominator})
 
     query_and_benchmark(BRUTE_FORCE, 10, 0)
 

--- a/tests/performance/nearest_neighbor/ann_sift_base.rb
+++ b/tests/performance/nearest_neighbor/ann_sift_base.rb
@@ -76,11 +76,12 @@ class AnnSiftBase < CommonSiftGistBase
 
     num_queries_for_recall = 100
     num_documents = 1_000_000
-    filter_values = [1, 70, 90, 95, 97, 99]
+    filter_values_denominator = 10_000 # filter_values below are per myriad
+    filter_values = [1_00, 70_00, 90_00, 95_00, 97_00, 99_00, 99_50]
 
     compile_generators
     generate_vectors_for_recall(num_queries_for_recall)
-    feed_and_benchmark(num_documents, "1M-docs", {:filter_values => filter_values, :mixed_tensor => mixed_tensor})
+    feed_and_benchmark(num_documents, "1M-docs", {:filter_values => filter_values, :filter_values_denominator => filter_values_denominator, :mixed_tensor => mixed_tensor})
 
     # Warm-up
     query_and_benchmark(BRUTE_FORCE, 10, 0)

--- a/tests/performance/nearest_neighbor/ann_sift_base.rb
+++ b/tests/performance/nearest_neighbor/ann_sift_base.rb
@@ -86,8 +86,7 @@ class AnnSiftBase < CommonSiftGistBase
     # Warm-up
     query_and_benchmark(BRUTE_FORCE, 10, 0)
 
-    run_target_hits_10_filter_first_tests
-    run_target_hits_100_filter_first_tests
+    run_target_hits_10_filter_first_tests(95_00)
 
     filter_values.each do |filter_percent|
       # Now with filter-first heuristic enabled

--- a/tests/performance/nearest_neighbor/common_sift_gist_base.rb
+++ b/tests/performance/nearest_neighbor/common_sift_gist_base.rb
@@ -230,27 +230,18 @@ class CommonSiftGistBase < CommonAnnBaseTest
     end
   end
 
-  def run_target_hits_10_filter_first_tests
-    [0, 50, 100].each do |explore_hits|
-      query_and_benchmark(HNSW, 10, explore_hits, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3})
-      calc_recall_for_queries(10, explore_hits, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3})
+  def run_target_hits_10_filter_first_tests(filter_percent)
+    query_and_benchmark(HNSW, 10, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3})
+    calc_recall_for_queries(10, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3})
+
+    [50, 100].each do |explore_hits|
+      query_and_benchmark(HNSW, 10, explore_hits, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3})
+      calc_recall_for_queries(10, explore_hits, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3})
     end
 
-    [0.0, 0.1, 0.2].each do |slack|
-      query_and_benchmark(HNSW, 100, 0, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
-      calc_recall_for_queries(100, 0, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
-    end
-  end
-
-  def run_target_hits_100_filter_first_tests
-    [0, 100, 200].each do |explore_hits|
-      query_and_benchmark(HNSW, 100, explore_hits, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3})
-      calc_recall_for_queries(100, explore_hits, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3})
-    end
-
-    [0.0, 0.1, 0.2].each do |slack|
-      query_and_benchmark(HNSW, 100, 0, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
-      calc_recall_for_queries(100, 0, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
+    [0.1, 0.2].each do |slack|
+      query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
+      calc_recall_for_queries(100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
     end
   end
 

--- a/tests/performance/nearest_neighbor/common_sift_gist_base.rb
+++ b/tests/performance/nearest_neighbor/common_sift_gist_base.rb
@@ -95,6 +95,7 @@ class CommonSiftGistBase < CommonAnnBaseTest
     start_with_docid = params[:start_with_docid] || 0
     start_with_vector = params[:start_with_vector] || 0
     filter_values = params[:filter_values] || nil
+    filter_values_denominator = params[:filter_values_denominator] || 100
     latitude_lower = params[:latitude_lower] || 0.0
     latitude_upper = params[:latitude_upper] || -1.0
     longitude_lower = params[:longitude_lower] || 0.0
@@ -110,6 +111,7 @@ class CommonSiftGistBase < CommonAnnBaseTest
                                                     "#{start_with_docid} "\
                                                     "#{start_with_vector} #{start_with_vector + num_documents} "\
                                                     "#{filter_values.nil? ? "[]" : filter_values.join(",")} "\
+                                                    "#{filter_values_denominator} "\
                                                     "[#{latitude_lower},#{latitude_upper}] "\
                                                     "[#{longitude_lower},#{longitude_upper}] "\
                                                     "#{mixed} "\

--- a/tests/performance/nearest_neighbor/common_sift_gist_base.rb
+++ b/tests/performance/nearest_neighbor/common_sift_gist_base.rb
@@ -240,8 +240,8 @@ class CommonSiftGistBase < CommonAnnBaseTest
     end
 
     [0.1, 0.2].each do |slack|
-      query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
-      calc_recall_for_queries(100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
+      query_and_benchmark(HNSW, 10, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
+      calc_recall_for_queries(10, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
     end
   end
 

--- a/tests/performance/nearest_neighbor/make_docs.cpp
+++ b/tests/performance/nearest_neighbor/make_docs.cpp
@@ -37,11 +37,11 @@ parse_filters(const std::string &str) {
 }
 
 IntVector
-gen_filter_values(size_t docid, const IntVector &filters)
+gen_filter_values(size_t docid, const IntVector &filters, size_t filter_values_denominator)
 {
     IntVector result;
     for (auto filter_percent : filters) {
-        if ((docid % 100) >= filter_percent) {
+        if ((docid % filter_values_denominator) >= filter_percent) {
             // This document is NOT filtered away for this filter percent.
             result.push_back(filter_percent);
         }
@@ -101,14 +101,14 @@ print_assign_vector_field(std::ostream& os, const std::string& field_name, const
 using StringVector = std::vector<std::string>;
 
 void
-print_put(std::ostream& os, size_t docid, const IntVector &filters, const Interval &latitude, const Interval &longitude, const StringVector& tensor_fields, const FloatVector& vector, bool mixed_tensor)
+print_put(std::ostream& os, size_t docid, const IntVector &filters, size_t filter_values_denominator, const Interval &latitude, const Interval &longitude, const StringVector& tensor_fields, const FloatVector& vector, bool mixed_tensor)
 {
     os << "{" << std::endl;
     os << "  \"put\": \"id:test:test::" << docid << "\"," << std::endl;
     os << "  \"fields\": {" << std::endl;
     os << "    \"id\": " << docid << "," << std::endl;
     if (!filters.empty()) {
-        os << "    \"filter\": "; print_vector(os, gen_filter_values(docid, filters)); os << "," << std::endl;
+        os << "    \"filter\": "; print_vector(os, gen_filter_values(docid, filters, filter_values_denominator)); os << "," << std::endl;
     }
     if (latitude.non_empty() && longitude.non_empty()) {
         os << "    \"latlng\": "
@@ -151,7 +151,7 @@ print_update(std::ostream& os, size_t docid, const StringVector& tensor_fields, 
  *   tar -xf gist.tar.gz
  *
  * To run:
- *   ./make_docs <vector-file> <num-dimensions> <feed-op> <begin-doc> <start-vector> <end-vector> <filter-values> <latitude-interval> <longitude-interval> <mixed-tensor> <tensor-field-0> ... <tensor-field-n>
+ *   ./make_docs <vector-file> <num-dimensions> <feed-op> <begin-doc> <start-vector> <end-vector> <filter-values> <filter-values-denominator> <latitude-interval> <longitude-interval> <mixed-tensor> <tensor-field-0> ... <tensor-field-n>
  */ 
 int
 main(int argc, char **argv)
@@ -164,6 +164,7 @@ main(int argc, char **argv)
     size_t end_vector = 1000000; // exclusive
     size_t dim_size = 128;
     IntVector filters;
+    size_t filter_values_denominator = 100;
     Interval latitude;
     Interval longitude;
     bool mixed_tensor = false;
@@ -190,15 +191,18 @@ main(int argc, char **argv)
         filters = parse_filters(argv[7]);
     }
     if (argc > 8) {
-        latitude = parse_interval(argv[8]);
+        filter_values_denominator = std::stoll(argv[8]);
     }
     if (argc > 9) {
-        longitude = parse_interval(argv[9]);
+        latitude = parse_interval(argv[9]);
     }
     if (argc > 10) {
-        mixed_tensor = (argv[10] == std::string("true"));
+        longitude = parse_interval(argv[10]);
     }
-    for (int i = 11; i < argc; ++i) {
+    if (argc > 11) {
+        mixed_tensor = (argv[11] == std::string("true"));
+    }
+    for (int i = 12; i < argc; ++i) {
         tensor_fields.push_back(std::string(argv[i]));
     }
     std::ifstream is(vector_file, std::ifstream::binary);
@@ -224,7 +228,7 @@ main(int argc, char **argv)
         }
         first = false;
         if (make_puts) {
-            print_put(std::cout, begin_doc + vector_num - start_vector, filters, latitude, longitude, tensor_fields, vector, mixed_tensor);
+            print_put(std::cout, begin_doc + vector_num - start_vector, filters, filter_values_denominator, latitude, longitude, tensor_fields, vector, mixed_tensor);
         } else {
             print_update(std::cout, begin_doc + vector_num - start_vector, tensor_fields, vector, mixed_tensor);
         }


### PR DESCRIPTION
Makes it possible to specify filter values in permille/permyriad/... in order to test filter hit ratios lower than 1% in the sift/gist tests.