### PR TITLE
changed streaming to use NaN for missing floating-point fields as well

### DIFF
--- a/tests/search/grouping_adv/answers/default-values/streaming-argmin-undefined-key-min.json
+++ b/tests/search/grouping_adv/answers/default-values/streaming-argmin-undefined-key-min.json
@@ -31,7 +31,7 @@
                 "relevance": 7.0,
                 "value": "false",
                 "fields": {
-                  "argmin(d, i)": 6
+                  "argmin(d, i)": 3
                 }
               },
               {

--- a/tests/search/grouping_adv/answers/default-values/streaming-group-tolong.json
+++ b/tests/search/grouping_adv/answers/default-values/streaming-group-tolong.json
@@ -27,9 +27,9 @@
             "label": "tolong(f)",
             "children": [
               {
-                "id": "group:long:0",
+                "id": "group:long:-9223372036854775808",
                 "relevance": 7.0,
-                "value": "0",
+                "value": "-9223372036854775808",
                 "fields": {
                   "count()": 4
                 }

--- a/tests/search/grouping_adv/grouping_base.rb
+++ b/tests/search/grouping_adv/grouping_base.rb
@@ -348,11 +348,8 @@ module GroupingBase
     classifier = streaming ? 'streaming' : 'indexed'
     # Only all-fields (i=2) has boool=true. In the false group d is defined for i=3 (1.2) and i=5 (7.8) only.
     check_query_default_value('all(group(boool) each(output(argmax(d, i))))', "#{classifier}-argmin-undefined-key-max")
-    if !streaming
-      # An undefined double key is NaN and must never be selected. Streaming has no undefined values, the
-      # missing d is 0.0 there and the hits lacking it would tie, so this is only checked for indexed.
-      check_query_default_value('all(group(boool) each(output(argmin(d, i))))', "#{classifier}-argmin-undefined-key-min")
-    end
+    # An undefined double key is NaN and must never be selected.
+    check_query_default_value('all(group(boool) each(output(argmin(d, i))))', "#{classifier}-argmin-undefined-key-min")
     # A multi-value result is forwarded as an array, empty when the selected hit has no value.
     check_query_default_value('all(group(boool) each(output(argmax(i, na), argmax(i, fa))))', "#{classifier}-argmin-multivalue-result")
     check_query_default_value('all(group(boool) each(output(argmin(i, na))))', "#{classifier}-argmin-empty-multivalue-result")


### PR DESCRIPTION
goes with https://github.com/vespa-engine/vespa/pull/37892
makes these answers same as for indexed.