### PR TITLE
Remove stale config override (sendProtobufQuerytree)

### DIFF
--- a/tests/search/near_fieldset/near_fieldset.rb
+++ b/tests/search/near_fieldset/near_fieldset.rb
@@ -24,8 +24,6 @@ class NearFieldSet < IndexedStreamingSearchTest
     deploy_app(SearchApp.new
       .sd(selfdir+"test.sd")
       .container(Container.new
-        .config(ConfigOverride.new("container.qr-searchers")
-          .add("sendProtobufQuerytree", true))
         .search(Searching.new)
         .docproc(DocumentProcessing.new)
         .documentapi(ContainerDocumentApi.new)))

--- a/tests/search/nearsearch/nearsearch.rb
+++ b/tests/search/nearsearch/nearsearch.rb
@@ -132,8 +132,6 @@ class NearSearch < IndexedStreamingSearchTest
     deploy_app(SearchApp.new
       .sd(selfdir+"music.sd")
       .container(Container.new
-        .config(ConfigOverride.new("container.qr-searchers")
-          .add("sendProtobufQuerytree", true))
         .search(Searching.new)
         .docproc(DocumentProcessing.new)
         .documentapi(ContainerDocumentApi.new)))


### PR DESCRIPTION
Config field sendProtobufQuerytree has been removed, always true