### PR TITLE
Wait for coverage before testing searchGroups

### DIFF
--- a/lib/test_base.rb
+++ b/lib/test_base.rb
@@ -419,6 +419,40 @@ module TestBase
     vespa.metricsproxies.each_value { |metrics_proxy| metrics_proxy.wait_until_ready(timeout) }
   end
 
+  def wait_for_coverage_from_group(query, wanted_group, wanted_coverage, timeout_in=60, qrserver_id=0, params={})
+    query = query.merge({"hits" => "1", "model.searchGroup" => "#{wanted_group}"})
+
+    coverage = -1
+    group = -1
+    timeout = timeout_in
+    timeout = calculateQueryTimeout(timeout)
+
+    puts "Waiting for #{wanted_coverage} coverage from group #{wanted_group}, timeout: #{timeout}"
+    trynum = 0
+    start = Time.now.to_i
+
+    while Time.now.to_i < start + timeout
+      begin
+        trynum += 1
+        result = search_with_timeout(timeout_in, query, qrserver_id, {}, false, params)
+        coverage = result.json['root']['coverage']['coverage']
+        group = result.json['root']['fields']['searchGroup']
+        if coverage == wanted_coverage && (wanted_group == nil || group == wanted_group)
+          puts "Success on try #{trynum}: Got #{wanted_coverage} coverage from group #{wanted_group}"
+          return true
+        else
+          puts "Failure on try #{trynum}: Expected #{wanted_coverage} coverage from group #{wanted_group}, got #{coverage} coverage from group #{group}"
+        end
+      rescue StandardError => e
+        puts "error #{e}: #{e.backtrace}"
+      rescue Interrupt
+        puts "low-level timeout, retry"
+      end
+      sleep 1
+    end
+    fail("Timeout after #{trynum} tries: Expected #{wanted_coverage} coverage from group #{wanted_group}, got #{coverage} coverage from group #{group}")
+  end
+
   def getcluster(args={})
     clusters = args[:clusters] ? args[:clusters] : [ ]
     if args[:cluster]

--- a/tests/search/dispatch/dispatch.rb
+++ b/tests/search/dispatch/dispatch.rb
@@ -58,6 +58,11 @@ class DispatchTest < IndexedOnlySearchTest
     start
     generate_and_feed_docs
 
+    @simple_query = {"query" => "sddocname:test"}
+    # Make sure we have full coverage from both groups before proceeding
+    wait_for_coverage_from_group(@simple_query, 0, 100)
+    wait_for_coverage_from_group(@simple_query, 1, 100)
+
     # Without searchGroup: response should expose the group the query ran on
     default_result = search("yql=select+*+from+sources+*+where+f1+contains+%22word%22%3B&nocache")
     assert_result_hitcount(default_result, @num_docs)

--- a/tests/search/reportcoverage-groups/coverage.rb
+++ b/tests/search/reportcoverage-groups/coverage.rb
@@ -128,38 +128,4 @@ class Coverage < IndexedOnlySearchTest
     fail("Timeout after #{trynum} tries: Expected #{wanted_hitcount} hits from group #{wanted_group}, got #{hitcount} hits from group #{group}")
   end
 
-  def wait_for_coverage_from_group(query, wanted_group, wanted_coverage, timeout_in=60, qrserver_id=0, params={})
-    query = query.merge({"hits" => "1", "model.searchGroup" => "#{wanted_group}"})
-
-    coverage = -1
-    group = -1
-    timeout = timeout_in
-    timeout = calculateQueryTimeout(timeout)
-
-    puts "Waiting for #{wanted_coverage} coverage from group #{wanted_group}, timeout: #{timeout}"
-    trynum = 0
-    start = Time.now.to_i
-
-    while Time.now.to_i < start + timeout
-      begin
-        trynum += 1
-        result = search_with_timeout(timeout_in, query, qrserver_id, {}, false, params)
-        coverage = result.json['root']['coverage']['coverage']
-        group = result.json['root']['fields']['searchGroup']
-        if coverage == wanted_coverage && (wanted_group == nil || group == wanted_group)
-          puts "Success on try #{trynum}: Got #{wanted_coverage} coverage from group #{wanted_group}"
-          return true
-        else
-          puts "Failure on try #{trynum}: Expected #{wanted_coverage} coverage from group #{wanted_group}, got #{coverage} coverage from group #{group}"
-        end
-      rescue StandardError => e
-        puts "error #{e}: #{e.backtrace}"
-      rescue Interrupt
-        puts "low-level timeout, retry"
-      end
-      sleep 1
-    end
-    fail("Timeout after #{trynum} tries: Expected #{wanted_coverage} coverage from group #{wanted_group}, got #{coverage} coverage from group #{group}")
-  end
-
 end


### PR DESCRIPTION
* Move wait_for_coverage_from_group() to test_base
* Use it to check for full coverage before querying and checking searchGroups

Test failed occasionally, I think this should fix it

@gjoranv or @bratseth please review