### PR TITLE
test fast map search with shorthand syntax

### DIFF
--- a/tests/search/fast_map_search/fast_map_search.rb
+++ b/tests/search/fast_map_search/fast_map_search.rb
@@ -14,28 +14,41 @@ class FastMapSearch < IndexedOnlySearchTest
     start
     feed_and_wait_for_docs("fast_map_search", 2, :file => selfdir+"feed.json")
 
+    run_queries(:same_element_query)
+    run_queries(:shortform_query)
+  end
+
+  def run_queries(make_query_fn)
     # A key-value pair matches only when both are present in the same map entry.
     # Document 1 contains both the key 'foo' and the value 'bar', but in different
     # entries, so it must not match.
-    assert_hitcount(same_element_query("foo", "bar"), 1)
-    assert_hitcount(same_element_query("baz", "bar"), 1)
-    assert_hitcount(same_element_query("foo", "baz"), 0)
+    assert_hitcount(public_send(make_query_fn, "foo", "bar"), 1)
+    assert_hitcount(public_send(make_query_fn, "baz", "bar"), 1)
+    assert_hitcount(public_send(make_query_fn, "foo", "baz"), 0)
 
     # 'map: fast-search' makes the container rewrite the sameElement operator to a
     # single lookup in the synthetic key-value attribute. Verify through the query
     # trace that the rewrite actually happened.
-    result = search(same_element_query("foo", "bar", 2))
+    result = search(public_send(make_query_fn, "foo", "bar", 2))
     assert(result.json.to_s.include?("my_map$keyvalue"),
            "Expected sameElement to be rewritten to a fast map lookup")
 
     # The rewrite does not change the result: the map summary is returned,
     # and the synthetic attribute is not part of it.
-    assert_result(same_element_query("foo", "bar"), selfdir + "result.json")
+    assert_result(public_send(make_query_fn, "foo", "bar"), selfdir + "result.json")
   end
 
   def same_element_query(key, value, tracelevel = nil)
     yql = "select * from sources * where my_map contains sameElement(" +
           "key contains '#{key}', value contains '#{value}')"
+    form = [['yql', yql]]
+    form << ['tracelevel', tracelevel.to_s] if tracelevel
+    URI.encode_www_form(form)
+  end
+
+  # fancy syntax: field{key} contains value.
+  def shortform_query(key, value, tracelevel = nil)
+    yql = "select * from sources * where my_map{'#{key}'} contains '#{value}'"
     form = [['yql', yql]]
     form << ['tracelevel', tracelevel.to_s] if tracelevel
     URI.encode_www_form(form)


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Ref shorthand syntax:

```
field{key} contains value
```