### PR TITLE
Test hitLimit annotation for string ranges

### DIFF
--- a/tests/search/lexical_range/lexical_range.rb
+++ b/tests/search/lexical_range/lexical_range.rb
@@ -18,7 +18,7 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
     string_single_cased
   ]
   SINGLE_VALUE_CASED_FAST_FIELDS = %w[
-    string_single_fast_cased_both
+    string_single_fast_cased_btree_hash
     string_single_fast_cased_btree
     string_single_fast_cased_hash
   ]
@@ -32,7 +32,7 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
     string_multi_cased
   ]
   MULTI_VALUE_CASED_FAST_FIELDS = %w[
-    string_multi_fast_cased_both
+    string_multi_fast_cased_btree_hash
     string_multi_fast_cased_btree
     string_multi_fast_cased_hash
   ]
@@ -46,16 +46,12 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
   SINGLE_VALUE_CASED_FIELDS = SINGLE_VALUE_CASED_SLOW_FIELDS + SINGLE_VALUE_CASED_FAST_FIELDS
   SINGLE_VALUE_UNCASED_FIELDS = SINGLE_VALUE_UNCASED_SLOW_FIELDS + SINGLE_VALUE_UNCASED_FAST_FIELDS
   SINGLE_VALUE_FIELDS = SINGLE_VALUE_CASED_FIELDS + SINGLE_VALUE_UNCASED_FIELDS
-  SINGLE_VALUE_FAST_FIELDS = SINGLE_VALUE_CASED_FAST_FIELDS + SINGLE_VALUE_UNCASED_FAST_FIELDS
 
   MULTI_VALUE_CASED_FIELDS = MULTI_VALUE_CASED_SLOW_FIELDS + MULTI_VALUE_CASED_FAST_FIELDS
   MULTI_VALUE_UNCASED_FIELDS = MULTI_VALUE_UNCASED_SLOW_FIELDS + MULTI_VALUE_UNCASED_FAST_FIELDS
   MULTI_VALUE_FIELDS = MULTI_VALUE_CASED_FIELDS + MULTI_VALUE_UNCASED_FIELDS
-  MULTI_VALUE_FAST_FIELDS = MULTI_VALUE_CASED_FAST_FIELDS + MULTI_VALUE_UNCASED_FAST_FIELDS
 
   FIELDS = SINGLE_VALUE_FIELDS + MULTI_VALUE_FIELDS
-  FAST_FIELDS = SINGLE_VALUE_FAST_FIELDS + MULTI_VALUE_FAST_FIELDS
-
   CASED_FIELDS = SINGLE_VALUE_CASED_FIELDS + MULTI_VALUE_CASED_FIELDS
   UNCASED_FIELDS = SINGLE_VALUE_UNCASED_FIELDS + MULTI_VALUE_UNCASED_FIELDS
 
@@ -329,16 +325,16 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
     search_and_verify2(ids_prefix, ids_suffix, min_hits, max_hits, annotation, field_name, hex_from, hex_to)
   end
 
-  def search_and_verify_hex_prefix(ids_prefix, annotation, field_name, from, to, prefix = "", factor = 1)
+  def search_and_verify_hex_prefix(ids_prefix, allowed_additional_hits, annotation, field_name, from, to, prefix = "", factor = 1)
     # Allow two more hits than contained in the prefix
     ids_prefix_array = Array(ids_prefix)
-    search_and_verify_hex2(ids_prefix_array, [], ids_prefix_array.length, ids_prefix_array.length + 2, annotation, field_name, from, to, prefix, factor)
+    search_and_verify_hex2(ids_prefix_array, [], ids_prefix_array.length, ids_prefix_array.length + allowed_additional_hits, annotation, field_name, from, to, prefix, factor)
   end
 
-  def search_and_verify_hex_suffix(ids_suffix, annotation, field_name, from, to, prefix = "", factor = 1)
+  def search_and_verify_hex_suffix(ids_suffix, allowed_additional_hits, annotation, field_name, from, to, prefix = "", factor = 1)
     # Allow two more hits than contained in the suffix
     ids_suffix_array = Array(ids_suffix)
-    search_and_verify_hex2([], ids_suffix_array, ids_suffix_array.length, ids_suffix_array.length + 2, annotation, field_name, from, to, prefix, factor)
+    search_and_verify_hex2([], ids_suffix_array, ids_suffix_array.length, ids_suffix_array.length + allowed_additional_hits, annotation, field_name, from, to, prefix, factor)
   end
 
   def search_and_verify_hex(expected_ids, annotation, field_name, from, to, prefix = "", factor = 1)
@@ -356,25 +352,41 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
     feed_hex_docs(range)
 
     puts "Bounded ranges"
-    # The hitLimit annotation requires an attribute with fast search enabled
-    FAST_FIELDS.each do |field_name|
+    FIELDS.each do |field_name|
       puts "Testing field '#{field_name}'"
+      # The hitLimit annotation requires an attribute with fast search enabled using a btree dictionary
+      btree = field_name.include?("btree")
       prefix = field_name.include?("multi") ? "foo" : :""
 
       from = 12
       to = 18
       [0, 1, 2, 3].each do |i|
