### PR TITLE
Override softtimeout factor to disable automatic adjustment in ANN time test

### DIFF
--- a/tests/search/anntime/anntime.rb
+++ b/tests/search/anntime/anntime.rb
@@ -204,6 +204,8 @@ class AnnTimeout < IndexedOnlySearchTest
     query.merge({ 'hits' => 1,
                   'summary' => 'minimal',
                   'ranking.matching.explorationSlack' => 1.0,
+                  'ranking.softtimeout.enable' => "true", # Not necessary, should be true by default
+                  'ranking.softtimeout.factor' => 0.5, # Override manually to avoid automatic adjustment
                   'ranking.matching.anntimeout.enable' => "true", # Not necessary, should be true by default
                   'ranking.matching.anntimeout.factor' => "#{factor}",
                   })


### PR DESCRIPTION
The soft-timeout factor being automatically adjusted could make the testcase fail. Not sure if this ever happened, but let's make sure that this will not happen.