### PR TITLE
Bump cryptography to 50.0.0 in ecommerce_hybrid_search requirements.txt (Mend HIGH CVE-2026-69247)

### DIFF
--- a/tests/performance/ecommerce_hybrid_search/common/requirements.txt
+++ b/tests/performance/ecommerce_hybrid_search/common/requirements.txt
@@ -1,8 +1,10 @@
-docker>=7.1.0
-elasticsearch>=9.4.0
-pyvespa>=1.2.0
-vespacli>=8.687.75
-tqdm>=4.67.3
-requests>=2.34.0
+docker>=7.2.0
+elasticsearch>=9.4.1
+pyvespa>=1.2.4
+vespacli>=8.730.36
+tqdm>=4.70.0
+requests>=2.34.2
 zstandard>=0.25.0
 urllib3>=2.7.0
+# transitive via pyvespa; floor for CVE-2026-69247
+cryptography>=50.0.0


### PR DESCRIPTION
> ⚠️ **This PR was created by an AI assistant (Claude). Please review all changes carefully before merging.**

## Summary
Fixes the Mend HIGH finding CVE-2026-69247 (GHSA-g6cj-pr64-35w5): `cryptography 49.0.0` was resolved transitively via `pyvespa` in the ecommerce_hybrid_search performance-test requirements. Adds an explicit floor at the first patched release, `50.0.0`, and raises the file's existing floors to the latest releases within their majors.

## Changed Files

**`tests/performance/ecommerce_hybrid_search/common/requirements.txt`**:
- `cryptography`: added `>=50.0.0` (CVE-2026-69247; transitive via `pyvespa`)
- `docker`: `>=7.1.0` → `>=7.2.0`
- `elasticsearch`: `>=9.4.0` → `>=9.4.1`
- `pyvespa`: `>=1.2.0` → `>=1.2.4`
- `vespacli`: `>=8.687.75` → `>=8.730.36`
- `tqdm`: `>=4.67.3` → `>=4.70.0`
- `requests`: `>=2.34.0` → `>=2.34.2`
- `zstandard`, `urllib3`: already at latest, unchanged

## CVEs Addressed

Verified against the GitHub Advisory Database:

| Package | CVE(s) | Severity | Fix version reached |
|---|---|---|---|
| cryptography | CVE-2026-69247 | high | 49.0.0 → 50.0.0 |

## Implementation Notes
- Scoped to the flagged manifest only per core-repo policy — the Ruby side and other Python manifests in this repo are untouched. No lockfile accompanies this requirements.txt.
- The finding is transitive (via `pyvespa 1.2.4`, whose own constraint `cryptography>=48.0.1` still admits vulnerable releases), so the patched floor is declared directly in this file.

## Verification
- `uv pip compile tests/performance/ecommerce_hybrid_search/common/requirements.txt` resolves cleanly with `cryptography==50.0.0`
- GHSA-g6cj-pr64-35w5: vulnerable `>=44.0.0, <50.0.0`, first patched `50.0.0`
- Re-run the Mend scan after merge to confirm the finding clears

Jira: VESPANG-3773
