### PR TITLE
update grouping test results for size-1 array broadcasting

### DIFF
--- a/tests/search/struct_and_map_types/struct_and_map_grouping.rb
+++ b/tests/search/struct_and_map_types/struct_and_map_grouping.rb
@@ -85,7 +85,7 @@ class StructAndMapGroupingTest < IndexedStreamingSearchTest
     check_grouping("all(group(strcat(str_int_map.key, str_int_map.value)) each(output(count())))",
                    {""=>1, "@foo@bar1020"=>1, "@foo@bar2030"=>1})
     check_grouping("all(group(str_int_map.value + int_array) each(output(count())))",
-                   {"20"=>1, "30"=>2, "40"=>1})
+                   {"20"=>1, "30"=>1, "40"=>2})
 
     check_grouping("all(group(str_int_map.key) each(output(sum(str_int_map.value))))", {"@bar"=>50, "@foo"=>30}, "sum(str_int_map.value)")
     check_grouping("all(group(str_int_map.key) each(group(str_int_map.value) each(output(sum(str_int_map.value)))))",
@@ -97,8 +97,8 @@ class StructAndMapGroupingTest < IndexedStreamingSearchTest
                     "@foo"=>{"@foo10"=>10, "@foo20"=>20}},
                    "sum(str_int_map.value)")
     check_grouping("all(group(str_int_map.key) each(group(str_int_map.value + int_array) each(output(count()))))",
-                   {"@bar"=>{"20"=>1, "30"=>1, "40"=>1},
-                    "@foo"=>{"20"=>2, "30"=>1}})
+                   {"@bar"=>{"30"=>1, "40"=>2},
+                    "@foo"=>{"20"=>1, "30"=>2}})
 
     if is_streaming
         check_grouping("all(group(str_int_map{\"@foo\"}) each(output(count())))", {"10"=>1, "20"=>1})


### PR DESCRIPTION
Vespa commit 0f604239444 ("searchlib: broadcast vectors of size 1 in NumericFunctionNode") changed how arithmetic in grouping combines two array results element-wise: an operand of length 1 is now broadcast to the length of the other operand, instead of being zipped as a length-mismatched pair where the surplus slots were left uncombined.

This test groups on "str_int_map.value + int_array", and both documents with data hit the changed code paths, in two different ways:

Flat grouping combines the two arrays directly.  For the document with str_int_map.value=[20,30] and int_array=[10]:
  [20, 30] + [10] => [30, 30]  (old: only index 0 was added to)
  [20, 30] + [10] => [30, 40]  (new: [10] is broadcast)

Nested grouping (group by key, then by value + int_array) fixes the map index in the outer level, so the left operand is a single value that is now broadcast over int_array.  For the document with int_array=[10,20]:
  10 + [10, 20] => [20, 20]    (old: index 1 kept the raw arg value)
  10 + [10, 20] => [20, 30]    (new: the single value is broadcast)

Why: the new behavior is the intended one - a scalar-shaped (size 1) array should interact with a longer array the way users expect - so the recorded expectations are updated to match.