-        # ascending
-        search_and_verify_hex(from..from+i, CLOSED.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
-        search_and_verify_hex_prefix(from..from+i, RIGHT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
-        search_and_verify_hex_prefix(from+1..from+1+i, LEFT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
-        search_and_verify_hex_prefix(from+1..from+1+i, OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+        if btree
+          # ascending
+          search_and_verify_hex_prefix(from..from+i, 0, CLOSED.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+          search_and_verify_hex_prefix(from..from+i, 1, RIGHT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+          search_and_verify_hex_prefix(from+1..from+1+i, 1, LEFT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+          search_and_verify_hex_prefix(from+1..from+1+i, 2, OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
 
-        # descending
-        search_and_verify_hex(to-i..to, CLOSED.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
-        search_and_verify_hex_suffix(to-i..to, LEFT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
-        search_and_verify_hex_suffix(to-1-i..to-1, RIGHT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
-        search_and_verify_hex_suffix(to-1-i..to-1, OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+          # descending
+          search_and_verify_hex_suffix(to-i..to, 0, CLOSED.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+          search_and_verify_hex_suffix(to-i..to, 1, LEFT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+          search_and_verify_hex_suffix(to-1-i..to-1, 1, RIGHT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+          search_and_verify_hex_suffix(to-1-i..to-1, 2, OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+        else
+          # Without a btree, the hitLimit should be ignored
+          # ascending
+          search_and_verify_hex(from..to, CLOSED.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+          search_and_verify_hex(from..to-1, RIGHT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+          search_and_verify_hex(from+1..to, LEFT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+          search_and_verify_hex(from+1..to-1, OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+
+          # descending
+          search_and_verify_hex(from..to, CLOSED.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+          search_and_verify_hex(from+1..to, LEFT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+          search_and_verify_hex(from..to-1, RIGHT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+          search_and_verify_hex(from+1..to-1, OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+        end
       end
 
       # Check that we still can get the whole range
@@ -386,33 +398,65 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
       from = 0
       to = 100
       [0, 1, 2, 3].each do |i|
-        # ascending
-        search_and_verify_hex(range.begin..range.begin+i, CLOSED.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
-        search_and_verify_hex_prefix(range.begin..range.begin+i, RIGHT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
-        search_and_verify_hex_prefix(range.begin..range.begin+i, LEFT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
-        search_and_verify_hex_prefix(range.begin..range.begin+i, OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+        if btree
+          # ascending
+          search_and_verify_hex_prefix(range.begin..range.begin+i, 0, CLOSED.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+          search_and_verify_hex_prefix(range.begin..range.begin+i, 1, RIGHT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+          search_and_verify_hex_prefix(range.begin..range.begin+i, 1, LEFT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+          search_and_verify_hex_prefix(range.begin..range.begin+i, 2, OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
 
-        # descending
-        search_and_verify_hex(range.end-i..range.end, CLOSED.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
-        search_and_verify_hex_suffix(range.end-i..range.end, LEFT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
-        search_and_verify_hex_suffix(range.end-i..range.end, RIGHT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
-        search_and_verify_hex_suffix(range.end-i..range.end, OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+          # descending
+          search_and_verify_hex_suffix(range.end-i..range.end, 0, CLOSED.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+          search_and_verify_hex_suffix(range.end-i..range.end, 1, LEFT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+          search_and_verify_hex_suffix(range.end-i..range.end, 1, RIGHT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+          search_and_verify_hex_suffix(range.end-i..range.end, 2, OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+        else
+          # ascending
+          search_and_verify_hex(range, CLOSED.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+          search_and_verify_hex(range, RIGHT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+          search_and_verify_hex(range, LEFT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+          search_and_verify_hex(range, OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+
+          # descending
+          search_and_verify_hex(range, CLOSED.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+          search_and_verify_hex(range, LEFT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+          search_and_verify_hex(range, RIGHT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+          search_and_verify_hex(range, OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+        end
       end
     end
 
     puts "Unbounded ranges"
-    SINGLE_VALUE_FAST_FIELDS.each do |field_name|
+    SINGLE_VALUE_FIELDS.each do |field_name|
       puts "Testing field '#{field_name}'"
+      btree = field_name.include?("btree")
       from = 12
       to = 18
-      [CLOSED, LEFT_OPEN, RIGHT_OPEN, OPEN].each do |bounds|
-        search_and_verify_hex_prefix([10], bounds.merge({"hitLimit" => 1}), field_name, nil, to)
-        search_and_verify_hex_prefix([10, 11], bounds.merge({"hitLimit" => 2}), field_name, nil, to)
-        search_and_verify_hex_prefix([10, 11, 12], bounds.merge({"hitLimit" => 3}), field_name, nil, to)
 
-        search_and_verify_hex_suffix([20], bounds.merge({"hitLimit" => 1, "descending" => true}), field_name, from, nil)
-        search_and_verify_hex_suffix([19, 20], bounds.merge({"hitLimit" => 2, "descending" => true}), field_name, from, nil)
-        search_and_verify_hex_suffix([18, 19, 20], bounds.merge({"hitLimit" => 3, "descending" => true}), field_name, from, nil)
+      if btree
+        [CLOSED, LEFT_OPEN, RIGHT_OPEN, OPEN].each do |bounds|
+          search_and_verify_hex_prefix([10], 2, bounds.merge({"hitLimit" => 1}), field_name, nil, to)
+          search_and_verify_hex_prefix([10, 11], 2, bounds.merge({"hitLimit" => 2}), field_name, nil, to)
+          search_and_verify_hex_prefix([10, 11, 12], 2, bounds.merge({"hitLimit" => 3}), field_name, nil, to)
+
+          search_and_verify_hex_suffix([20], 2, bounds.merge({"hitLimit" => 1, "descending" => true}), field_name, from, nil)
+          search_and_verify_hex_suffix([19, 20], 2, bounds.merge({"hitLimit" => 2, "descending" => true}), field_name, from, nil)
+          search_and_verify_hex_suffix([18, 19, 20], 2, bounds.merge({"hitLimit" => 3, "descending" => true}), field_name, from, nil)
+        end
+      else
+        search_and_verify_hex(range.begin..to, CLOSED.merge({"hitLimit" => 1}), field_name, nil, to)
+        search_and_verify_hex(range.begin..to-1, OPEN.merge({"hitLimit" => 1}), field_name, nil, to)
+        search_and_verify_hex(range.begin..to, CLOSED.merge({"hitLimit" => 2}), field_name, nil, to)
+        search_and_verify_hex(range.begin..to-1, OPEN.merge({"hitLimit" => 2}), field_name, nil, to)
+        search_and_verify_hex(range.begin..to, CLOSED.merge({"hitLimit" => 3}), field_name, nil, to)
+        search_and_verify_hex(range.begin..to-1, OPEN.merge({"hitLimit" => 3}), field_name, nil, to)
+
+        search_and_verify_hex(from..range.end, CLOSED.merge({"hitLimit" => 1, "descending" => true}), field_name, from, nil)
+        search_and_verify_hex(from+1..range.end, OPEN.merge({"hitLimit" => 1, "descending" => true}), field_name, from, nil)
+        search_and_verify_hex(from..range.end, CLOSED.merge({"hitLimit" => 2, "descending" => true}), field_name, from, nil)
+        search_and_verify_hex(from+1..range.end, OPEN.merge({"hitLimit" => 2, "descending" => true}), field_name, from, nil)
+        search_and_verify_hex(from..range.end, CLOSED.merge({"hitLimit" => 3, "descending" => true}), field_name, from, nil)
+        search_and_verify_hex(from+1..range.end, OPEN.merge({"hitLimit" => 3, "descending" => true}), field_name, from, nil)
       end
 
       search_and_verify_hex(10..18, CLOSED.merge({"hitLimit" => 100}), field_name, nil, to)
@@ -421,26 +465,45 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
       search_and_verify_hex(10..20, OPEN.merge({"hitLimit" => 100}), field_name, nil, nil)
     end
 
-    MULTI_VALUE_FAST_FIELDS.each do |field_name|
+    MULTI_VALUE_FIELDS.each do |field_name|
       puts "Testing field '#{field_name}'"
+      btree = field_name.include?("btree")
       from = 12
       to = 18
-      [CLOSED, LEFT_OPEN, RIGHT_OPEN, OPEN].each do |bounds|
-        search_and_verify_hex_prefix([10], bounds.merge({"hitLimit" => 1}), field_name, nil, to, "foo")
-        search_and_verify_hex_prefix([10, 11], bounds.merge({"hitLimit" => 2}), field_name, nil, to, "foo")
-        search_and_verify_hex_prefix([10, 11, 12], bounds.merge({"hitLimit" => 3}), field_name, nil, to, "foo")
 
-        # The junk fields make hitLimit behave poorly: We get all documents, even with a hitLimit
-        search_and_verify_hex2([], [20], 1, 11, bounds.merge({"hitLimit" => 1, "descending" => true}), field_name, from, nil, "foo")
-        search_and_verify_hex2([], [19, 20], 2, 11, bounds.merge({"hitLimit" => 2, "descending" => true}), field_name, from, nil, "foo")
-        search_and_verify_hex2([], [18, 19, 20], 3, 11, bounds.merge({"hitLimit" => 3, "descending" => true}), field_name, from, nil, "foo")
+      if btree
+        [CLOSED, LEFT_OPEN, RIGHT_OPEN, OPEN].each do |bounds|
+          search_and_verify_hex_prefix([10], 2, bounds.merge({"hitLimit" => 1}), field_name, nil, to, "foo")
+          search_and_verify_hex_prefix([10, 11], 2, bounds.merge({"hitLimit" => 2}), field_name, nil, to, "foo")
+          search_and_verify_hex_prefix([10, 11, 12], 2, bounds.merge({"hitLimit" => 3}), field_name, nil, to, "foo")
+
+          # The junk fields make hitLimit behave poorly: We get all documents, even with a hitLimit
+          search_and_verify_hex(range, bounds.merge({"hitLimit" => 1, "descending" => true}), field_name, from, nil, "foo")
+          search_and_verify_hex(range, bounds.merge({"hitLimit" => 2, "descending" => true}), field_name, from, nil, "foo")
+          search_and_verify_hex(range, bounds.merge({"hitLimit" => 3, "descending" => true}), field_name, from, nil, "foo")
+        end
+      else
+        # We just get everything all the time
+        search_and_verify_hex(range, CLOSED.merge({"hitLimit" => 1}), field_name, nil, to, "foo")
+        search_and_verify_hex(range, OPEN.merge({"hitLimit" => 1}), field_name, nil, to, "foo")
+        search_and_verify_hex(range, CLOSED.merge({"hitLimit" => 2}), field_name, nil, to, "foo")
+        search_and_verify_hex(range, OPEN.merge({"hitLimit" => 2}), field_name, nil, to, "foo")
+        search_and_verify_hex(range, CLOSED.merge({"hitLimit" => 3}), field_name, nil, to, "foo")
+        search_and_verify_hex(range, OPEN.merge({"hitLimit" => 3}), field_name, nil, to, "foo")
+
+        search_and_verify_hex(range, CLOSED.merge({"hitLimit" => 1, "descending" => true}), field_name, from, nil, "foo")
+        search_and_verify_hex(range, OPEN.merge({"hitLimit" => 1, "descending" => true}), field_name, from, nil, "foo")
+        search_and_verify_hex(range, CLOSED.merge({"hitLimit" => 2, "descending" => true}), field_name, from, nil, "foo")
+        search_and_verify_hex(range, OPEN.merge({"hitLimit" => 2, "descending" => true}), field_name, from, nil, "foo")
+        search_and_verify_hex(range, CLOSED.merge({"hitLimit" => 3, "descending" => true}), field_name, from, nil, "foo")
+        search_and_verify_hex(range, OPEN.merge({"hitLimit" => 3, "descending" => true}), field_name, from, nil, "foo")
       end
 
       # We get all document every time
-      search_and_verify_hex(10..20, CLOSED.merge({"hitLimit" => 100}), field_name, nil, to, "foo")
-      search_and_verify_hex(10..20, OPEN.merge({"hitLimit" => 100}), field_name, nil, to, "foo")
-      search_and_verify_hex(10..20, CLOSED.merge({"hitLimit" => 100}), field_name, nil, nil, "foo")
-      search_and_verify_hex(10..20, OPEN.merge({"hitLimit" => 100}), field_name, nil, nil, "foo")
+      search_and_verify_hex(range, CLOSED.merge({"hitLimit" => 100}), field_name, nil, to, "foo")
+      search_and_verify_hex(range, OPEN.merge({"hitLimit" => 100}), field_name, nil, to, "foo")
+      search_and_verify_hex(range, CLOSED.merge({"hitLimit" => 100}), field_name, nil, nil, "foo")
+      search_and_verify_hex(range, OPEN.merge({"hitLimit" => 100}), field_name, nil, nil, "foo")
     end
   end
 

--- a/tests/search/lexical_range/lexical_range.rb
+++ b/tests/search/lexical_range/lexical_range.rb
@@ -14,12 +14,50 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
   RIGHT_OPEN = {"bounds" => "rightOpen"}
   OPEN = {"bounds" => "open"}
 
-  CASED_FIELDS = %w[string_single_cased string_single_fast_cased string_multi_cased string_multi_fast_cased]
-  UNCASED_FIELDS = %w[string_single string_single_fast string_multi string_multi_fast]
-  FIELDS = CASED_FIELDS + UNCASED_FIELDS
+  SINGLE_VALUE_CASED_SLOW_FIELDS = %w[
+    string_single_cased
+  ]
+  SINGLE_VALUE_CASED_FAST_FIELDS = %w[
+    string_single_fast_cased_both
+    string_single_fast_cased_btree
+    string_single_fast_cased_hash
+  ]
+  SINGLE_VALUE_UNCASED_SLOW_FIELDS = %w[
+    string_single
+  ]
+  SINGLE_VALUE_UNCASED_FAST_FIELDS = %w[
+    string_single_fast_btree
+  ]
+  MULTI_VALUE_CASED_SLOW_FIELDS = %w[
+    string_multi_cased
+  ]
+  MULTI_VALUE_CASED_FAST_FIELDS = %w[
+    string_multi_fast_cased_both
+    string_multi_fast_cased_btree
+    string_multi_fast_cased_hash
+  ]
+  MULTI_VALUE_UNCASED_SLOW_FIELDS = %w[
+    string_multi
+  ]
+  MULTI_VALUE_UNCASED_FAST_FIELDS = %w[
+    string_multi_fast_btree
+  ]
 
-  SINGLE_VALUE_FIELDS = %w[string_single_cased string_single_fast_cased string_single string_single_fast]
-  MULTI_VALUE_FIELDS = %w[string_multi_cased string_multi_fast_cased string_multi string_multi_fast]
+  SINGLE_VALUE_CASED_FIELDS = SINGLE_VALUE_CASED_SLOW_FIELDS + SINGLE_VALUE_CASED_FAST_FIELDS
+  SINGLE_VALUE_UNCASED_FIELDS = SINGLE_VALUE_UNCASED_SLOW_FIELDS + SINGLE_VALUE_UNCASED_FAST_FIELDS
+  SINGLE_VALUE_FIELDS = SINGLE_VALUE_CASED_FIELDS + SINGLE_VALUE_UNCASED_FIELDS
+  SINGLE_VALUE_FAST_FIELDS = SINGLE_VALUE_CASED_FAST_FIELDS + SINGLE_VALUE_UNCASED_FAST_FIELDS
+
+  MULTI_VALUE_CASED_FIELDS = MULTI_VALUE_CASED_SLOW_FIELDS + MULTI_VALUE_CASED_FAST_FIELDS
+  MULTI_VALUE_UNCASED_FIELDS = MULTI_VALUE_UNCASED_SLOW_FIELDS + MULTI_VALUE_UNCASED_FAST_FIELDS
+  MULTI_VALUE_FIELDS = MULTI_VALUE_CASED_FIELDS + MULTI_VALUE_UNCASED_FIELDS
+  MULTI_VALUE_FAST_FIELDS = MULTI_VALUE_CASED_FAST_FIELDS + MULTI_VALUE_UNCASED_FAST_FIELDS
+
+  FIELDS = SINGLE_VALUE_FIELDS + MULTI_VALUE_FIELDS
+  FAST_FIELDS = SINGLE_VALUE_FAST_FIELDS + MULTI_VALUE_FAST_FIELDS
+
+  CASED_FIELDS = SINGLE_VALUE_CASED_FIELDS + MULTI_VALUE_CASED_FIELDS
+  UNCASED_FIELDS = SINGLE_VALUE_UNCASED_FIELDS + MULTI_VALUE_UNCASED_FIELDS
 
   def setup
     set_owner("boeker")
@@ -36,17 +74,14 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
     puts "Sorted: #{words.sort}"
     id = 0
     words.each do |word|
-      vespa.document_api_v1.put(Document.new("id:test:test::#{id}")
-                                        .add_field("id", id)
-                                        .add_field("string_single", word)
-                                        .add_field("string_single_fast", word)
-                                        .add_field("string_multi", [word])
-                                        .add_field("string_multi_fast", [word])
-                                        .add_field("string_single_cased", word)
-                                        .add_field("string_single_fast_cased", word)
-                                        .add_field("string_multi_cased", [word])
-                                        .add_field("string_multi_fast_cased", [word])
-      )
+      doc = Document.new("id:test:test::#{id}").add_field("id", id)
+      SINGLE_VALUE_FIELDS.each do |field_name|
+        doc.add_field(field_name, word)
+      end
+      MULTI_VALUE_FIELDS.each do |field_name|
+        doc.add_field(field_name, [word])
+      end
+      vespa.document_api_v1.put(doc)
       id += 1
     end
     wait_for_hitcount('query=sddocname:test', words.size)
@@ -73,6 +108,7 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
     # Verify cased matching: The order will be exactly as in the list above
     puts "Cased tests"
     CASED_FIELDS.each do |field_name|
+      puts "Testing field '#{field_name}'"
       verify_words_cased(words, field_name)
     end
 
@@ -87,6 +123,7 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
     puts "Uncased tests"
 
     UNCASED_FIELDS.each do |field_name|
+      puts "Testing field '#{field_name}'"
       # 1 to 3
       # Closed: 0 and 4 will also match
       search_and_verify([0, 1, 2, 3, 4], CLOSED, field_name, words[1], words[3])
@@ -220,18 +257,14 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
       end
       hex_strings << "bar" + to_hex(2 * n) # Searching with prefix "bar" for twice the number should also work
 
-
-      vespa.document_api_v1.put(Document.new("id:test:test::#{n}")
-                                        .add_field("id", n)
-                                        .add_field("string_single", hex_string)
-                                        .add_field("string_single_fast", hex_string)
-                                        .add_field("string_multi", hex_strings)
-                                        .add_field("string_multi_fast", hex_strings)
-                                        .add_field("string_single_cased", hex_string)
-                                        .add_field("string_single_fast_cased", hex_string)
-                                        .add_field("string_multi_cased", hex_strings)
-                                        .add_field("string_multi_fast_cased", hex_strings)
-      )
+      doc = Document.new("id:test:test::#{n}").add_field("id", n)
+      SINGLE_VALUE_FIELDS.each do |field_name|
+        doc.add_field(field_name, hex_string)
+      end
+      MULTI_VALUE_FIELDS.each do |field_name|
+        doc.add_field(field_name, hex_strings)
+      end
+      vespa.document_api_v1.put(doc)
     end
     wait_for_hitcount('query=sddocname:test', range.size)
   end
@@ -322,8 +355,10 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
     range = (10..20)
     feed_hex_docs(range)
 
+    puts "Bounded ranges"
     # The hitLimit annotation requires an attribute with fast search enabled
-    ["string_single_fast_cased", "string_single_fast", "string_multi_fast_cased", "string_multi_fast"].each do |field_name|
+    FAST_FIELDS.each do |field_name|
+      puts "Testing field '#{field_name}'"
       prefix = field_name.include?("multi") ? "foo" : :""
 
       from = 12
@@ -365,8 +400,9 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
       end
     end
 
-    # Unbounded ranges
-    ["string_single_fast_cased", "string_single_fast"].each do |field_name|
+    puts "Unbounded ranges"
+    SINGLE_VALUE_FAST_FIELDS.each do |field_name|
+      puts "Testing field '#{field_name}'"
       from = 12
       to = 18
       [CLOSED, LEFT_OPEN, RIGHT_OPEN, OPEN].each do |bounds|
@@ -385,7 +421,8 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
       search_and_verify_hex(10..20, OPEN.merge({"hitLimit" => 100}), field_name, nil, nil)
     end
 
-    ["string_multi_fast_cased", "string_multi_fast"].each do |field_name|
+    MULTI_VALUE_FAST_FIELDS.each do |field_name|
+      puts "Testing field '#{field_name}'"
       from = 12
       to = 18
       [CLOSED, LEFT_OPEN, RIGHT_OPEN, OPEN].each do |bounds|

--- a/tests/search/lexical_range/lexical_range.rb
+++ b/tests/search/lexical_range/lexical_range.rb
@@ -3,12 +3,16 @@ require 'indexed_streaming_search_test'
 
 class LexicalRangeSearch < IndexedStreamingSearchTest
 
+  def self.final_test_methods
+    ['test_hit_limit']
+  end
+
   DEBUG = false
 
-  CLOSED = ""
-  LEFT_OPEN = "{bounds:\"leftOpen\"}"
-  RIGHT_OPEN = "{bounds:\"rightOpen\"}"
-  OPEN = "{bounds:\"open\"}"
+  CLOSED = {}
+  LEFT_OPEN = {"bounds" => "leftOpen"}
+  RIGHT_OPEN = {"bounds" => "rightOpen"}
+  OPEN = {"bounds" => "open"}
 
   CASED_FIELDS = %w[string_single_cased string_single_fast_cased string_multi_cased string_multi_fast_cased]
   UNCASED_FIELDS = %w[string_single string_single_fast string_multi string_multi_fast]
@@ -130,37 +134,63 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
     end
   end
 
-  def search_and_verify(expected_ids, annotation, field_name, from, to)
+  def search_and_verify2(ids_prefix, ids_suffix, min_hits, max_hits, annotation, field_name, from, to)
     yql_query = get_yql_query(annotation, field_name, from, to)
     puts "YQL query: #{yql_query}" if DEBUG
     yql_result = search(yql_query)
     puts "YQL result: #{yql_result}" if DEBUG
-    verify_ids(expected_ids, yql_result)
+    verify_ids(ids_prefix, ids_suffix, min_hits, max_hits, yql_result)
 
     select_query = get_select_query(annotation, field_name, from, to)
     puts "Select query: #{select_query}" if DEBUG
     select_result = vespa.container.values.first.post_search("/search/", select_query, 0, {'Content-Type' => 'application/json'})
     puts "Select result: #{select_result}" if DEBUG
-    verify_ids(expected_ids, select_result)
+    verify_ids(ids_prefix, ids_suffix, min_hits, max_hits, select_result)
   end
 
-  def verify_ids(expected_ids, result)
+  def search_and_verify(expected_ids, annotation, field_name, from, to)
     expected_ids_array = Array(expected_ids)
-    got_ids_array = result.hit.map{ |hit| hit.field["id"] }
-    assert_equal(expected_ids_array, got_ids_array)
+    search_and_verify2(expected_ids_array, expected_ids_array, expected_ids_array.length, expected_ids_array.length, annotation, field_name, from, to)
   end
 
-  def get_yql_query(annotation, field_name, from, to)
+  def verify_ids(ids_prefix, ids_suffix, min_hits, max_hits, result)
+    expected_ids_prefix_array = Array(ids_prefix)
+    expected_ids_suffix_array = Array(ids_suffix)
+    got_ids_array = result.hit.map{ |hit| hit.field["id"] }
+    assert_true(min_hits <= got_ids_array.length, "Expected at least #{min_hits} hits, got #{got_ids_array.length}: #{got_ids_array}")
+    assert_true(got_ids_array.length <= max_hits, "Expected at most #{max_hits} hits, got #{got_ids_array.length}: #{got_ids_array}")
+    assert_true(expected_ids_prefix_array.length <= got_ids_array.length, "Expected prefix #{expected_ids_prefix_array} is longer than received hits #{got_ids_array}")
+    assert_true(expected_ids_suffix_array.length <= got_ids_array.length, "Expected suffix #{expected_ids_suffix_array} is longer than received hits #{got_ids_array}")
+    assert_equal(expected_ids_prefix_array, got_ids_array[0, expected_ids_prefix_array.length], "Expected prefix #{expected_ids_prefix_array}, but got #{got_ids_array}")
+    assert_equal(expected_ids_suffix_array, got_ids_array[-expected_ids_suffix_array.length, expected_ids_suffix_array.length], "Expected suffix #{expected_ids_suffix_array}, but got #{got_ids_array}")
+  end
+
+  def get_yql_query(annotations, field_name, from, to)
+    annotation_string = "{"
+    first = true
+    annotations.each do |k, v|
+      annotation_string += ", " unless first
+      first = false
+      if v.is_a? String
+        annotation_string += "#{k}:\"#{v}\""
+      else
+        annotation_string += "#{k}:#{v}"
+      end
+    end
+    annotation_string += "}"
+
     from_str = from.nil? ? "-Infinity" : "\"#{from}\""
     to_str = to.nil? ? "Infinity" : "\"#{to}\""
-    {"yql" => "select * from sources * where (#{annotation}range(#{field_name}, #{from_str}, #{to_str})) order by id asc", "hits" => 100}
+    {"yql" => "select * from sources * where (#{annotation_string}range(#{field_name}, #{from_str}, #{to_str})) order by id asc", "hits" => 100}
   end
 
-  def get_select_query(annotation, field_name, from, to)
-    lower_bound = from.nil? ? {} : { ((annotation.eql? LEFT_OPEN) || (annotation.eql? OPEN) ? ">" : ">=") => from }
-    upper_bound = to.nil? ? {} : { ((annotation.eql? RIGHT_OPEN) || (annotation.eql? OPEN) ? "<" : "<=") => to }
+  def get_select_query(annotations, field_name, from, to)
+    left_open = annotations.key?("bounds") && (annotations["bounds"].eql?("leftOpen") || annotations["bounds"].eql?("open"))
+    right_open = annotations.key?("bounds") && (annotations["bounds"].eql?("rightOpen") || annotations["bounds"].eql?("open"))
+    lower_bound = from.nil? ? {} : { (left_open ? ">" : ">=") => from }
+    upper_bound = to.nil? ? {} : { (right_open ? "<" : "<=") => to }
 
-    json = { "select" => { "where" => { "range" => [ field_name, lower_bound.merge(upper_bound) ] } },
+    json = { "select" => { "where" => { "range" => { "children" => [ field_name, lower_bound.merge(upper_bound) ], "attributes" => annotations.except("bounds") } }},
              "sorting" => "id",
              "hits" => 100,
              "timeout" => 5 }
@@ -225,10 +255,10 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
       # Using Infinity on the left or right with "foo" or "bar" also selects all the values without a prefix or with the "junk" prefix => Matches everything
       puts "Testing field '#{field_name}' with hex numbers from #{range.first} to #{range.last}: Unbounded ranges"
       range.each do |mid|
-        search_and_verify_hex(range.first..range.last, "", field_name, nil, mid, "foo")
-        search_and_verify_hex(range.first..range.last, "", field_name, nil, mid, "bar", 2)
-        search_and_verify_hex(range.first..range.last, "", field_name, mid, nil, "foo", 1)
-        search_and_verify_hex(range.first..range.last, "", field_name, mid, nil, "bar", 2)
+        search_and_verify_hex(range.first..range.last, CLOSED, field_name, nil, mid, "foo")
+        search_and_verify_hex(range.first..range.last, CLOSED, field_name, nil, mid, "bar", 2)
+        search_and_verify_hex(range.first..range.last, CLOSED, field_name, mid, nil, "foo", 1)
+        search_and_verify_hex(range.first..range.last, CLOSED, field_name, mid, nil, "bar", 2)
       end
 
     end
@@ -238,12 +268,12 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
     puts "Testing field '#{field_name}' with hex numbers from #{range.first} to #{range.last}: Unbounded ranges"
 
     # Unbounded on both sides
-    search_and_verify_hex(range.first..range.last, "", field_name, nil, nil)
+    search_and_verify_hex(range.first..range.last, CLOSED, field_name, nil, nil)
 
     # Unbounded on one side
     range.each do |mid|
-      search_and_verify_hex(range.first..mid, "", field_name, nil, mid)
-      search_and_verify_hex(mid..range.last, "", field_name, mid, nil)
+      search_and_verify_hex(range.first..mid, CLOSED, field_name, nil, mid)
+      search_and_verify_hex(mid..range.last, CLOSED, field_name, mid, nil)
     end
   end
 
@@ -260,10 +290,121 @@ class LexicalRangeSearch < IndexedStreamingSearchTest
     end
   end
 
-  def search_and_verify_hex(expected_ids, annotation, field_name, from, to, prefix = "", factor = 1)
+  def search_and_verify_hex2(ids_prefix, ids_suffix, min_hits, max_hits, annotation, field_name, from, to, prefix = "", factor = 1)
     hex_from = from.nil? ? nil : "#{prefix}#{to_hex(factor * from)}"
     hex_to = to.nil? ? nil : "#{prefix}#{to_hex(factor * to)}"
-    search_and_verify(expected_ids, annotation, field_name, hex_from, hex_to)
+    search_and_verify2(ids_prefix, ids_suffix, min_hits, max_hits, annotation, field_name, hex_from, hex_to)
+  end
+
+  def search_and_verify_hex_prefix(ids_prefix, annotation, field_name, from, to, prefix = "", factor = 1)
+    # Allow two more hits than contained in the prefix
+    ids_prefix_array = Array(ids_prefix)
+    search_and_verify_hex2(ids_prefix_array, [], ids_prefix_array.length, ids_prefix_array.length + 2, annotation, field_name, from, to, prefix, factor)
+  end
+
+  def search_and_verify_hex_suffix(ids_suffix, annotation, field_name, from, to, prefix = "", factor = 1)
+    # Allow two more hits than contained in the suffix
+    ids_suffix_array = Array(ids_suffix)
+    search_and_verify_hex2([], ids_suffix_array, ids_suffix_array.length, ids_suffix_array.length + 2, annotation, field_name, from, to, prefix, factor)
+  end
+
+  def search_and_verify_hex(expected_ids, annotation, field_name, from, to, prefix = "", factor = 1)
+    expected_ids_array = Array(expected_ids)
+    search_and_verify_hex2(expected_ids_array, expected_ids_array, expected_ids_array.length, expected_ids_array.length, annotation, field_name, from, to, prefix, factor)
+  end
+
+  def test_hit_limit
+    @params = { :search_type => "INDEXED" }
+    set_description("Verify that the hitLimit annotation works")
+    deploy_app(SearchApp.new.cluster_name("test").sd(selfdir+"test.sd"))
+    start
+
+    range = (10..20)
+    feed_hex_docs(range)
+
+    # The hitLimit annotation requires an attribute with fast search enabled
+    ["string_single_fast_cased", "string_single_fast", "string_multi_fast_cased", "string_multi_fast"].each do |field_name|
+      prefix = field_name.include?("multi") ? "foo" : :""
+
+      from = 12
+      to = 18
+      [0, 1, 2, 3].each do |i|
+        # ascending
+        search_and_verify_hex(from..from+i, CLOSED.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+        search_and_verify_hex_prefix(from..from+i, RIGHT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+        search_and_verify_hex_prefix(from+1..from+1+i, LEFT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+        search_and_verify_hex_prefix(from+1..from+1+i, OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+
+        # descending
+        search_and_verify_hex(to-i..to, CLOSED.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+        search_and_verify_hex_suffix(to-i..to, LEFT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+        search_and_verify_hex_suffix(to-1-i..to-1, RIGHT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+        search_and_verify_hex_suffix(to-1-i..to-1, OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+      end
+
+      # Check that we still can get the whole range
+      search_and_verify_hex(from..to, CLOSED.merge({"hitLimit" => to - from + 1}), field_name, from, to, prefix)
+      # hitLimit larger than range
+      search_and_verify_hex(from..to, CLOSED.merge({"hitLimit" => to - from + 10}), field_name, from, to, prefix)
+
+      # Now with a range that is larger than the range of documents
+      from = 0
+      to = 100
+      [0, 1, 2, 3].each do |i|
+        # ascending
+        search_and_verify_hex(range.begin..range.begin+i, CLOSED.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+        search_and_verify_hex_prefix(range.begin..range.begin+i, RIGHT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+        search_and_verify_hex_prefix(range.begin..range.begin+i, LEFT_OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+        search_and_verify_hex_prefix(range.begin..range.begin+i, OPEN.merge({"hitLimit" => i + 1}), field_name, from, to, prefix)
+
+        # descending
+        search_and_verify_hex(range.end-i..range.end, CLOSED.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+        search_and_verify_hex_suffix(range.end-i..range.end, LEFT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+        search_and_verify_hex_suffix(range.end-i..range.end, RIGHT_OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+        search_and_verify_hex_suffix(range.end-i..range.end, OPEN.merge({"hitLimit" => i + 1, "descending" => true}), field_name, from, to, prefix)
+      end
+    end
+
+    # Unbounded ranges
+    ["string_single_fast_cased", "string_single_fast"].each do |field_name|
+      from = 12
+      to = 18
+      [CLOSED, LEFT_OPEN, RIGHT_OPEN, OPEN].each do |bounds|
+        search_and_verify_hex_prefix([10], bounds.merge({"hitLimit" => 1}), field_name, nil, to)
+        search_and_verify_hex_prefix([10, 11], bounds.merge({"hitLimit" => 2}), field_name, nil, to)
+        search_and_verify_hex_prefix([10, 11, 12], bounds.merge({"hitLimit" => 3}), field_name, nil, to)
+
+        search_and_verify_hex_suffix([20], bounds.merge({"hitLimit" => 1, "descending" => true}), field_name, from, nil)
+        search_and_verify_hex_suffix([19, 20], bounds.merge({"hitLimit" => 2, "descending" => true}), field_name, from, nil)
+        search_and_verify_hex_suffix([18, 19, 20], bounds.merge({"hitLimit" => 3, "descending" => true}), field_name, from, nil)
+      end
+
+      search_and_verify_hex(10..18, CLOSED.merge({"hitLimit" => 100}), field_name, nil, to)
+      search_and_verify_hex(10..17, OPEN.merge({"hitLimit" => 100}), field_name, nil, to)
+      search_and_verify_hex(10..20, CLOSED.merge({"hitLimit" => 100}), field_name, nil, nil)
+      search_and_verify_hex(10..20, OPEN.merge({"hitLimit" => 100}), field_name, nil, nil)
+    end
+
+    ["string_multi_fast_cased", "string_multi_fast"].each do |field_name|
+      from = 12
+      to = 18
+      [CLOSED, LEFT_OPEN, RIGHT_OPEN, OPEN].each do |bounds|
+        search_and_verify_hex_prefix([10], bounds.merge({"hitLimit" => 1}), field_name, nil, to, "foo")
+        search_and_verify_hex_prefix([10, 11], bounds.merge({"hitLimit" => 2}), field_name, nil, to, "foo")
+        search_and_verify_hex_prefix([10, 11, 12], bounds.merge({"hitLimit" => 3}), field_name, nil, to, "foo")
+
+        # The junk fields make hitLimit behave poorly: We get all documents, even with a hitLimit
+        search_and_verify_hex2([], [20], 1, 11, bounds.merge({"hitLimit" => 1, "descending" => true}), field_name, from, nil, "foo")
+        search_and_verify_hex2([], [19, 20], 2, 11, bounds.merge({"hitLimit" => 2, "descending" => true}), field_name, from, nil, "foo")
+        search_and_verify_hex2([], [18, 19, 20], 3, 11, bounds.merge({"hitLimit" => 3, "descending" => true}), field_name, from, nil, "foo")
+      end
+
+      # We get all document every time
+      search_and_verify_hex(10..20, CLOSED.merge({"hitLimit" => 100}), field_name, nil, to, "foo")
+      search_and_verify_hex(10..20, OPEN.merge({"hitLimit" => 100}), field_name, nil, to, "foo")
+      search_and_verify_hex(10..20, CLOSED.merge({"hitLimit" => 100}), field_name, nil, nil, "foo")
+      search_and_verify_hex(10..20, OPEN.merge({"hitLimit" => 100}), field_name, nil, nil, "foo")
+    end
   end
 
   ######################################################################################################################

--- a/tests/search/lexical_range/test.sd
+++ b/tests/search/lexical_range/test.sd
@@ -10,16 +10,22 @@ schema test {
      field string_single type string {
          indexing: attribute | summary
      }
-     field string_single_fast type string {
+     field string_single_fast_btree type string {
          indexing: attribute | summary
          attribute: fast-search
+         dictionary {
+           btree
+         }
      }
      field string_multi type array<string> {
          indexing: attribute | summary
      }
-     field string_multi_fast type array<string> {
+     field string_multi_fast_btree type array<string> {
          indexing: attribute | summary
          attribute: fast-search
+         dictionary {
+           btree
+         }
      }
 
      # String fields with cased matching
@@ -27,31 +33,81 @@ schema test {
          indexing: attribute | summary
          match: cased
      }
-     field string_single_fast_cased type string {
+     field string_single_fast_cased_btree type string {
          indexing: attribute | summary
          attribute: fast-search
          match: cased
+         dictionary {
+           btree
+           cased
+         }
+     }
+     field string_single_fast_cased_hash type string {
+         indexing: attribute | summary
+         attribute: fast-search
+         match: cased
+         dictionary {
+           hash
+           cased
+         }
+     }
+     field string_single_fast_cased_both type string {
+         indexing: attribute | summary
+         attribute: fast-search
+         match: cased
+         dictionary {
+           btree
+           hash
+           cased
+         }
      }
      field string_multi_cased type array<string> {
          indexing: attribute | summary
          match: cased
      }
-     field string_multi_fast_cased type array<string> {
+     field string_multi_fast_cased_btree type array<string> {
          indexing: attribute | summary
          attribute: fast-search
          match: cased
+         dictionary {
+           btree
+           cased
+         }
+     }
+     field string_multi_fast_cased_hash type array<string> {
+         indexing: attribute | summary
+         attribute: fast-search
+         match: cased
+         dictionary {
+           hash
+           cased
+         }
+     }
+     field string_multi_fast_cased_both type array<string> {
+         indexing: attribute | summary
+         attribute: fast-search
+         match: cased
+         dictionary {
+           btree
+           hash
+           cased
+         }
      }
   }
   rank-profile my-rank-profile {
     match-features {
       matches(string_single)
-      matches(string_single_fast)
+      matches(string_single_fast_btree)
       matches(string_multi)
-      matches(string_multi_fast)
+      matches(string_multi_fast_btree)
       matches(string_single_cased)
-      matches(string_single_fast_cased)
+      matches(string_single_fast_cased_btree)
+      matches(string_single_fast_cased_hash)
+      matches(string_single_fast_cased_both)
       matches(string_multi_cased)
-      matches(string_multi_fast_cased)
+      matches(string_multi_fast_cased_btree)
+      matches(string_multi_fast_cased_hash)
+      matches(string_multi_fast_cased_both)
     }
   }
 }

--- a/tests/search/lexical_range/test.sd
+++ b/tests/search/lexical_range/test.sd
@@ -51,7 +51,7 @@ schema test {
            cased
          }
      }
-     field string_single_fast_cased_both type string {
+     field string_single_fast_cased_btree_hash type string {
          indexing: attribute | summary
          attribute: fast-search
          match: cased
@@ -83,7 +83,7 @@ schema test {
            cased
          }
      }
-     field string_multi_fast_cased_both type array<string> {
+     field string_multi_fast_cased_btree_hash type array<string> {
          indexing: attribute | summary
          attribute: fast-search
          match: cased
@@ -103,11 +103,11 @@ schema test {
       matches(string_single_cased)
       matches(string_single_fast_cased_btree)
       matches(string_single_fast_cased_hash)
-      matches(string_single_fast_cased_both)
+      matches(string_single_fast_cased_btree_hash)
       matches(string_multi_cased)
       matches(string_multi_fast_cased_btree)
       matches(string_multi_fast_cased_hash)
-      matches(string_multi_fast_cased_both)
+      matches(string_multi_fast_cased_btree_hash)
     }
   }
 }


### PR DESCRIPTION
Adds a test case that tests the `hitLimit` annotation for string ranges. This became really ugly and annoying, see the implementation: .