### PR TITLE
Fix leaked watch thread in tensor_matrix_matrix_prod test

### DIFF
--- a/tests/performance/tensor_matrix_matrix_prod/tensor_matrix_matrix_prod.rb
+++ b/tests/performance/tensor_matrix_matrix_prod/tensor_matrix_matrix_prod.rb
@@ -14,7 +14,6 @@ class TensorMatrixMatrixProduct < PerformanceTest
     set_owner("hmusum")
   end
 
-
   def test_tensor_matrix_matrix_products
     set_description("Test of various matrix-matrix products")
 
@@ -28,8 +27,12 @@ class TensorMatrixMatrixProduct < PerformanceTest
     copy_query_file
     warmup
     t = Thread.new() { watch(@container) }
-    run_queries
-    t.kill
+    begin
+      run_queries
+    ensure
+      t.kill
+      t.join
+    end
   end
 
   def watch(node)


### PR DESCRIPTION
## Summary
- The `watch` monitoring thread in `test_tensor_matrix_matrix_products` runs an unconditional `while true` loop and was only killed via `t.kill` after `run_queries` returned normally.
- If `run_queries` raised (fbench failure, assertion, connection issue, etc.), `t.kill` was never reached, leaking a background thread that would loop forever calling `node.execute("turbostat sleep 20 ...")` against the container.
- Wrapped `run_queries` in `begin/ensure` so the thread is always killed and joined, regardless of whether `run_queries` succeeds or raises.

Generated by Claude Code.

This test occasionally runs forever (test run times out before test finishes), no log, sp not sure if this will help, but maybe worth a try?