### PR TITLE
Activate fast map search in map performance test

### DIFF
--- a/tests/performance/map_search/test.sd
+++ b/tests/performance/map_search/test.sd
@@ -5,6 +5,7 @@ schema test {
     # See create_docs.cpp for details on how the dataset is generated.
     field kv_5 type map<string, int> {
       indexing: summary
+      map: fast-search
       struct-field key {
         indexing: attribute
         attribute: fast-search
@@ -22,6 +23,7 @@ schema test {
     }
     field kv_25 type map<string, int> {
       indexing: summary
+      map: fast-search
       struct-field key {
         indexing: attribute
         attribute: fast-search
@@ -39,6 +41,7 @@ schema test {
     }
     field kv_125 type map<string, int> {
       indexing: summary
+      map: fast-search
       struct-field key {
         indexing: attribute
         attribute: fast-search


### PR DESCRIPTION
Let's see what happens.

The plan is to update the test later to add a separate field for fast map search. Then one can verify that the queries yield the same results with and without fast map search.