### PR TITLE
Add int version of basic fast-map-search test

### DIFF
--- a/tests/search/fast_map_search/fast_map_search.rb
+++ b/tests/search/fast_map_search/fast_map_search.rb
@@ -9,33 +9,43 @@ class FastMapSearch < IndexedOnlySearchTest
     set_owner("johsol")
   end
 
-  def test_fast_map_search_basic
-    deploy_app(SearchApp.new.sd(write_sd("map: fast-search")))
+  def test_fast_map_search_basic_string
+    deploy_app(SearchApp.new.sd(write_sd("map: fast-search", "string")))
     start
     feed_and_wait_for_docs("fast_map_search", 2, :file => selfdir+"feed.json")
 
-    run_queries(:same_element_query)
-    run_queries(:shortform_query)
+    run_queries(:same_element_query, "bar", "baz", "result.json")
+    run_queries(:shortform_query, "bar", "baz", "result.json")
   end
 
-  def run_queries(make_query_fn)
+  def test_fast_map_search_basic_int
+    deploy_app(SearchApp.new.sd(write_sd("map: fast-search", "int")))
+    start
+    feed_and_wait_for_docs("fast_map_search", 2, :file => selfdir+"feed_int.json")
+
+    run_queries(:same_element_query, 42, 43, "result_int.json")
+    run_queries(:shortform_query, 42, 43, "result_int.json")
+  end
+
+
+  def run_queries(make_query_fn, value_one, value_two, result_file)
     # A key-value pair matches only when both are present in the same map entry.
     # Document 1 contains both the key 'foo' and the value 'bar', but in different
     # entries, so it must not match.
-    assert_hitcount(public_send(make_query_fn, "foo", "bar"), 1)
-    assert_hitcount(public_send(make_query_fn, "baz", "bar"), 1)
-    assert_hitcount(public_send(make_query_fn, "foo", "baz"), 0)
+    assert_hitcount(public_send(make_query_fn, "foo", value_one), 1)
+    assert_hitcount(public_send(make_query_fn, "baz", value_one), 1)
+    assert_hitcount(public_send(make_query_fn, "foo", value_two), 0)
 
     # 'map: fast-search' makes the container rewrite the sameElement operator to a
     # single lookup in the synthetic key-value attribute. Verify through the query
     # trace that the rewrite actually happened.
-    result = search(public_send(make_query_fn, "foo", "bar", 2))
+    result = search(public_send(make_query_fn, "foo", value_one, 2))
     assert(result.json.to_s.include?("my_map$keyvalue"),
            "Expected sameElement to be rewritten to a fast map lookup")
 
     # The rewrite does not change the result: the map summary is returned,
     # and the synthetic attribute is not part of it.
-    assert_result(public_send(make_query_fn, "foo", "bar"), selfdir + "result.json")
+    assert_result(public_send(make_query_fn, "foo", value_one), selfdir + result_file)
   end
 
   def same_element_query(key, value, tracelevel = nil)
@@ -54,12 +64,12 @@ class FastMapSearch < IndexedOnlySearchTest
     URI.encode_www_form(form)
   end
 
-  def write_sd(field_body)
+  def write_sd(field_body, type)
     sd_file = "#{dirs.tmpdir}fast_map_search.sd"
     File.write(sd_file, <<~SD)
       schema fast_map_search {
         document fast_map_search {
-          field my_map type map<string, string> {
+          field my_map type map<string, #{type}> {
             indexing: summary
             #{field_body}
           }

--- a/tests/search/fast_map_search/feed_int.json
+++ b/tests/search/fast_map_search/feed_int.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "id:fast_map_search:fast_map_search::0",
+    "fields": {
+      "my_map": {
+        "foo": 42
+      }
+    }
+  },
+  {
+    "id": "id:fast_map_search:fast_map_search::1",
+    "fields": {
+      "my_map": {
+        "foo": 13,
+        "baz": 42
+      }
+    }
+  }
+]

--- a/tests/search/fast_map_search/result_int.json
+++ b/tests/search/fast_map_search/result_int.json
@@ -1,0 +1,31 @@
+{
+  "root": {
+    "id": "toplevel",
+    "relevance": 1.0,
+    "fields": {
+      "totalCount": 1
+    },
+    "coverage": {
+      "coverage": 100,
+      "documents": 1,
+      "full": true,
+      "nodes": 1,
+      "results": 1,
+      "resultsFull": 1
+    },
+    "children": [
+      {
+        "id": "id:fast_map_search:fast_map_search::0",
+        "relevance": 0.0,
+        "source": "search",
+        "fields": {
+          "sddocname": "fast_map_search",
+          "documentid": "id:fast_map_search:fast_map_search::0",
+          "my_map": {
+            "foo": 42
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Succeeds at the moment. Will break once https://github.com/vespa-engine/vespa/pull/37749 is merged. Should start working again once the query-to-hex translation is implemented.