### PR TITLE
Slim down sift/gist ANN tests

### DIFF
--- a/tests/performance/nearest_neighbor/ann_gist_base.rb
+++ b/tests/performance/nearest_neighbor/ann_gist_base.rb
@@ -39,13 +39,7 @@ class AnnGistBase < CommonSiftGistBase
       query_and_benchmark(BRUTE_FORCE, 100, 0, {:filter_percent => filter_percent})
       # Standard HNSW
       query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent})
-      # Now with filter-first heuristic enabled
-      query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.40, :filter_first_exploration => 0.3})
-
-      # Recall for standard HNSW
       calc_recall_for_queries(100, 0, {:filter_percent => filter_percent})
-      # Recall for filter-first heuristic
-      calc_recall_for_queries(100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.40, :filter_first_exploration => 0.3})
     end
   end
 

--- a/tests/performance/nearest_neighbor/ann_sift_base.rb
+++ b/tests/performance/nearest_neighbor/ann_sift_base.rb
@@ -42,25 +42,13 @@ class AnnSiftBase < CommonSiftGistBase
       query_and_benchmark(BRUTE_FORCE, 100, 0, {:filter_percent => filter_percent})
       # Standard HNSW
       query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent})
-      # Now with filter-first heuristic enabled
-      query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.20, :filter_first_exploration => 0.3})
-      # Increased exploration
-      query_and_benchmark(HNSW, 100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.20, :filter_first_exploration => 0.35})
-
-      # Recall for standard HNSW
       calc_recall_for_queries(100, 0, {:filter_percent => filter_percent})
-      # Recall for filter-first heuristic
-      calc_recall_for_queries(100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.20, :filter_first_exploration => 0.3})
-      # Increased exploration
-      calc_recall_for_queries(100, 0, {:filter_percent => filter_percent, :approximate_threshold => 0.00, :filter_first_threshold => 0.20, :filter_first_exploration => 0.35})
     end
 
     if test_threads_per_search
       [1, 2, 4, 8, 16].each do |threads|
         # Standard HNSW
         query_and_benchmark(HNSW, 100, 0, {:filter_percent => 10, :threads_per_search => threads})
-        # Now with filter-first heuristic enabled
-        query_and_benchmark(HNSW, 100, 0, {:filter_percent => 10, :approximate_threshold => 0.00, :filter_first_threshold => 0.20, :filter_first_exploration => 0.3, :threads_per_search => threads})
       end
     end
 

--- a/tests/performance/nearest_neighbor/common_sift_gist_base.rb
+++ b/tests/performance/nearest_neighbor/common_sift_gist_base.rb
@@ -222,12 +222,6 @@ class CommonSiftGistBase < CommonAnnBaseTest
       query_and_benchmark(HNSW, 100, 0, {:slack => slack})
       calc_recall_for_queries(100, 0, {:slack => slack})
     end
-
-    # Now with filtering and filter first
-    [0.00, 0.05, 0.10, 0.15, 0.2, 0.3, 0.4, 0.5].each do |slack|
-      query_and_benchmark(HNSW, 100, 0, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
-      calc_recall_for_queries(100, 0, {:filter_percent => 95, :approximate_threshold => 0.00, :filter_first_threshold => 0.4, :filter_first_exploration => 0.3, :slack => slack})
-    end
   end
 
   def run_target_hits_10_filter_first_tests(filter_percent)

--- a/tests/performance/nearest_neighbor/common_sift_gist_base.rb
+++ b/tests/performance/nearest_neighbor/common_sift_gist_base.rb
@@ -206,7 +206,7 @@ class CommonSiftGistBase < CommonAnnBaseTest
       calc_recall_for_queries(10, explore_hits)
     end
 
-    [0.00, 0.05, 0.10, 0.15, 0.2, 0.3, 0.4, 0.5].each do |slack|
+    [0.1, 0.2].each do |slack|
       query_and_benchmark(HNSW, 10, 0, {:slack => slack})
       calc_recall_for_queries(10, 0, {:slack => slack})
     end
@@ -218,7 +218,7 @@ class CommonSiftGistBase < CommonAnnBaseTest
       calc_recall_for_queries(100, explore_hits)
     end
 
-    [0.00, 0.05, 0.10, 0.15, 0.2, 0.3, 0.4, 0.5].each do |slack|
+    [0.1, 0.2].each do |slack|
       query_and_benchmark(HNSW, 100, 0, {:slack => slack})
       calc_recall_for_queries(100, 0, {:slack => slack})
     end


### PR DESCRIPTION
Removes the filter-first testing and reduces the amount of parameter combinations tested.

Please review only, will merge later.